### PR TITLE
Prepare train for using credential sets

### DIFF
--- a/lib/train.rb
+++ b/lib/train.rb
@@ -62,8 +62,9 @@ module Train
   end
 
   # Legacy code to unpack a series of items from an incoming Hash
-  # Inspec::Config.unpack_train_credentials now handles this in most cases
-  def self.target_config(config) # TODO: deprecate
+  # Inspec::Config.unpack_train_credentials now handles this in most cases that InSpec needs
+  # If you need to unpack a URI, use upack_target_from_uri
+  def self.target_config(config = nil)
     conf = config.dup
     # Symbolize keys
     conf.keys.each do |key|
@@ -100,7 +101,8 @@ module Train
     # ensure path is nil, if its empty; e.g. required to reset defaults for winrm # TODO: move logic into winrm plugin
     creds[:path] = nil if !creds[:path].nil? && creds[:path].to_s.empty?
 
-    creds.compact!
+    # compat! is available in ruby 2.4+
+    creds = creds.delete_if { |_, value| value.nil? }
 
     # return the updated config
     creds

--- a/lib/train.rb
+++ b/lib/train.rb
@@ -63,7 +63,7 @@ module Train
 
   # Legacy code to unpack a series of items from an incoming Hash
   # Inspec::Config.unpack_train_credentials now handles this in most cases that InSpec needs
-  # If you need to unpack a URI, use upack_target_from_uri
+  # If you need to unpack a URI, use unpack_target_from_uri
   def self.target_config(config = nil)
     conf = config.dup
     # Symbolize keys
@@ -149,7 +149,7 @@ module Train
       # We should not get here, because if target_uri unpacking was successful,
       # it would have set credentials[:backend]
       fail Train::UserError, 'Cannot determine backend from target '\
-           "configuration #{credentials[:target_uri].inspect}. Valid example: ssh://192.168.0.1."
+           "configuration #{credentials[:target]}. Valid example: ssh://192.168.0.1."
     end
 
     if !credentials[:host].nil?

--- a/lib/train/plugins/transport.rb
+++ b/lib/train/plugins/transport.rb
@@ -41,12 +41,6 @@ class Train::Plugins
       Train::Plugins.registry[name] = self
     end
 
-    # Describe the defaults for the options this transport provides.
-    def self.credential_option_defaults
-      # TODO
-      {}
-    end
-
     private
 
     # @return [Logger] logger for reporting information

--- a/lib/train/plugins/transport.rb
+++ b/lib/train/plugins/transport.rb
@@ -41,6 +41,12 @@ class Train::Plugins
       Train::Plugins.registry[name] = self
     end
 
+    # Describe the defaults for the options this transport provides.
+    def self.credential_option_defaults
+      # TODO
+      Hash.new
+    end
+
     private
 
     # @return [Logger] logger for reporting information

--- a/lib/train/plugins/transport.rb
+++ b/lib/train/plugins/transport.rb
@@ -44,7 +44,7 @@ class Train::Plugins
     # Describe the defaults for the options this transport provides.
     def self.credential_option_defaults
       # TODO
-      Hash.new
+      {}
     end
 
     private

--- a/test/unit/helper.rb
+++ b/test/unit/helper.rb
@@ -3,5 +3,6 @@
 require 'minitest/autorun'
 require 'minitest/spec'
 require 'mocha/setup'
+require 'byebug'
 
 require 'train'

--- a/test/unit/train_test.rb
+++ b/test/unit/train_test.rb
@@ -67,60 +67,7 @@ describe Train do
     end
   end
 
-  describe '#unpack_target_creds' do
-    describe 'when the target_uri is a backend://credset format' do
-      it 'resolves an SSH target' do
-        config = Class.new do
-          CREDSETS = {
-            mock: {
-              myset1: {}
-            },
-            ssh: {
-              myset2: {},
-              myset3: {
-                host: 'host.com',
-                user: 'user',
-                password: 'pass',
-                port: 123,
-                path: '/path',
-              }
-            }
-          }
-          def target_uri
-            'ssh://myset3'
-          end
-          def fetch_credentials(xport, credset_name, _opts)
-            CREDSETS[xport][credset_name]
-          end
-        end.new
-
-        result = Train.unpack_target_creds(config)
-        result[:backend].must_equal :ssh
-        result[:host].must_equal 'host.com'
-        result[:user].must_equal 'user'
-        result[:password].must_equal 'pass'
-        result[:port].must_equal 123
-        result[:target].must_equal 'ssh://myset3'
-        result[:path].must_equal '/path'
-      end
-    end
-
-    describe 'when the target_uri is a backend://user:pass@host format' do
-      it 'resolves an SSH target' do
-        target_uri = 'ssh://user:pass@host.com:123/path'
-        result = Train.unpack_target_creds(OpenStruct.new(target_uri: target_uri ))
-        result[:backend].must_equal 'ssh'
-        result[:host].must_equal 'host.com'
-        result[:user].must_equal 'user'
-        result[:password].must_equal 'pass'
-        result[:port].must_equal 123
-        result[:target].must_equal target_uri
-        result[:path].must_equal '/path'
-      end
-    end
-  end
-
-  describe '#target_config - Legacy support' do
+  describe '#target_config - URI parsing' do
     it 'configures resolves target' do
       org = {
         target: 'ssh://user:pass@host.com:123/path',
@@ -282,7 +229,7 @@ describe Train do
     end
 
     it 'returns the local backend if nothing was provided' do
-      Train.validate_backend({}).must_equal :local
+      Train.validate_backend({}).must_equal 'local'
     end
 
     it 'returns the default backend if nothing was provided' do

--- a/test/unit/train_test.rb
+++ b/test/unit/train_test.rb
@@ -2,7 +2,6 @@
 #
 # Author:: Dominik Richter (<dominik.richter@gmail.com>)
 require_relative 'helper'
-require 'byebug'
 
 describe Train do
   before do


### PR DESCRIPTION
Train has historically either used explicit options passed in a hash, or parsed a --target option as a URL. Both are a bit unwieldy, especially the URI method. 

This PR makes a few changes to make it easier to work with credentials passed in as a hash.