### PR TITLE
Modify `WindowsPipeRunner` stderr to use String

### DIFF
--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -206,7 +206,7 @@ module Train::Transports
                 $result = @{ 'stdout' = $stdout ; 'stderr' = ''; 'exitstatus' = 0 }
               } catch {
                 $stderr = $_ | Out-String
-                $result = @{ 'stdout' = ''; 'stderr' = $_; 'exitstatus' = 1 }
+                $result = @{ 'stdout' = ''; 'stderr' = $stderr; 'exitstatus' = 1 }
               }
               $resultJSON = $result | ConvertTo-JSON
 


### PR DESCRIPTION
This modifies `WindowPipeRunner` to use a String for stderr instead of an object.

![2018-07-02-214715_635x633_scrot](https://user-images.githubusercontent.com/13783510/42199271-74dabfe6-7e42-11e8-8a51-fc9663373504.png)
![2018-07-02-214822_636x633_scrot](https://user-images.githubusercontent.com/13783510/42199276-78ad9684-7e42-11e8-8890-b9b00425ef3f.png)
