### PR TITLE
Only ship the runtime files in the gem to slim install sizes

### DIFF
--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/inspec/train/'
   spec.license       = 'Apache-2.0'
 
-  spec.files = %w{train-core.gemspec README.md LICENSE Gemfile CHANGELOG.md} + Dir
+  spec.files = %w{LICENSE} + Dir
                .glob('lib/**/*', File::FNM_DOTMATCH)
                .reject { |f| f =~ %r{lib/train/transports} unless CORE_TRANSPORTS.include?(f) }
                .reject { |f| File.directory?(f) }

--- a/train.gemspec
+++ b/train.gemspec
@@ -13,11 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/inspec/train/'
   spec.license       = 'Apache-2.0'
 
-  spec.files = %w{
-    train.gemspec README.md Rakefile LICENSE Gemfile CHANGELOG.md .rubocop.yml
-  } + Dir.glob(
-    '{lib,test}/**/*', File::FNM_DOTMATCH
-  ).reject { |f| File.directory?(f) }
+  spec.files = %w{LICENSE} + Dir.glob('lib/**/*', File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
 
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Don't ship the readme, changelog, or test files in the gem artifact.
There's no need for these files deep in a Ruby install. This shrinks the
gem install from 108k to 49k.

Signed-off-by: Tim Smith <tsmith@chef.io>