### PR TITLE
Fixes the link pointing back to the plugin docs

### DIFF
--- a/examples/plugins/train-local-rot13/README.md
+++ b/examples/plugins/train-local-rot13/README.md
@@ -56,7 +56,7 @@ You are encouraged to use this plugin as a starting point for real plugins.
 
 ## Development of a Plugin
 
-[Plugin Development](https://github.com/inspec/train/blob/master/docs/dev/plugins.md) is documented on the `train` project on GitHub.  Additionally, this example
+[Plugin Development](https://github.com/inspec/train/blob/master/docs/plugins.md) is documented on the `train` project on GitHub.  Additionally, this example
 plugin has extensive comments explaining what is happening, and why.
 
 ### A Tour of the Plugin


### PR DESCRIPTION
There is a link in the example train plugin README which looks like it's intended to point to a plugins doc back towards the top level of the train project. However, the path has `dev/` inside it which doesn't exist. Removed this so the link works. 