### PR TITLE
Add a export method for platforms

### DIFF
--- a/lib/train/platforms.rb
+++ b/lib/train/platforms.rb
@@ -81,4 +81,16 @@ module Train::Platforms
       print_children(obj, pad + 2) if defined?(obj.children) && !obj.children.nil?
     end
   end
+
+  def self.export
+    export = []
+    list.each do |name, platform|
+      platform.find_family_hierarchy
+      export << {
+        name: name,
+        families: platform.family_hierarchy,
+      }
+    end
+    export
+  end
 end

--- a/lib/train/platforms.rb
+++ b/lib/train/platforms.rb
@@ -24,6 +24,12 @@ module Train::Platforms
     def families
       @families ||= {}
     end
+
+    # Clear all platform settings. Only used for testing.
+    def __reset
+      @list = {}
+      @families = {}
+    end
   end
 
   # Create or update a platform

--- a/lib/train/platforms.rb
+++ b/lib/train/platforms.rb
@@ -91,6 +91,6 @@ module Train::Platforms
         families: platform.family_hierarchy,
       }
     end
-    export
+    export.sort_by { |platform| platform[:name] }
   end
 end

--- a/lib/train/platforms/platform.rb
+++ b/lib/train/platforms/platform.rb
@@ -22,6 +22,14 @@ module Train::Platforms
       @families.collect { |k, _v| k.name }
     end
 
+    def find_family_hierarchy(platform = self)
+      families = platform.families.each_with_object([]) do |(k, _v), memo|
+        memo << k.name
+        memo << find_family_hierarchy(k) unless k.families.empty?
+      end
+      @family_hierarchy = families.flatten
+    end
+
     def family
       @platform[:family] || @family_hierarchy[0]
     end

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -81,19 +81,12 @@ class Train::Plugins::Transport
       plat = Train::Platforms.name(name)
       plat.backend = self
       plat.platform = platform_details unless platform_details.nil?
-      plat.family_hierarchy = family_hierarchy(plat).flatten
+      plat.find_family_hierarchy
       plat.add_platform_methods
       plat
     end
 
     alias direct_platform force_platform!
-
-    def family_hierarchy(plat)
-      plat.families.each_with_object([]) do |(k, _v), memo|
-        memo << k.name
-        memo << family_hierarchy(k) unless k.families.empty?
-      end
-    end
 
     # Get information on the operating system which this transport connects to.
     #

--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -77,7 +77,7 @@ class Train::Transports::Mock
       value = { name: 'mock', family: 'mock', release: 'unknown', arch: 'unknown' }.merge(value)
 
       platform = Train::Platforms.name(value[:name])
-      platform.family_hierarchy = family_hierarchy(platform).flatten
+      platform.find_family_hierarchy
       platform.platform = value
       platform.add_platform_methods
       @platform = platform

--- a/test/unit/platforms/platform_test.rb
+++ b/test/unit/platforms/platform_test.rb
@@ -61,6 +61,12 @@ describe 'platform' do
     plat.families.values[0].must_equal({ arch: '= x86_64' })
   end
 
+  it 'finds family hierarchy' do
+    plat = Train::Platforms.name('linux')
+    plat.find_family_hierarchy
+    plat.family_hierarchy.must_equal ['linux', 'unix', 'os']
+  end
+
   it 'return direct families' do
     plat = mock_platform_family('mock')
     plat.in_family('mock2')

--- a/test/unit/platforms/platforms_test.rb
+++ b/test/unit/platforms/platforms_test.rb
@@ -41,6 +41,7 @@ describe 'platforms' do
   end
 
   it 'return platforms export with data' do
+    Train::Platforms.__reset
     Train::Platforms::Detect::Specifications::OS.load
     export = Train::Platforms.export
     export.size.must_be :>, 10

--- a/test/unit/platforms/platforms_test.rb
+++ b/test/unit/platforms/platforms_test.rb
@@ -39,4 +39,13 @@ describe 'platforms' do
     top = Train::Platforms.top_platforms
     top.count.must_equal(1)
   end
+
+  it 'return platforms export with data' do
+    Train::Platforms::Detect::Specifications::OS.load
+    export = Train::Platforms.export
+    export.size.must_be :>, 10
+    export[0][:name].must_equal 'aix'
+    expected_families = ['aix', 'unix', 'os']
+    export[0][:families].must_equal expected_families
+  end
 end

--- a/test/unit/plugins/connection_test.rb
+++ b/test/unit/plugins/connection_test.rb
@@ -72,12 +72,6 @@ describe 'v1 Connection Plugin' do
       plat[:release].must_equal aws_version
     end
 
-    it 'provides family hierarchy' do
-      plat = Train::Platforms.name('linux')
-      family = connection.family_hierarchy(plat)
-      family.flatten.must_equal ['linux', 'unix', 'os']
-    end
-
     it 'must use the user-provided logger' do
       l = rand
       cls.new({logger: l})


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

This is needed for upstream https://github.com/inspec/inspec/issues/2488

This new method dumps all platforms and their families.