### PR TITLE
[aws] Use last SDK

### DIFF
--- a/train.gemspec
+++ b/train.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'winrm', '~> 2.0'
   spec.add_dependency 'winrm-fs', '~> 1.0'
   spec.add_dependency 'docker-api', '~> 1.26'
-  spec.add_dependency 'aws-sdk', '~> 2'
+  spec.add_dependency 'aws-sdk', '~> 3'
   spec.add_dependency 'azure_mgmt_resources', '~> 0.15'
   spec.add_dependency 'azure_graph_rbac', '~> 0.16'
   spec.add_dependency 'azure_mgmt_key_vault', '~> 0.17'


### PR DESCRIPTION
Move to SDK 3 in particular because many other aws libs depends on it, for example the last versions of https://rubygems.org/gems/aws-sdk-ec2 have this dependency: `aws-sdk-core ~> 3, >= 3.39.0`.

This is an alternative solution for https://github.com/inspec/train/pull/398