### PR TITLE
Require Ruby 2.0 and allow net-ssh 5.0

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -28,6 +28,6 @@ merge_actions:
         - built_in:bump_version
 
 promote:
-  action:
-    - built_in:publish_rubygems
+  actions:
     - built_in:rollover_changelog
+    - built_in:publish_rubygems

--- a/train.gemspec
+++ b/train.gemspec
@@ -23,12 +23,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.0'
+
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   # chef-client < 12.4.1 require mixlib-shellout-2.0.1
   spec.add_dependency 'mixlib-shellout', '~> 2.0'
-  # net-ssh 3.x drops Ruby 1.9 support, so this constraint could be raised when
-  # 1.9 support is no longer needed here or for Inspec
-  spec.add_dependency 'net-ssh', '>= 2.9', '< 5.0'
+  spec.add_dependency 'net-ssh', '>= 2.9', '< 6.0'
   spec.add_dependency 'net-scp', '~> 1.2'
   spec.add_dependency 'winrm', '~> 2.0'
   spec.add_dependency 'winrm-fs', '~> 1.0'


### PR DESCRIPTION
net-ssh 5.0 is contrained by other deps, but this will allow us to pull
it in once those deps (net-scp) release updates.

Signed-off-by: Tim Smith <tsmith@chef.io>