### PR TITLE
Fixes enable password and catches failure

### DIFF
--- a/lib/train/transports/cisco_ios_connection.rb
+++ b/lib/train/transports/cisco_ios_connection.rb
@@ -46,7 +46,8 @@ class Train::Transports::SSH
         # This verifies we are not in privileged exec mode before running the
         # enable command. Otherwise, the password will be in history.
         if run_command_via_connection('show privilege').stdout.split[-1] != '15'
-          run_command_via_connection("enable\n#{@enable_password}")
+          # Extra newlines to get back to prompt if incorrect password is used
+          run_command_via_connection("enable\n#{@enable_password}\n\n\n")
         end
       end
 
@@ -65,7 +66,9 @@ class Train::Transports::SSH
 
       logger.debug('[SSH] waiting for prompt')
       until @buf =~ @prompt
-        raise BadEnablePassword if @buf =~ /Bad secrets/ || @buf =~ /Access denied/
+        if @buf =~ /Bad (secrets|password)|Access denied/
+          raise BadEnablePassword
+        end
         session.connection.process(0)
       end
 

--- a/lib/train/transports/cisco_ios_connection.rb
+++ b/lib/train/transports/cisco_ios_connection.rb
@@ -46,7 +46,7 @@ class Train::Transports::SSH
         # This verifies we are not in privileged exec mode before running the
         # enable command. Otherwise, the password will be in history.
         if run_command_via_connection('show privilege').stdout.split[-1] != '15'
-          run_command_via_connection("enable\r\n#{@enable_password}")
+          run_command_via_connection("enable\n#{@enable_password}")
         end
       end
 
@@ -65,7 +65,7 @@ class Train::Transports::SSH
 
       logger.debug('[SSH] waiting for prompt')
       until @buf =~ @prompt
-        raise BadEnablePassword if @buf =~ /Bad secrets/
+        raise BadEnablePassword if @buf =~ /Bad secrets/ || @buf =~ /Access denied/
         session.connection.process(0)
       end
 


### PR DESCRIPTION
On my switch, '\r\n' is being interpreted as two enter key presses, so
the enable password is being sent to the shell prompt on the switch, not
to the password prompt.

I'm not sure if it is different behavior on some routers or if this has
been broken for a while, given that inspec may not need enable. But
'show running-config' does require enable privileges.

Fixes #382

Signed-off-by: Bryan McLellan <btm@loftninjas.org>