### PR TITLE
Added a new matcher for amazon linux 2

### DIFF
--- a/lib/train/platforms/detect/helpers/os_linux.rb
+++ b/lib/train/platforms/detect/helpers/os_linux.rb
@@ -12,6 +12,8 @@ module Train::Platforms::Detect::Helpers
         /((\d+) \(Rawhide\))/i.match(conf)[1].downcase
       when /Amazon Linux AMI/i
         /release ([\d\.]+)/.match(conf)[1]
+      when /amazon linux release/i
+        /Linux release ((\d+|\.)+)/i.match(conf)[1]
       when /derived from .*linux|amazon/i
         /Linux ((\d+|\.)+)/i.match(conf)[1]
       else

--- a/test/unit/platforms/detect/os_linux_test.rb
+++ b/test/unit/platforms/detect/os_linux_test.rb
@@ -28,6 +28,14 @@ describe 'os_linux' do
     it 'normal linux' do
       detector.redhatish_version('derived from Ubuntu Linux 11').must_equal('11')
     end
+
+    it 'amazon linux 2 new release naming schema' do
+      detector.redhatish_version('Amazon Linux release 2 (Karoo)').must_equal('2')
+    end
+
+    it 'amazon linux 2 old release naming schema' do
+      detector.redhatish_version('Amazon Linux 2').must_equal('2')
+    end
   end
 
   describe 'lsb parse' do


### PR DESCRIPTION
Th target of this PR is to address a problem which appeared after AWS updated naming schema for Amazon Linux 2.

More details can be found [here](https://github.com/inspec/inspec/issues/3614)