### PR TITLE
Modify Cisco UUID detection to use processor ID

### DIFF
--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -555,7 +555,7 @@ module Train::Platforms::Detect::Specifications
             next unless v[:type] == 'nexus'
             @platform[:release] = v[:version]
             @platform[:arch] = nil
-            @platform[:uuid_command] = 'show inventory chassis | include SN'
+            @platform[:uuid_command] = 'show version | include Processor'
             true
           }
 

--- a/lib/train/transports/cisco_ios_connection.rb
+++ b/lib/train/transports/cisco_ios_connection.rb
@@ -26,10 +26,8 @@ class Train::Transports::SSH
     end
 
     def unique_identifier
-      result = run_command_via_connection('show inventory').stdout
-      result.split("\r\n\r\n").each do |section|
-        return section.split('SN: ')[1].strip if section.include?('Chassis')
-      end
+      result = run_command_via_connection('show version | include Processor')
+      result.stdout.split(' ')[-1]
     end
 
     private

--- a/test/unit/transports/cisco_ios_connection.rb
+++ b/test/unit/transports/cisco_ios_connection.rb
@@ -33,11 +33,12 @@ describe 'CiscoIOSConnection' do
 
   describe '#unique_identifier' do
     it 'returns the correct identifier' do
-      output = "NAME: \"Chassis\", DESCR: \"Cisco 7206VXR, 6-slot chassis\"\r\nPID: CISCO7206VXR      , VID:    , SN: 4279256517 \r\n\r\nNAME: \"NPE400 0\", DESCR: \"Cisco 7200VXR Network Processing Engine NPE-400\"\r\nPID: NPE-400           , VID:    , SN: 11111111   \r\n\r\nNAME: \"module 0\", DESCR: \"I/O FastEthernet (TX-ISL)\"\r\nPID: C7200-IO-FE-MII/RJ45=, VID:    , SN: 4294967295 \r\n\r\nNAME: \"Power Supply 1\", DESCR: \"Cisco 7200 AC Power Supply\"\r\nPID: PWR-7200-AC       , VID:    , SN:            \r\n\r\nNAME: \"Power Supply 2\", DESCR: \"Cisco 7200 AC Power Supply\"\r\nPID: PWR-7200-AC       , VID:    , SN:            "
+      output = "\r\nProcessor board ID 1111111111\r\n"
       Train::Transports::SSH::CiscoIOSConnection.any_instance
-        .expects(:run_command_via_connection).with('show inventory')
+        .expects(:run_command_via_connection)
+        .with('show version | include Processor')
         .returns(OpenStruct.new(stdout: output))
-      connection.unique_identifier.must_equal('4279256517')
+      connection.unique_identifier.must_equal('1111111111')
     end
   end
 


### PR DESCRIPTION
Not all Cisco devices have a chassis. This modifies the detection to use the `Processor board ID` which should be static and unique.