### PR TITLE
Add non_interactive support for SSH

### DIFF
--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -62,6 +62,7 @@ module Train::Transports
     option :bastion_host, default: nil
     option :bastion_user, default: 'root'
     option :bastion_port, default: 22
+    option :non_interactive, default: false
 
     option :compression_level do |opts|
       # on nil or false: set compression level to 0
@@ -162,9 +163,9 @@ module Train::Transports
         bastion_host:           opts[:bastion_host],
         bastion_user:           opts[:bastion_user],
         bastion_port:           opts[:bastion_port],
+        non_interactive:        opts[:non_interactive],
         transport_options:      opts,
       }
-
       # disable host key verification. The hash key to use
       # depends on the version of net-ssh in use.
       connection_options[verify_host_key_option] = false

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -69,6 +69,7 @@ class Train::Transports::SSH
       args  = %w{ -o UserKnownHostsFile=/dev/null }
       args += %w{ -o StrictHostKeyChecking=no }
       args += %w{ -o IdentitiesOnly=yes } if options[:keys]
+      args += %w{ -o BatchMode=yes } if options[:non_interactive]
       args += %W( -o LogLevel=#{level} )
       args += %W( -o ForwardAgent=#{fwd_agent} ) if options.key?(:forward_agent)
       Array(options[:keys]).each do |ssh_key|

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -55,6 +55,18 @@ describe 'ssh transport' do
     end
   end
 
+  describe 'ssh options' do
+    let(:ssh) { cls.new(conf) }
+    let(:connection) { ssh.connection }
+    it 'includes BatchMode when :non_interactive is set' do
+      conf[:non_interactive] = true
+      connection.ssh_opts.include?("BatchMode=yes").must_equal true
+    end
+    it 'excludes BatchMode when :non_interactive is not set' do
+      connection.ssh_opts.include?("BatchMode=yes").must_equal false
+    end
+  end
+
   describe 'opening a connection' do
     let(:ssh) { cls.new(conf) }
     let(:connection) { ssh.connection }


### PR DESCRIPTION
This passes through the :non_interactive option to Net::SSH.start
for cases where the caller does not want the net/ssh UI to display interactive
prompting.

This is mapped to BatchMode=true in the ssh command usage.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>