### PR TITLE
Enable using rubygems as plugins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,8 @@ Metrics/PerceivedComplexity:
   Max: 10
 Metrics/AbcSize:
   Max: 33
+Metrics/ModuleLength:
+  Enabled: false
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%':  '{}'

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ group :test do
   gem 'rubocop', '~> 0.36.0'
   gem 'simplecov', '~> 0.10'
   gem 'concurrent-ruby', '~> 1.0'
+  gem 'pry-byebug'
+  gem 'm'
 end
 
 group :integration do

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,11 @@ group :test do
   gem 'concurrent-ruby', '~> 1.0'
   gem 'pry-byebug'
   gem 'm'
+  # This is not a true gem installation
+  # (Gem::Specification.find_by_path('train-gem-fixture') will return nil)
+  # but it's close enough to show the gempath handler can find a plugin
+  # See test/unit/
+  gem 'train-gem-fixture', path: 'test/fixtures/gempath/gems'
 end
 
 group :integration do

--- a/lib/train.rb
+++ b/lib/train.rb
@@ -44,8 +44,9 @@ module Train
     require 'train/transports/' + name.to_s
     Train::Plugins.registry[name.to_s]
   rescue LoadError => _
-    raise Train::UserError,
-          "Can't find train plugin #{name.inspect}. Please install it first."
+    ex = Train::PluginLoadError.new("Can't find train plugin #{name.inspect}. Please install it first.")
+    ex.transport_name = name.inspect
+    raise ex
   end
 
   # Resolve target configuration in URI-scheme into

--- a/lib/train/errors.rb
+++ b/lib/train/errors.rb
@@ -23,6 +23,11 @@ module Train
   # errors.
   class UserError < Error; end
 
+  # We could not load a plugin, because of a user error
+  class PluginLoadError < UserError
+    attr_accessor :transport_name
+  end
+
   # Base exception class for all exceptions that are caused by incorrect use
   # of an API.
   class ClientError < Error; end

--- a/lib/train/platforms/detect/helpers/os_common.rb
+++ b/lib/train/platforms/detect/helpers/os_common.rb
@@ -5,7 +5,7 @@ require 'train/platforms/detect/helpers/os_windows'
 require 'rbconfig'
 
 module Train::Platforms::Detect::Helpers
-  module OSCommon # rubocop:disable Metrics/ModuleLength
+  module OSCommon
     include Train::Platforms::Detect::Helpers::Linux
     include Train::Platforms::Detect::Helpers::Windows
 

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -77,7 +77,7 @@ class Train::Plugins::Transport
       false
     end
 
-    def direct_platform(name, platform_details = nil)
+    def force_platform!(name, platform_details = nil)
       plat = Train::Platforms.name(name)
       plat.backend = self
       plat.platform = platform_details unless platform_details.nil?
@@ -85,6 +85,8 @@ class Train::Plugins::Transport
       plat.add_platform_methods
       plat
     end
+
+    alias direct_platform force_platform!
 
     def family_hierarchy(plat)
       plat.families.each_with_object([]) do |(k, _v), memo|

--- a/lib/train/transports/aws.rb
+++ b/lib/train/transports/aws.rb
@@ -39,7 +39,7 @@ module Train::Transports
       end
 
       def platform
-        direct_platform('aws', @platform_details)
+        force_platform!('aws', @platform_details)
       end
 
       def aws_client(klass)

--- a/lib/train/transports/azure.rb
+++ b/lib/train/transports/azure.rb
@@ -51,7 +51,7 @@ module Train::Transports
       end
 
       def platform
-        direct_platform('azure', @platform_details)
+        force_platform!('azure', @platform_details)
       end
 
       def azure_client(klass = ::Azure::Resources::Profiles::Latest::Mgmt::Client)

--- a/lib/train/transports/gcp.rb
+++ b/lib/train/transports/gcp.rb
@@ -43,7 +43,7 @@ module Train::Transports
       end
 
       def platform
-        direct_platform('gcp', @platform_details)
+        force_platform!('gcp', @platform_details)
       end
 
       # Instantiate some named classes for ease of use

