### PR TITLE
Fix (most) VM integration tests

### DIFF
--- a/contrib/fixup_requiretty.rb
+++ b/contrib/fixup_requiretty.rb
@@ -14,11 +14,12 @@
 
 # FIXME
 user = ENV['TRAIN_SUDO_USER'] || 'todo-some-clever-default-maybe-current-user'
-sudoer = "/etc/sudoers.d/#{user}"
+sudo_conf_prefix = node['platform_family'] == 'freebsd' ? '/usr/local/etc' : '/etc'
+sudoer = "#{sudo_conf_prefix}/sudoers.d/#{user}"
 
 log "Warning: a sudoers configuration for user #{user} already exists, "\
     'doing nothing (override with TRAIN_SUDO_VERY_MUCH=yes)' do
-  only_if "test -f #{sudoer} || grep #{user} /etc/sudoers"
+  only_if "test -f #{sudoer} || grep #{user} #{sudo_conf_prefix}/sudoers"
 end
 
 file sudoer do
@@ -28,7 +29,7 @@ file sudoer do
   action ENV['TRAIN_SUDO_VERY_MUCH'] == 'yes' ? :create : :create_if_missing
 
   # Do not add something here if the user is mentioned explicitly in /etc/sudoers
-  not_if "grep #{user} /etc/sudoers"
+  not_if "grep #{user} #{sudo_conf_prefix}/sudoers"
 end
 
 # /!\ broken files in /etc/sudoers.d/ will break sudo for ALL USERS /!\

--- a/test/integration/.kitchen.yml
+++ b/test/integration/.kitchen.yml
@@ -12,25 +12,22 @@ platforms:
   - name: centos-6.7-i386
   - name: centos-5.11
   - name: centos-5.11-i386
-  - name: debian-6.0.10
-  - name: debian-6.0.10-i386
-  - name: debian-7.8
-  - name: debian-7.8-i386
-  - name: debian-8.1
-  - name: debian-8.1-i386
-  - name: fedora-21
-  - name: fedora-21-i386
-  - name: fedora-22
+  - name: debian-7.11
+  - name: debian-7.11-i386
+  - name: debian-8.6
+  - name: debian-8.6-i386
+  - name: fedora-23
+  - name: fedora-24
   - name: freebsd-9.3
   - name: freebsd-10.2
   - name: opensuse-13.2-x86_64
   - name: opensuse-13.2-i386
+  - name: ubuntu-16.04
+  - name: ubuntu-16.04-i386
   - name: ubuntu-14.04
   - name: ubuntu-14.04-i386
   - name: ubuntu-12.04
   - name: ubuntu-12.04-i386
-  - name: ubuntu-10.04
-  - name: ubuntu-10.04-i386
 
 suites:
   - name: default

--- a/test/integration/Berksfile
+++ b/test/integration/Berksfile
@@ -1,3 +1,3 @@
 source 'https://supermarket.chef.io'
-cookbook 'sudo', '~> 2.7.2'
+
 cookbook 'test', path: 'cookbooks/test'

--- a/test/integration/cookbooks/test/metadata.rb
+++ b/test/integration/cookbooks/test/metadata.rb
@@ -1,3 +1,4 @@
 name 'test'
 
 depends 'sudo', '~> 3.0.0'
+depends 'build-essential', '~> 7.0.1'

--- a/test/integration/cookbooks/test/metadata.rb
+++ b/test/integration/cookbooks/test/metadata.rb
@@ -1,1 +1,3 @@
 name 'test'
+
+depends 'sudo', '~> 3.0.0'

--- a/test/integration/cookbooks/test/recipes/default.rb
+++ b/test/integration/cookbooks/test/recipes/default.rb
@@ -9,7 +9,8 @@
 # Finally (for now), it actually executes the all tests with
 # the local execution backend
 
-include_recipe('test::prep_files')
+include_recipe 'build-essential'
+include_recipe 'test::prep_files'
 
 # prepare ssh for backend
 execute 'create ssh key' do

--- a/test/integration/cookbooks/test/recipes/default.rb
+++ b/test/integration/cookbooks/test/recipes/default.rb
@@ -9,6 +9,8 @@
 # Finally (for now), it actually executes the all tests with
 # the local execution backend
 
+apt_update 'update' if platform_family?('debian')
+
 include_recipe 'build-essential'
 include_recipe 'test::prep_files'
 

--- a/test/integration/cookbooks/test/recipes/default.rb
+++ b/test/integration/cookbooks/test/recipes/default.rb
@@ -14,6 +14,12 @@ when 'debian'
   apt_update 'update'
 when 'freebsd'
   package 'base64'
+when 'fedora'
+  if File.exist?('/usr/bin/dnf')
+    execute 'dnf install -y yum' do
+      not_if { File.exist?('/usr/bin/yum-deprecated') }
+    end
+  end
 end
 
 include_recipe 'build-essential'

--- a/test/integration/cookbooks/test/recipes/default.rb
+++ b/test/integration/cookbooks/test/recipes/default.rb
@@ -9,7 +9,12 @@
 # Finally (for now), it actually executes the all tests with
 # the local execution backend
 
-apt_update 'update' if platform_family?('debian')
+case node['platform_family']
+when 'debian'
+  apt_update 'update'
+when 'freebsd'
+  package 'base64'
+end
 
 include_recipe 'build-essential'
 include_recipe 'test::prep_files'

--- a/test/integration/cookbooks/test/recipes/default.rb
+++ b/test/integration/cookbooks/test/recipes/default.rb
@@ -49,7 +49,7 @@ end
 
 %w{nopasswd vagrant}.each do |name|
   sudo name do
-    user '%'+name
+    user name
     nopasswd true
     defaults ['!requiretty']
   end

--- a/test/integration/cookbooks/test/recipes/prep_files.rb
+++ b/test/integration/cookbooks/test/recipes/prep_files.rb
@@ -35,7 +35,7 @@ link '/tmp/symlink' do
 end
 
 link '/usr/bin/allyourbase' do
-  to '/usr/bin/sudo'
+  to node['platform_family'] == 'freebsd' ? '/usr/local/bin/sudo' : '/usr/bin/sudo'
   owner 'root'
   group gid
   mode '0777'


### PR DESCRIPTION
I noticed that VM integration tests invoked with `rake test:vm` didn't seem to pass. I spent a bit of time trying to fix these failures. I managed to fix most of the problems.

Unfortunately, I had some problems with CentOS 5.11 and Ubuntu 12.04:
- `bento/centos-5.11` using VirtualBox fails to start on my machine. I end up getting stuck in a "gurumeditation" state. This could be because of something weird with my machine.
- Centos 5.11 (i386) fails due to permissions on files in `/etc/sudoers.d`, possibly something to be fixed in the `sudo` cookbook?:

```
[vagrant@default-centos-511-i386 ~]$ sudo /bin/true
sudo: /etc/sudoers.d/reqtty is mode 0600, should be 0440
>>> /etc/sudoers.d/passwd: /etc/sudoers.d/reqtty near line 9 <<<
sudo: parse error in /etc/sudoers.d/passwd near line 9
sudo: no valid sudoers sources found, quitting
```
- The tests in `test/integration/sudo/passwd.rb` fail on Ubuntu 12.04.

I didn't want to spend too long looking at this because I wasn't sure if you actually run these tests anywhere? I'm assuming maybe you run them internally at Chef?
