### PR TITLE
Upgrade aws-sdk dependency to version ~>3 .

### DIFF
--- a/train.gemspec
+++ b/train.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'winrm', '~> 2.0'
   spec.add_dependency 'winrm-fs', '~> 1.0'
   spec.add_dependency 'docker-api', '~> 1.26'
-  spec.add_dependency 'aws-sdk', '~> 2'
+  spec.add_dependency 'aws-sdk', '~> 3'
   spec.add_dependency 'azure_mgmt_resources', '~> 0.15'
   spec.add_dependency 'google-api-client', '~> 0.19.8'
   spec.add_dependency 'googleauth', '~> 0.6.2'


### PR DESCRIPTION
Since aws-sdk is now at version 3.0.1 , I upgraded the dependency in gemspec to `~> 3` .
I bundle installed the dependencies and ran `rake` to ensure it passed the build locally.

According to upgrade doco https://aws.amazon.com/blogs/developer/upgrading-from-version-2-to-version-3-of-the-aws-sdk-for-ruby-2/ , it's as simple as changing `~> 2` to `~> 3` since train is requiring aws-sdk and not aws-sdk-core.