--- a/lib/train/transports/vmware.rb
+++ b/lib/train/transports/vmware.rb
@@ -74,7 +74,7 @@ module Train::Transports
       end
 
       def platform
-        direct_platform('vmware', @platform_details)
+        force_platform!('vmware', @platform_details)
       end
 
       def run_command_via_connection(cmd)

--- a/test/fixtures/gempath/gems/train-gem-fixture-0.1.0/README.md
+++ b/test/fixtures/gempath/gems/train-gem-fixture-0.1.0/README.md
@@ -1,0 +1,1 @@
+This is a very simple train transport plugin, laid out as though it were an installed gem.  It is not a good example to use for learning, nor a good base for starting your own plugin - it's intended for for use during the testing of Train.

--- a/test/fixtures/gempath/gems/train-gem-fixture-0.1.0/lib/train-gem-fixture.rb
+++ b/test/fixtures/gempath/gems/train-gem-fixture-0.1.0/lib/train-gem-fixture.rb
@@ -1,0 +1,2 @@
+require 'train'
+require 'train-gem-fixture/transport'

--- a/test/fixtures/gempath/gems/train-gem-fixture-0.1.0/lib/train-gem-fixture/transport.rb
+++ b/test/fixtures/gempath/gems/train-gem-fixture-0.1.0/lib/train-gem-fixture/transport.rb
@@ -1,0 +1,7 @@
+module TrainTransports
+  class GemFixture < Train.plugin(1)
+    name 'gem-fixture'
+
+    # what else do we need to implement?
+  end
+end

--- a/test/fixtures/gempath/gems/train-gem-fixture-0.1.0/lib/train-gem-fixture/version.rb
+++ b/test/fixtures/gempath/gems/train-gem-fixture-0.1.0/lib/train-gem-fixture/version.rb
@@ -1,0 +1,5 @@
+module TrainTransports
+  class GemFixture
+    VERSION = '0.1.0'
+  end
+end

--- a/test/fixtures/gempath/gems/train-gem-fixture-0.1.0/train-gem-fixture.gemspec
+++ b/test/fixtures/gempath/gems/train-gem-fixture-0.1.0/train-gem-fixture.gemspec
@@ -1,0 +1,34 @@
+
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+Gem::Specification.new do |spec|
+  spec.name          = "train-gem-fixture"
+  spec.version       = '0.1.0'
+  spec.authors       = ["Inspec core engineering team"]
+  spec.email         = ["hello@chef.io"]
+
+  spec.summary       = %q{Test train plugin, packaged as a local gem}
+  spec.description   = %q{Test train plugin, packaged as a local gem}
+  spec.homepage      = "https://github.com/inspec/train"
+
+  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
+  # to allow pushing to a single host or delete this section to allow pushing to any host.
+  if spec.respond_to?(:metadata)
+    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+  else
+    raise "RubyGems 2.0 or newer is required to protect against " \
+      "public gem pushes."
+  end
+
+  spec.files         = %w{
+    README.md
+    lib/train-gem-fixture.rb
+    lib/train-gem-fixture/version.rb
+    lib/train-gem-fixture/transport.rb
+  }
+  spec.executables   = []
+  spec.require_paths = ["lib"]
+
+  # No deps
+end

--- a/test/unit/platforms/detect/uuid_test.rb
+++ b/test/unit/platforms/detect/uuid_test.rb
@@ -36,7 +36,7 @@ describe 'uuid' do
     end
 
     mock.files = file_objects
-    mock.direct_platform(name, plat_options)
+    mock.force_platform!(name, plat_options)
   end
 
   it 'finds a linux uuid from chef entity_uuid' do

--- a/test/unit/plugins/connection_test.rb
+++ b/test/unit/plugins/connection_test.rb
@@ -44,7 +44,7 @@ describe 'v1 Connection Plugin' do
     end
 
     it 'provides direct platform' do
-      plat = connection.direct_platform('mac_os_x')
+      plat = connection.force_platform!('mac_os_x')
       plat.name.must_equal 'mac_os_x'
       plat.linux?.must_equal false
       plat.cloud?.must_equal false
@@ -54,7 +54,7 @@ describe 'v1 Connection Plugin' do
     end
 
     it 'provides api direct platform' do
