### PR TITLE
Adds support for IOS XE virtual appliances too

### DIFF
--- a/lib/train/platforms/detect/helpers/os_common.rb
+++ b/lib/train/platforms/detect/helpers/os_common.rb
@@ -79,6 +79,11 @@ module Train::Platforms::Detect::Helpers
         return @cache[:cisco] = { version: m[2], model: m[1], type: 'ios-xe' }
       end
 
+      m = res.match(/Cisco IOS Software \[([^,]+)\], Virtual XE Software [^,]+, Version (\d+\.\d+\.\d+[A-Z]*)/)
+      unless m.nil?
+        return @cache[:cisco] = { version: m[2], model: m[1], type: 'ios-xe' }
+      end
+
       m = res.match(/Cisco Nexus Operating System \(NX-OS\) Software/)
       unless m.nil?
         v = res[/^\s*system:\s+version (\d+\.\d+)/, 1]


### PR DESCRIPTION
Tested manually against an appliance I'm about to not have access to anymore. Not sure how to add test support for this change quite yet, but I've saved off a copy of `show version` to a local text file in case it involves stubbing a command. Assistance?

Target platform is a Cisco IOS XE Virtual appliance v16.9.1 (Fuji).