### PR TITLE
Fix Azure Test by adding a require

### DIFF
--- a/test/unit/transports/azure_test.rb
+++ b/test/unit/transports/azure_test.rb
@@ -2,6 +2,9 @@
 
 require 'helper'
 
+# Required because this test file acesses classes under Azure::
+require 'azure_mgmt_resources'
+
 describe 'azure transport' do
   def transport(options = nil)
     ENV['AZURE_TENANT_ID'] = 'test_tenant_id'


### PR DESCRIPTION
We've been seeing sporadic unit test failures that include the error:

```
  1) Error:
azure transport::azure_client#test_0003_can use azure_client default client:
NameError: uninitialized constant Azure
    /home/travis/build/inspec/train/test/unit/transports/azure_test.rb:78:in `block (3 levels) in <top (required)>'
```

This is caused by the unit test file neglecting to include the Azure SDK libraries, which it later references. Because other files do load the library, depending on the randomized test order, we may or may not trigger the error.