### PR TITLE
Fix detection of amazon linux 2

### DIFF
--- a/lib/train/platforms/detect/helpers/os_linux.rb
+++ b/lib/train/platforms/detect/helpers/os_linux.rb
@@ -10,7 +10,9 @@ module Train::Platforms::Detect::Helpers
       case conf
       when /rawhide/i
         /((\d+) \(Rawhide\))/i.match(conf)[1].downcase
-      when /derived from .*linux/i
+      when /Amazon Linux AMI/i
+        /release ([\d\.]+)/.match(conf)[1]
+      when /derived from .*linux|amazon/i
         /Linux ((\d+|\.)+)/i.match(conf)[1]
       else
         /release ([\d\.]+)/.match(conf)[1]


### PR DESCRIPTION
Amazon Linux 1 has the release label like 'Amazon Linux AMI release 2018.03'
Amazon Linux 2 has the release label like 'Amazon Linux 2'

This fixes the following problem when running agains Amazon Linux 2:
```
E, [2018-06-27T11:02:40.026432 #44019] ERROR -- Kitchen: Class:
Kitchen::ActionFailed
E, [2018-06-27T11:02:40.026473 #44019] ERROR -- Kitchen: Message: Failed
to complete #verify action: [undefined method `[]' for nil:NilClass]
E, [2018-06-27T11:02:40.026516 #44019] ERROR -- Kitchen:
----------------------
E, [2018-06-27T11:02:40.026586 #44019] ERROR -- Kitchen:
------Backtrace-------
E, [2018-06-27T11:02:40.026628 #44019] ERROR -- Kitchen:
/Users/artem/.rvm/gems/ruby-2.4.2/gems/train-1.4.15/lib/train/platforms/detect/helpers/os_linux.rb:16:in
`redhatish_version'
E, [2018-06-27T11:02:40.026671 #44019] ERROR -- Kitchen:
/Users/artem/.rvm/gems/ruby-2.4.2/gems/train-1.4.15/lib/train/platforms/detect/specifications/os.rb:194:in
`block in load
```

Signed-off-by: Artem Sidorenko <artem@posteo.de>