### PR TITLE
drop ruby 2.0-2.2 support, allow bundler 2.x, bump integration gems, allow mixlib-shellout 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ branches:
 
 matrix:
   include:
-  - rvm: 2.2.10
-    before_install:
-      - gem install bundler
-      - gem --version
   - rvm: 2.3.8
     before_install:
       - gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,6 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2')
   gem 'json', '< 2.0'
 end
 
-# bundler is built into Ruby 2.6 and later
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.6')
-  gem 'bundler', '>= 1.11'
-end
-
 group :test do
   gem 'minitest', '~> 5.8'
   gem 'rake', '~> 10'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ end
 
 # bundler is built into Ruby 2.6 and later
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.6')
-  gem 'bundler', '~> 1.11'
+  gem 'bundler', '>= 1.11'
 end
 
 group :test do
@@ -33,8 +33,8 @@ group :test do
 end
 
 group :integration do
-  gem 'berkshelf', '~> 5.2'
-  gem 'test-kitchen', '~> 1.11'
+  gem 'berkshelf', '>= 6.3.4'
+  gem 'test-kitchen', '>= 1.2.4'
   gem 'kitchen-vagrant'
 end
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,6 @@ environment:
   winrm_pass: Pass@word1
 
   matrix:
-    - ruby_version: "22"
-      train_target: winrm://test_user@localhost:5985
-
     - ruby_version: "24"
       train_target: winrm://test_user@localhost:5985
 

--- a/lib/train/transports/gcp.rb
+++ b/lib/train/transports/gcp.rb
@@ -25,7 +25,7 @@ module Train::Transports
     # https://cloud.google.com/compute/docs/regions-zones/changing-default-zone-region
     # can also specify project via env var:
     option :google_cloud_project, required: false do
-     ENV['GOOGLE_CLOUD_PROJECT']
+      ENV['GOOGLE_CLOUD_PROJECT']
     end
     option :google_super_admin_email, required: false do
       ENV['GOOGLE_SUPER_ADMIN_EMAIL']

--- a/lib/train/transports/gcp.rb
+++ b/lib/train/transports/gcp.rb
@@ -14,7 +14,9 @@ module Train::Transports
     name 'gcp'
 
     # GCP will look automatically for the below env var for service accounts etc. :
-    option :google_application_credentials, required: false, default: ENV['GOOGLE_APPLICATION_CREDENTIALS']
+    option :google_application_credentials, required: false do
+      ENV['GOOGLE_APPLICATION_CREDENTIALS']
+    end
     # see https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application
     # In the absence of this, the client is expected to have already set up local credentials via:
     #   $ gcloud auth application-default login
@@ -22,8 +24,12 @@ module Train::Transports
     # GCP projects can have default regions / zones set, see:
     # https://cloud.google.com/compute/docs/regions-zones/changing-default-zone-region
     # can also specify project via env var:
-    option :google_cloud_project, required: false, default: ENV['GOOGLE_CLOUD_PROJECT']
-    option :google_super_admin_email, required: false, default: ENV['GOOGLE_SUPER_ADMIN_EMAIL']
+    option :google_cloud_project, required: false do
+     ENV['GOOGLE_CLOUD_PROJECT']
+    end
+    option :google_super_admin_email, required: false do
+      ENV['GOOGLE_SUPER_ADMIN_EMAIL']
+    end
 
     def connection(_ = nil)
       @connection ||= Connection.new(@options)

--- a/test/unit/transports/gcp_test.rb
+++ b/test/unit/transports/gcp_test.rb
@@ -48,6 +48,13 @@ describe 'gcp transport' do
   let(:options) { connection.instance_variable_get(:@options) }
   let(:cache) { connection.instance_variable_get(:@cache) }
 
+  before do
+    # force the tempfile object to persist for the lifetime of the test so the finalizer does not get
+    # called in the middle of our tests and delete the Tempfile out from underneath us.
+    @credentials_file = credentials_file
+    @credentials_file_override = credentials_file_override
+  end
+
   describe 'options' do
     it 'defaults to env options' do
       options[:google_application_credentials] = credentials_file.path

--- a/test/unit/transports/gcp_test.rb
+++ b/test/unit/transports/gcp_test.rb
@@ -1,58 +1,45 @@
 # encoding: utf-8
 
 require 'helper'
+require 'train/transports/gcp'
 
 describe 'gcp transport' do
 
-  # XXX: The use of class variables here creates truly global state, but this is
-  # because we get used to set the ENV var which is parsed only once at class loading
-  # time when `require 'train/transports/gcp'` is parsed.  We need to create a tempfile
-  # once with this content and then have it be used for every example.
-
-  def credentials_file
-    @@credentials_file ||=
-      begin
-        require 'tempfile'
-        file = Tempfile.new('application_default_credentials.json')
-        info = <<-INFO
+  let(:credentials_file) do
+    require 'tempfile'
+    file = Tempfile.new('application_default_credentials.json')
+    info = <<-INFO
 {
   "client_id": "asdfasf-asdfasdf.apps.googleusercontent.com",
   "client_secret": "d-asdfasdf",
   "refresh_token": "1/adsfasdf-lCkju3-yQmjr20xVZonrfkE48L",
   "type": "authorized_user"
 }
-        INFO
-        file.write(info)
-        file.close
-        file
-      end
+    INFO
+    file.write(info)
+    file.close
+    file
   end
 
-  def credentials_file_override
-    @@credentials_file_override ||=
-      begin
-        require 'tempfile'
-        file = Tempfile.new('application_default_credentials.json')
-        info = <<-INFO
+  let(:credentials_file_override) do
+    require 'tempfile'
+    file = Tempfile.new('application_default_credentials.json')
+    info = <<-INFO
 {
   "client_id": "asdfasf-asdfasdf.apps.googleusercontent.com",
   "client_secret": "d-asdfasdf",
   "refresh_token": "1/adsfasdf-lCkju3-yQmjr20xVZonrfkE48L",
   "type": "authorized_user"
 }
-        INFO
-        file.write(info)
-        file.close
-        file
-      end
+    INFO
+    file.write(info)
+    file.close
+    file
   end
 
   def transport(options = nil)
     ENV['GOOGLE_APPLICATION_CREDENTIALS'] = credentials_file.path
     ENV['GOOGLE_CLOUD_PROJECT'] = 'test_project'
-    # need to require this at here as it captures the envs on load
-    # XXX: this require statement is parsed only once for all examples
-    require 'train/transports/gcp'
     Train::Transports::Gcp.new(options)
   end
 

--- a/train.gemspec
+++ b/train.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.0'
+  spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   # chef-client < 12.4.1 require mixlib-shellout-2.0.1
-  spec.add_dependency 'mixlib-shellout', '~> 2.0'
+  spec.add_dependency 'mixlib-shellout', '>= 2.0'
   spec.add_dependency 'net-ssh', '>= 2.9', '< 6.0'
   spec.add_dependency 'net-scp', '~> 1.2'
   spec.add_dependency 'winrm', '~> 2.0'


### PR DESCRIPTION
companion to inspec/inspec#3723

this will drop support for chef-client <= 12.13.37 which is  August 15, 2016 and it is not clear that affects anyone practically since inspec only supports >= ruby 2.3 right now.

bonus fix in here for the gcp_test failures -- which are due to the way the ENV var is parsed only once when the require line is first required.