### PR TITLE
Remove compat with unsupported Ruby 1.9 in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,6 @@
 source 'https://rubygems.org'
 gemspec name: 'train'
 
-# pin dependency for Ruby 1.9.3 since bundler is not
-# detecting that net-ssh 3 does not work with 1.9.3
-if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('1.9.3')
-  gem 'net-ssh', '~> 2.9'
-end
-
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2')
   gem 'json', '< 2.0'
 end
@@ -19,7 +13,7 @@ end
 
 group :test do
   gem 'minitest', '~> 5.8'
-  gem 'rake', '~> 10'
+  gem 'rake', '~> 12'
   gem 'rubocop', '~> 0.36.0'
   gem 'simplecov', '~> 0.10'
   gem 'concurrent-ruby', '~> 1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 
 group :test do
   gem 'minitest', '~> 5.8'
-  gem 'rake', '~> 12'
+  gem 'rake', '~> 10' # @todo bump this when we bump rubocop
   gem 'rubocop', '~> 0.36.0'
   gem 'simplecov', '~> 0.10'
   gem 'concurrent-ruby', '~> 1.0'


### PR DESCRIPTION
We require Ruby 2+ so there's no point in this now.

Signed-off-by: Tim Smith <tsmith@chef.io>