### PR TITLE
Adds cached_client method in BaseConnection

### DIFF
--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -37,6 +37,25 @@ class Train::Plugins::Transport
       end
     end
 
+    # Returns cached client if caching enabled. Otherwise returns whatever is
+    # given in the block.
+    #
+    # @example
+    #
+    #   def demo_client
+    #     cached_client(:api_call, :demo_connection) do
+    #       DemoClient.new(args)
+    #     end
+    #   end
+    #
+    # @param [symbol] type one of [:api_call, :file, :command]
+    # @param [symbol] key for your cached connection
+    def cached_client(type, key)
+      return yield unless cache_enabled?(type)
+
+      @cache[type][key] ||= yield
+    end
+
     def cache_enabled?(type)
       @cache_enabled[type.to_sym]
     end


### PR DESCRIPTION
Adds a helper method in base connection so you no longer have to
duplicate caching logic in any plugins you may create. Example:

```Ruby
def demo_client
  cache_client(:api_call, :demo_connection) do
    DemoClient.new(options)
  end
end
```

This will automatically check if the cache is enabled and return the the
cached object if it exists. If it doesn't exist then the cache will be
hydrated.

Signed-off-by: David McCown <dmccown@chef.io>