### PR TITLE
Add shallow_link_path to inspect symlink direct link

### DIFF
--- a/lib/train/file.rb
+++ b/lib/train/file.rb
@@ -135,14 +135,6 @@ module Train
       end
     end
 
-    def link_path
-      fail NotImplementedError, "#{self.class} does not implement #link_path()"
-    end
-
-    def shallow_link_path
-      fail NotImplementedError, "#{self.class} does not implement #shallow_link_path()"
-    end
-
     # if the OS-specific file class supports inquirying as to whether the
     # file/device is mounted, the #mounted method should return a command
     # object whose stdout will not be nil if indeed the device is mounted.

--- a/lib/train/file.rb
+++ b/lib/train/file.rb
@@ -135,6 +135,14 @@ module Train
       end
     end
 
+    def link_path
+      fail NotImplementedError, "#{self.class} does not implement #link_path()"
+    end
+
+    def shallow_link_path
+      fail NotImplementedError, "#{self.class} does not implement #shallow_link_path()"
+    end
+
     # if the OS-specific file class supports inquirying as to whether the
     # file/device is mounted, the #mounted method should return a command
     # object whose stdout will not be nil if indeed the device is mounted.

--- a/lib/train/file/local.rb
+++ b/lib/train/file/local.rb
@@ -27,6 +27,11 @@ module Train
         end
       end
 
+      def shallow_link_path
+        return nil unless symlink?
+        @link_path ||= ::File.readlink(@path)
+      end
+
       def block_device?
         ::File.blockdev?(@path)
       end

--- a/lib/train/file/remote/aix.rb
+++ b/lib/train/file/remote/aix.rb
@@ -12,6 +12,12 @@ module Train
             @backend.run_command("perl -e 'print readlink shift' #{@spath}").stdout.chomp
         end
 
+        def shallow_link_path
+          return nil unless symlink?
+          @shallow_link_path ||=
+            @backend.run_command("perl -e 'print readlink shift' #{@spath}").stdout.chomp
+        end
+
         def mounted
           @mounted ||= @backend.run_command("lsfs -c #{@spath}")
         end

--- a/lib/train/file/remote/unix.rb
+++ b/lib/train/file/remote/unix.rb
@@ -60,6 +60,11 @@ module Train
           symlink? ? path : nil
         end
 
+        def shallow_link_path
+          return nil unless symlink?
+          @shallow_link_path ||= ::File.readlink(@path)
+        end
+
         def unix_mode_mask(owner, type)
           o = UNIX_MODE_OWNERS[owner.to_sym]
           return nil if o.nil?

--- a/lib/train/file/remote/windows.rb
+++ b/lib/train/file/remote/windows.rb
@@ -77,6 +77,10 @@ module Train
           nil
         end
 
+        def shallow_link_path
+          nil
+        end
+
         def mounted
           nil
         end

--- a/test/unit/file/local_test.rb
+++ b/test/unit/file/local_test.rb
@@ -10,7 +10,7 @@ describe Train::File::Local do
     File.stub :read, res do
       connection.file(rand.to_s).content.must_equal(res)
     end
-  end 
+  end
 
   {
     exist?:            :exist?,
@@ -33,13 +33,13 @@ describe Train::File::Local do
     it 'returns the type block_device if it is block device' do
       File.stub :ftype, "blockSpecial" do
         connection.file(rand.to_s).type.must_equal :block_device
-      end  
+      end
     end
 
     it 'returns the type character_device if it is character device' do
       File.stub :ftype, "characterSpecial" do
         connection.file(rand.to_s).type.must_equal :character_device
-      end  
+      end
     end
 
     it 'returns the type symlink if it is symlink' do
@@ -77,7 +77,7 @@ describe Train::File::Local do
         connection.file(rand.to_s).type.must_equal :unknown
       end
     end
-  end  
+  end
 
   describe '#path' do
     it 'returns the path if it is not a symlink' do
@@ -103,6 +103,17 @@ describe Train::File::Local do
       File.stub :realpath, out do
         File.stub :symlink?, true do
           connection.file(rand.to_s).link_path.must_equal out
+        end
+      end
+    end
+  end
+
+  describe '#shallow_shlink_path' do
+    it 'returns file\'s direct link path' do
+      out = rand.to_s
+      File.stub :readlink, out do
+        File.stub :symlink?, true do
+          connection.file(rand.to_s).shallow_link_path.must_equal out
         end
       end
     end

--- a/test/unit/file/remote/aix_test.rb
+++ b/test/unit/file/remote/aix_test.rb
@@ -23,4 +23,11 @@ describe Train::File::Remote::Aix do
     backend.mock_command("perl -e 'print readlink shift' path", 'our_link_path')
     file.link_path.must_equal 'our_link_path'
   end
+
+  it 'returns a correct shallow_link_path' do
+    file = cls.new(backend, 'path')
+    file.stubs(:symlink?).returns(true)
+    backend.mock_command("perl -e 'print readlink shift' path", 'our_link_path')
+    file.link_path.must_equal 'our_link_path'
+  end
 end


### PR DESCRIPTION
Currently symlinks are read recursively.
There is the case where people simply want to inspect what the current symlink points to and not resolve the entire symlink chain. This `shallow_link_path` gives access to that information.

Helps fixing inspec/inspec#3100 and inspec/inspec#2106