### PR TITLE
Don't double-escape paths

### DIFF
--- a/lib/train/file/local/unix.rb
+++ b/lib/train/file/local/unix.rb
@@ -47,7 +47,7 @@ module Train
 
         def mounted
           @mounted ||=
-            @backend.run_command("mount | grep -- ' on #{@spath} '")
+            @backend.run_command("mount | grep -- ' on #{@path} '")
         end
 
         def grouped_into?(sth)

--- a/lib/train/file/remote/unix.rb
+++ b/lib/train/file/remote/unix.rb
@@ -33,7 +33,7 @@ module Train
 
         def mounted
           @mounted ||=
-            @backend.run_command("mount | grep -- ' on #{@spath} '")
+            @backend.run_command("mount | grep -- ' on #{@path} '")
         end
 
         %w{


### PR DESCRIPTION
Signed-off-by: Stanislav Voroniy <stas@voroniy.com>
As argument to grep original path should be used and not escaped, since it is already included in single quotes.