### PR TITLE
Add the mock transport to train-core

### DIFF
--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -3,6 +3,11 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'train/version'
 
+CORE_TRANSPORTS = [
+  'lib/train/transports/local.rb',
+  'lib/train/transports/mock.rb',
+]
+
 Gem::Specification.new do |spec|
   spec.name          = 'train-core'
   spec.version       = Train::VERSION
@@ -15,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.files = %w{train-core.gemspec README.md LICENSE Gemfile CHANGELOG.md} + Dir
                .glob('lib/**/*', File::FNM_DOTMATCH)
-               .reject { |f| f =~ /^(?!.*(local.rb)).*transports/ }
+               .reject { |f| f =~ /lib\/train\/transports/ unless CORE_TRANSPORTS.include?(f) }
                .reject { |f| File.directory?(f) }
 
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

We need to add mock to the train-core so `inspec check` and other things that rely on mock work as expected. Before and after testing:

```
jquick@Jareds-MBP:~/Chef/inspec/_test
(master)> inspec check long_commands
/Users/jquick/.gem/ruby/2.4.3/gems/train-core-1.4.11/lib/train.rb:47:in `rescue in load_transport': Can't find train plugin "mock". Please install it first. (Train::UserError)
        from /Users/jquick/.gem/ruby/2.4.3/gems/train-core-1.4.11/lib/train.rb:39:in `load_transport'
        from /Users/jquick/.gem/ruby/2.4.3/gems/train-core-1.4.11/lib/train.rb:20:in `create'
        from /Users/jquick/.gem/ruby/2.4.3/gems/inspec-core-2.2.10/lib/inspec/backend.rb:46:in `create'
        from /Users/jquick/.gem/ruby/2.4.3/gems/inspec-core-2.2.10/lib/inspec/cli.rb:71:in `check'
        from /Users/jquick/.gem/ruby/2.4.3/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
        from /Users/jquick/.gem/ruby/2.4.3/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
        from /Users/jquick/.gem/ruby/2.4.3/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
        from /Users/jquick/.gem/ruby/2.4.3/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
        from /Users/jquick/.gem/ruby/2.4.3/gems/inspec-core-2.2.10/bin/inspec:12:in `<top (required)>'
        from /Users/jquick/.gem/ruby/2.4.3/bin/inspec:23:in `load'
        from /Users/jquick/.gem/ruby/2.4.3/bin/inspec:23:in `<main>'
jquick@Jareds-MBP:~/Chef/inspec/_test
(master)> inspec check long_commands
Location:    long_commands
Profile:     long_commands
Controls:    7
Timestamp:   2018-06-14T09:21:47-04:00
Valid:       true

No errors or warnings
```