### PR TITLE
Pass logger to Cisco IOS transport

### DIFF
--- a/lib/train/transports/cisco_ios_connection.rb
+++ b/lib/train/transports/cisco_ios_connection.rb
@@ -7,8 +7,6 @@ class Train::Transports::SSH
     def initialize(options)
       super(options)
 
-      logger.level = Logger::INFO
-
       # Extract options to avoid passing them in to `Net::SSH.start` later
       @host = options.delete(:host)
       @user = options.delete(:user)

--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -218,6 +218,7 @@ module Train::Transports
         # We will also support the sudo password field for the same purpose
         # for the interim. # TODO
         ios_options[:enable_password] = @options[:enable_password] || @options[:sudo_password]
+        ios_options[:logger] = @options[:logger]
         ios_options.merge!(@connection_options)
         conn = CiscoIOSConnection.new(ios_options)
       end


### PR DESCRIPTION
Inherit the logger (and log level) from upstream rather than presuming
we'll make a new one.

Signed-off-by: Bryan McLellan <btm@loftninjas.org>