### PR TITLE
Use Addressable::URI, allowing IPv6 URLs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,6 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2')
   gem 'json', '< 2.0'
 end
 
-gem 'addressable', '~> 2.5'
-
 group :test do
   gem 'bundler', '~> 1.11'
   gem 'minitest', '~> 5.8'

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2')
   gem 'json', '< 2.0'
 end
 
+gem 'addressable', '~> 2.5'
+
 group :test do
   gem 'bundler', '~> 1.11'
   gem 'minitest', '~> 5.8'

--- a/lib/train.rb
+++ b/lib/train.rb
@@ -119,10 +119,10 @@ module Train
     # e.g. mock://. To do this, we match it manually and fake the hostname
     if u.scheme && (u.host.nil? || u.host.empty?) && u.path.empty?
       case string
-        when %r{^([a-z]+)://$}
-          string += 'dummy'
-        when /^([a-z]+):$/
-          string += '//dummy'
+      when %r{^([a-z]+)://$}
+        string += 'dummy'
+      when /^([a-z]+):$/
+        string += '//dummy'
       end
       u = Addressable::URI.parse(string)
       u.host = nil

--- a/lib/train.rb
+++ b/lib/train.rb
@@ -117,7 +117,7 @@ module Train
     u = Addressable::URI.parse(string)
     # A use-case we want to catch is parsing empty URIs with a schema
     # e.g. mock://. To do this, we match it manually and fake the hostname
-    if u.scheme and (u.host.nil? or u.host.empty?) and u.path.empty?
+    if u.scheme && (u.host.nil? || u.host.empty?) && u.path.empty?
       case string
         when %r{^([a-z]+)://$}
           string += 'dummy'

--- a/lib/train/transports/winrm_connection.rb
+++ b/lib/train/transports/winrm_connection.rb
@@ -114,7 +114,7 @@ class Train::Transports::WinRM
     #   Mac system
     # @api private
     def rdp_doc(opts = {})
-      host = URI.parse(options[:endpoint]).host
+      host = Addressable::URI.parse(options[:endpoint]).host
       content = [
         "full address:s:#{host}:#{@rdp_port}",
         'prompt for credentials:i:1',
@@ -145,7 +145,7 @@ class Train::Transports::WinRM
     def login_command_for_linux
       args  = %W( -u #{options[:user]} )
       args += %W( -p #{options[:pass]} ) if options.key?(:pass)
-      args += %W( #{URI.parse(options[:endpoint]).host}:#{@rdp_port} )
+      args += %W( #{Addressable::URI.parse(options[:endpoint]).host}:#{@rdp_port} )
       LoginCommand.new('rdesktop', args)
     end
 

--- a/train.gemspec
+++ b/train.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0'
 
+  spec.add_dependency 'addressable', '~> 2.5'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   # chef-client < 12.4.1 require mixlib-shellout-2.0.1
   spec.add_dependency 'mixlib-shellout', '~> 2.0'


### PR DESCRIPTION
"Addressable is a replacement for the URI implementation that is part of Ruby's standard library. It more closely conforms to RFC 3986, RFC 3987, and RFC 6570 (level 4), additionally providing support for IRIs and URI templates.", see https://github.com/sporkmonger/addressable

Fixes https://github.com/inspec/train/issues/110

Signed-off-by: Markus Grobelin <grobi@koppzu.de>