### PR TITLE
Rescues SystemCallError instead of Errno

### DIFF
--- a/lib/train/transports/azure.rb
+++ b/lib/train/transports/azure.rb
@@ -164,7 +164,7 @@ module Train::Transports
           begin
             TCPSocket.new('localhost', port).close
             true
-          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+          rescue SystemCallError
             false
           end
         end


### PR DESCRIPTION
Fixes #344

This fixes issue #344 by replacing rescue `Errno::*` with
`SystemCallError`. Each error in the `Errno::Constants` is a subclass of
SystemCallError. We can use SystemCallError to handle the exceptions on
different OSes.

Signed-off-by: David McCown <dmccown@chef.io>