### PR TITLE
Replace the usage of const_defined? in the WinRM detection helper

### DIFF
--- a/lib/train/platforms/detect/helpers/os_common.rb
+++ b/lib/train/platforms/detect/helpers/os_common.rb
@@ -14,8 +14,7 @@ module Train::Platforms::Detect::Helpers
     end
 
     def winrm?
-      Object.const_defined?('Train::Transports::WinRM::Connection') &&
-        @backend.class == Train::Transports::WinRM::Connection
+      @backend.class.to_s == 'Train::Transports::WinRM::Connection'
     end
 
     def unix_file_contents(path)

--- a/test/unit/platforms/detect/os_common_test.rb
+++ b/test/unit/platforms/detect/os_common_test.rb
@@ -22,10 +22,20 @@ describe 'os_common' do
       detector.winrm?.must_equal(true)
     end
 
-    it 'return winrm? false' do
+    it 'return winrm? false when winrm is loaded' do
+      require 'train/transports/winrm'
       be = mock('Backend')
       detector.instance_variable_set(:@backend, be)
       detector.winrm?.must_equal(false)
+    end
+
+    it 'return winrm? false when winrm is not loaded' do
+      require 'train/transports/winrm'
+      winrm = Train::Transports.send(:remove_const, 'WinRM')
+      be = mock('Backend')
+      detector.instance_variable_set(:@backend, be)
+      detector.winrm?.must_equal(false)
+      Train::Transports.const_set('WinRM', winrm)
     end
   end
 


### PR DESCRIPTION
Ruby 2.6.1 came with some [changes](https://github.com/ruby/ruby/pull/2061) to `const_defined?` that now have it evaluating as true from this helper method, matching the behavior of `const_get`, even though the constant is inaccessible by name. This results in an exception bubbling up from the `winrm?` method:

```
✗ bundle exec kitchen verify default-amazonlinux-2-chef-14
-----> Starting Kitchen (v1.24.0)
-----> Verifying <default-amazonlinux-2-chef-14>...
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: 1 actions failed.
>>>>>>     Failed to complete #verify action: [uninitialized constant Train::Transports::WinRM] on default-amazonlinux-2-chef-14
```

A quick way around it is to make this backend comparison match the one [here](https://github.com/inspec/train/blob/v1.7.2/lib/train/platforms/detect/specifications/os.rb#L24).

Signed-off-by: Jonathan Hartman <j@hartman.io>