### PR TITLE
Make `AMI` optional in Amazon Linux OS detection

### DIFF
--- a/lib/train/platforms/detect/helpers/os_linux.rb
+++ b/lib/train/platforms/detect/helpers/os_linux.rb
@@ -11,7 +11,7 @@ module Train::Platforms::Detect::Helpers
       when /rawhide/i
         /((\d+) \(Rawhide\))/i.match(conf)[1].downcase
       when /Amazon Linux/i
-        /release ([\d\.]+)/.match(conf)[1]
+        /([\d\.]+)/.match(conf)[1]
       when /derived from .*linux|amazon/i
         /Linux ((\d+|\.)+)/i.match(conf)[1]
       else

--- a/lib/train/platforms/detect/helpers/os_linux.rb
+++ b/lib/train/platforms/detect/helpers/os_linux.rb
@@ -10,7 +10,7 @@ module Train::Platforms::Detect::Helpers
       case conf
       when /rawhide/i
         /((\d+) \(Rawhide\))/i.match(conf)[1].downcase
-      when /Amazon Linux (?:AMI|.*)/i
+      when /Amazon Linux/i
         /release ([\d\.]+)/.match(conf)[1]
       when /derived from .*linux|amazon/i
         /Linux ((\d+|\.)+)/i.match(conf)[1]

--- a/lib/train/platforms/detect/helpers/os_linux.rb
+++ b/lib/train/platforms/detect/helpers/os_linux.rb
@@ -10,7 +10,7 @@ module Train::Platforms::Detect::Helpers
       case conf
       when /rawhide/i
         /((\d+) \(Rawhide\))/i.match(conf)[1].downcase
-      when /Amazon Linux AMI/i
+      when /Amazon Linux (?:AMI|.*)/i
         /release ([\d\.]+)/.match(conf)[1]
       when /derived from .*linux|amazon/i
         /Linux ((\d+|\.)+)/i.match(conf)[1]

--- a/test/unit/platforms/detect/os_linux_test.rb
+++ b/test/unit/platforms/detect/os_linux_test.rb
@@ -28,6 +28,14 @@ describe 'os_linux' do
     it 'normal linux' do
       detector.redhatish_version('derived from Ubuntu Linux 11').must_equal('11')
     end
+
+    it 'amazon linux 2 new release naming schema' do
+      detector.redhatish_version('Amazon Linux release 2 (Karoo)').must_equal('2')
+    end
+
+    it 'amazon linux 2 old release naming schema' do
+      detector.redhatish_version('Amazon Linux 2').must_equal('2')
+    end
   end
 
   describe 'lsb parse' do


### PR DESCRIPTION
See:

```
       __|  __|_  )
       _|  (     /   Amazon Linux 2 AMI
      ___|\___|___|

https://aws.amazon.com/amazon-linux-2/
[ec2-user@ip-172-31-47-126 ~]$ cat /etc/system-release
Amazon Linux release 2 (Karoo)
```

More context: https://github.com/inspec/train/pull/312

This closes https://github.com/inspec/train/pull/380 many thanks @artyomtkachenko