### PR TITLE
Fix Cisco IOS detection when banners lack a `\r\n`

### DIFF
--- a/lib/train/platforms/detect/helpers/os_common.rb
+++ b/lib/train/platforms/detect/helpers/os_common.rb
@@ -69,17 +69,17 @@ module Train::Platforms::Detect::Helpers
       return @cache[:cisco] if @cache.key?(:cisco)
       res = command_output('show version')
 
-      m = res.match(/^Cisco IOS Software, [^,]+? \(([^,]+?)\), Version (\d+\.\d+)/)
+      m = res.match(/Cisco IOS Software, [^,]+? \(([^,]+?)\), Version (\d+\.\d+)/)
       unless m.nil?
         return @cache[:cisco] = { version: m[2], model: m[1], type: 'ios' }
       end
 
-      m = res.match(/^Cisco IOS Software, IOS-XE Software, [^,]+? \(([^,]+?)\), Version (\d+\.\d+\.\d+[A-Z]*)/)
+      m = res.match(/Cisco IOS Software, IOS-XE Software, [^,]+? \(([^,]+?)\), Version (\d+\.\d+\.\d+[A-Z]*)/)
       unless m.nil?
         return @cache[:cisco] = { version: m[2], model: m[1], type: 'ios-xe' }
       end
 
-      m = res.match(/^Cisco Nexus Operating System \(NX-OS\) Software/)
+      m = res.match(/Cisco Nexus Operating System \(NX-OS\) Software/)
       unless m.nil?
         v = res[/^\s*system:\s+version (\d+\.\d+)/, 1]
         return @cache[:cisco] = { version: v, type: 'nexus' }


### PR DESCRIPTION
This modifies some detection RegEx to not require `Cisco IOS Software` to be at the start of a line. 

During detection, the first command ran will contain the MOTD banner. So if the banner was created without a newline before the delimiter character like so:

```
IOS_12_HARDENED(config)#banner motd |
Enter TEXT message.  End with the character '|'
A MOTD Banner|
IOS_12_HARDENED(config)#
```

It will show up in the output of `show version` like so:

```
A MOTD BannerCisco IOS Software...
```

If someone were to create a banner like this:

```
IOS_12_HARDENED(config)#banner motd |
Enter TEXT message.  End with the character '|'
A MOTD Banner
|
IOS_12_HARDENED(config)#
```

Then the detection RegEx would work because it would look like the following in the output:

```
A MOTD Banner\r\nCisco IOS Software...
```

This modifies the detection to support both as both are valid.

This fixes #370 