### PR TITLE
Fixes an issue where the credential file was nil

### DIFF
--- a/lib/train/transports/helpers/azure/file_credentials.rb
+++ b/lib/train/transports/helpers/azure/file_credentials.rb
@@ -12,6 +12,7 @@ module Train::Transports
         DEFAULT_FILE = ::File.join(Dir.home, '.azure', 'credentials')
 
         def self.parse(subscription_id: nil, credentials_file: DEFAULT_FILE, **_)
+          credentials_file = DEFAULT_FILE if credentials_file.nil?
           return {} unless ::File.readable?(credentials_file)
           credentials     = IniFile.load(::File.expand_path(credentials_file))
           subscription_id = parser(subscription_id, ENV['AZURE_SUBSCRIPTION_NUMBER'], credentials).subscription_id

--- a/test/unit/transports/helpers/azure/file_credentials_test.rb
+++ b/test/unit/transports/helpers/azure/file_credentials_test.rb
@@ -38,6 +38,14 @@ describe 'parse_credentials_file' do
 
   let(:options) { { credentials_file: cred_file_multiple_entries.path } }
 
+  it 'handles a nil file' do
+    options[:credentials_file] = nil
+
+    result = Train::Transports::Helpers::Azure::FileCredentials.parse(options)
+
+    assert_empty(result)
+  end
+
   it 'returns empty hash when no credentials file detected' do
     result = Train::Transports::Helpers::Azure::FileCredentials.parse({})
 


### PR DESCRIPTION
This adds a test and a guard to handle the case where the credentials
file can be nil.

Signed-off-by: David McCown <dmccown@chef.io>