### PR TITLE
Fixes failing test when you have a cred file

### DIFF
--- a/lib/train/transports/azure.rb
+++ b/lib/train/transports/azure.rb
@@ -26,6 +26,8 @@ module Train::Transports
     class Connection < BaseConnection
       attr_reader :options
 
+      DEFAULT_FILE = ::File.join(Dir.home, '.azure', 'credentials')
+
       def initialize(options)
         @apis = {}
 
@@ -38,6 +40,7 @@ module Train::Transports
         @cache[:api_call] = {}
 
         if @options[:client_secret].nil? && @options[:client_id].nil?
+          options[:credentials_file] = DEFAULT_FILE if options[:credentials_file].nil?
           @options.merge!(Helpers::Azure::FileCredentials.parse(@options))
         end
 

--- a/lib/train/transports/helpers/azure/file_credentials.rb
+++ b/lib/train/transports/helpers/azure/file_credentials.rb
@@ -9,10 +9,9 @@ module Train::Transports
   module Helpers
     module Azure
       class FileCredentials
-        DEFAULT_FILE = ::File.join(Dir.home, '.azure', 'credentials')
 
-        def self.parse(subscription_id: nil, credentials_file: DEFAULT_FILE, **_)
-          credentials_file = DEFAULT_FILE if credentials_file.nil?
+        def self.parse(subscription_id: nil, credentials_file: nil, **_)
+          return {} if credentials_file.nil?
           return {} unless ::File.readable?(credentials_file)
           credentials     = IniFile.load(::File.expand_path(credentials_file))
           subscription_id = parser(subscription_id, ENV['AZURE_SUBSCRIPTION_NUMBER'], credentials).subscription_id

--- a/lib/train/transports/helpers/azure/file_credentials.rb
+++ b/lib/train/transports/helpers/azure/file_credentials.rb
@@ -9,7 +9,6 @@ module Train::Transports
   module Helpers
     module Azure
       class FileCredentials
-
         def self.parse(subscription_id: nil, credentials_file: nil, **_)
           return {} if credentials_file.nil?
           return {} unless ::File.readable?(credentials_file)


### PR DESCRIPTION
This test could fail in cases where you already have a credentails file
in the default path (~/.azure/credentials).

I am moving the default
behavior to `azure.rb` so `file_credentials` can operate on what you
pass in. This makes an easier contract as the caller must provide a file,
and the test easier since there's no defaulting behavior.

Signed-off-by: David McCown <dmccown@chef.io>