### PR TITLE
[aws] SDK 3 and modularity

### DIFF
--- a/lib/train/transports/aws.rb
+++ b/lib/train/transports/aws.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 require 'train/plugins'
-require 'aws-sdk'
+require 'aws-sdk-core'
 
 module Train::Transports
   class Aws < Train.plugin(1)

--- a/train.gemspec
+++ b/train.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'winrm', '~> 2.0'
   spec.add_dependency 'winrm-fs', '~> 1.0'
   spec.add_dependency 'docker-api', '~> 1.26'
-  spec.add_dependency 'aws-sdk', '~> 2'
+  spec.add_dependency 'aws-sdk-core', '~> 3.45.0'
   spec.add_dependency 'azure_mgmt_resources', '~> 0.15'
   spec.add_dependency 'azure_graph_rbac', '~> 0.16'
   spec.add_dependency 'azure_mgmt_key_vault', '~> 0.17'


### PR DESCRIPTION
Take advantage of aws sdk3 modularity
- reduce the tree of dependencies
- move to last aws sdk version

This is an alternative solution for https://github.com/inspec/train/pull/397