-      plat = connection.direct_platform('aws')
+      plat = connection.force_platform!('aws')
       plat.name.must_equal 'aws'
       plat.linux?.must_equal false
       plat.cloud?.must_equal true
@@ -66,7 +66,7 @@ describe 'v1 Connection Plugin' do
       aws_version = Gem.loaded_specs['aws-sdk'].version
       aws_version = "aws-sdk-v#{aws_version}"
       details = { release: aws_version }
-      plat = connection.direct_platform('aws', details)
+      plat = connection.force_platform!('aws', details)
       plat.name.must_equal 'aws'
       plat.release.must_equal aws_version
       plat[:release].must_equal aws_version

--- a/test/unit/train_test.rb
+++ b/test/unit/train_test.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 #
 # Author:: Dominik Richter (<dominik.richter@gmail.com>)
-require 'helper'
+require_relative 'helper'
 
 describe Train do
   before do
@@ -11,6 +11,7 @@ describe Train do
   describe '#create' do
     it 'raises an error if the plugin isnt found' do
       proc { Train.create('missing') }.must_raise Train::UserError
+      proc { Train.create('missing') }.must_raise Train::PluginLoadError
     end
 
     it 'load a plugin if it isnt in the registry yet via symbol' do

--- a/test/unit/train_test.rb
+++ b/test/unit/train_test.rb
@@ -14,7 +14,7 @@ describe Train do
       proc { Train.create('missing') }.must_raise Train::PluginLoadError
     end
 
-    it 'load a plugin if it isnt in the registry yet via symbol' do
+    it 'loads a core plugin if it isnt in the registry yet via symbol' do
       Kernel.stub :require, true do
         ex = Class.new(Train.plugin 1) { name 'existing' }
         train = Train.create(:existing)
@@ -22,18 +22,30 @@ describe Train do
       end
     end
 
-    it 'load a plugin if it isnt in the registry yet via string' do
+    it 'loads a core plugin if it isnt in the registry yet via string' do
       Kernel.stub :require, true do
         ex = Class.new(Train.plugin 1) { name 'existing' }
         train = Train.create('existing')
         train.class.must_equal ex
       end
     end
+
+    it 'loads a gem plugin if it isnt in the registry yet via string' do
+      # The 'train-gem-fixture' gem is located in test/fixtures/gempath/gems and is
+      # added to the gempath via Bundler. The key difference is that it isn't under
+      # lib/train/trainsports, and Train will need to pre-pend 'train-' to the
+      # transport name to get the gem name.
+      transport = Train.create('gem-fixture')
+      # Normally one would call transport.class.name, but that's been overridden to be a write-only DSL method
+      # So use to_s
+      transport.class.to_s.must_equal 'TrainTransports::GemFixture'
+    end
   end
 
   describe '#options' do
     it 'raises exception if a given transport plugin isnt found' do
       proc { Train.options('missing') }.must_raise Train::UserError
+      proc { Train.options('missing') }.must_raise Train::PluginLoadError
     end
 
     it 'provides empty options of a transport plugin' do


### PR DESCRIPTION
In support of the "Platform Plugins" portion of https://github.com/inspec/inspec/issues/3089 , this PR introduces the ability to load Train transports from gems.  A train transport named `quantuum-entanglement` (and referenced on the InSpec CLI as `--target quantuum-entanglement://....`) would first be sought in Train's source code at `lib/train/transports/quantuum-entanglement.rb` (existing behavior); if that fails, Train would attempt to require a gem named `train-quantuum-entanglement`.  How that gem got installed is up to you; and its implementation is left as a simple exercise for the reader.

Additionally,  this PR makes a few minor changes:
* Makes a new exception class, `Train::PluginLoadError`, which inherits from `Train::UserError`.  This is now the error raised when neither a local file nor a gem could be found.  It contains an attribute with the transport name. This is intended to assist graceful error handling by a CLI consuming Train.
* Renames `BaseConnection::direct_platform` to `force_platform!` (leaving behind an alias for backwards compatibility).   I simply felt the new name reflected the purpose and short-circuiting nature of the method more clearly.  It's contained in one commit, so that can be backed out if desired.