### PR TITLE
Detect windows also with ssh transport

### DIFF
--- a/lib/train/platforms/detect/helpers/os_windows.rb
+++ b/lib/train/platforms/detect/helpers/os_windows.rb
@@ -3,7 +3,8 @@
 module Train::Platforms::Detect::Helpers
   module Windows
     def detect_windows
-      res = @backend.run_command('cmd /c ver')
+      # try to detect windows, use cmd.exe to also support Microsoft OpenSSH
+      res = @backend.run_command('cmd.exe /c ver')
       return false if res.exit_status != 0 or res.stdout.empty?
 
       # if the ver contains `Windows`, we know its a Windows system

--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -25,6 +25,11 @@ module Train::Platforms::Detect::Specifications
               is_windows = true if ruby_host_os(/mswin|mingw32|windows/)
             end
 
+            # Try to detect windows even for ssh transport
+            if !is_windows && detect_windows == true
+              is_windows = true
+            end
+
             is_windows
           }
       # windows platform

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -202,6 +202,8 @@ class Train::Transports::SSH
         Train::File::Remote::Unix.new(self, path)
       elsif os[:name] == 'qnx'
         Train::File::Remote::Qnx.new(self, path)
+      elsif os.windows?
+        Train::File::Remote::Windows.new(self, path)
       else
         Train::File::Remote::Linux.new(self, path)
       end

--- a/test/unit/extras/command_wrapper_test.rb
+++ b/test/unit/extras/command_wrapper_test.rb
@@ -108,3 +108,22 @@ describe 'linux command' do
     end
   end
 end
+
+describe 'windows command' do
+  let(:cls) { Train::Extras::WindowsCommand }
+  let(:cmd) { rand.to_s }
+  let(:backend) {
+    backend = Train::Transports::Mock.new.connection
+    backend.mock_os({ family: 'windows' })
+    backend
+  }
+
+  describe 'shell wrapping' do
+    it 'wraps commands in a default powershell' do
+      lc = cls.new(backend, { shell: true })
+      wcmd = "$ProgressPreference='SilentlyContinue';" + cmd
+      bcmd = Base64.strict_encode64(wcmd.encode('UTF-16LE', 'UTF-8'))
+      lc.run(cmd).must_equal "powershell -NoProfile -EncodedCommand #{bcmd}"
+    end
+  end
+end

--- a/test/unit/platforms/detect/os_windows_test.rb
+++ b/test/unit/platforms/detect/os_windows_test.rb
@@ -18,7 +18,7 @@ describe 'os_detect_windows' do
   describe 'windows 2012' do
     let(:detector) {
       detector = OsDetectWindowsTester.new
-      detector.backend.mock_command('cmd /c ver', "\r\nMicrosoft Windows [Version 6.3.9600]\r\n", '', 0)
+      detector.backend.mock_command('cmd.exe /c ver', "\r\nMicrosoft Windows [Version 6.3.9600]\r\n", '', 0)
       detector.backend.mock_command('wmic os get * /format:list',"\r\r\nBuildNumber=9600\r\r\nCaption=Microsoft Windows Server 2012 R2 Standard\r\r\nOSArchitecture=64-bit\r\r\nVersion=6.3.9600\r\r\n" , '', 0)
       detector.backend.mock_command('wmic cpu get architecture /format:list',"\r\r\nArchitecture=9\r\r\n" , '', 0)
       detector
@@ -36,7 +36,7 @@ describe 'os_detect_windows' do
   describe 'windows 2008' do
     let(:detector) {
       detector = OsDetectWindowsTester.new
-      detector.backend.mock_command('cmd /c ver', "\r\nMicrosoft Windows [Version 6.1.7601]\r\n", '', 0)
+      detector.backend.mock_command('cmd.exe /c ver', "\r\nMicrosoft Windows [Version 6.1.7601]\r\n", '', 0)
       detector.backend.mock_command('wmic os get * /format:list',"\r\r\nBuildNumber=7601\r\r\nCaption=Microsoft Windows Server 2008 R2 Standard \r\r\nOSArchitecture=64-bit\r\r\nVersion=6.1.7601\r\r\n" , '', 0)
       detector.backend.mock_command('wmic cpu get architecture /format:list',"\r\r\nArchitecture=9\r\r\n" , '', 0)
       detector
@@ -54,7 +54,7 @@ describe 'os_detect_windows' do
   describe 'windows 7' do
     let(:detector) {
       detector = OsDetectWindowsTester.new
-      detector.backend.mock_command('cmd /c ver', "\r\nMicrosoft Windows [Version 6.1.7601]\r\n", '', 0)
+      detector.backend.mock_command('cmd.exe /c ver', "\r\nMicrosoft Windows [Version 6.1.7601]\r\n", '', 0)
       detector.backend.mock_command('wmic os get * /format:list',"\r\r\nBuildNumber=7601\r\r\nCaption=Microsoft Windows 7 Enterprise \r\r\nOSArchitecture=32-bit\r\r\nVersion=6.1.7601\r\r\n\r\r\n" , '', 0)
       detector.backend.mock_command('wmic cpu get architecture /format:list',"\r\r\nArchitecture=0\r\r\n" , '', 0)
       detector
@@ -72,7 +72,7 @@ describe 'os_detect_windows' do
   describe 'windows 10' do
     let(:detector) {
       detector = OsDetectWindowsTester.new
-      detector.backend.mock_command('cmd /c ver', "\r\nMicrosoft Windows [Version 10.0.10240]\r\n", '', 0)
+      detector.backend.mock_command('cmd.exe /c ver', "\r\nMicrosoft Windows [Version 10.0.10240]\r\n", '', 0)
       detector.backend.mock_command('wmic os get * /format:list',"\r\r\nBuildNumber=10240\r\r\nCaption=Microsoft Windows 10 Pro\r\r\nOSArchitecture=64-bit\r\r\nVersion=10.0.10240\r\r\n\r\r\n" , '', 0)
       detector.backend.mock_command('wmic cpu get architecture /format:list',"\r\r\nArchitecture=9\r\r\n" , '', 0)
       detector
@@ -90,7 +90,7 @@ describe 'os_detect_windows' do
   describe 'windows 98' do
     let(:detector) {
       detector = OsDetectWindowsTester.new
-      detector.backend.mock_command('cmd /c ver', "\r\nMicrosoft Windows [Version 4.10.1998]\r\n", '', 0)
+      detector.backend.mock_command('cmd.exe /c ver', "\r\nMicrosoft Windows [Version 4.10.1998]\r\n", '', 0)
       detector.backend.mock_command('wmic os get * /format:list', nil, '', 1)
       detector.backend.mock_command('wmic cpu get architecture /format:list', nil, '', 1)
       detector

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -2,12 +2,12 @@
 require 'helper'
 require 'train/transports/mock'
 
-class OsDetectLinuxTester
+class OsDetectTester
   include Train::Platforms::Detect::Helpers::OSCommon
 end
 
 describe 'os_detect' do
-  let(:detector) { OsDetectLinuxTester.new }
+  let(:detector) { OsDetectTester.new }
 
   def scan_with_files(uname, files)
     mock = Train::Transports::Mock::Connection.new
@@ -17,6 +17,12 @@ describe 'os_detect' do
       mock.mock_command("test -f #{path}")
       mock.mock_command("test -f #{path} && cat #{path}", data)
     end
+    Train::Platforms::Detect.scan(mock)
+  end
+
+  def scan_with_windows()
+    mock = Train::Transports::Mock::Connection.new
+    mock.mock_command('cmd.exe /c ver', 'Microsoft Windows [Version 6.3.9600]')
     Train::Platforms::Detect.scan(mock)
   end
 
@@ -145,6 +151,16 @@ describe 'os_detect' do
         platform[:name].must_equal('raspbian')
         platform[:family].must_equal('debian')
         platform[:release].must_equal('13.6')
+      end
+    end
+
+    describe 'windows' do
+      it 'sets the correct family/release for windows ' do
+        platform = scan_with_windows()
+
+        platform[:name].must_equal('windows_6.3.9600')
+        platform[:family].must_equal('windows')
+        platform[:release].must_equal('6.3.9600')
       end
     end
 


### PR DESCRIPTION
I found out that Packer 1.3.5 comes with the Inspec provisioner built-in. This is awesome. I immediately tried it for a Packer build for a Windows VM. And here I struggled a little bit as the detection for Windows only checks if the winrm transport is used.

I run the Packer build on a non-Windows machine (macOS in my case) and so the other detections doesn't see that the target is a Windows machine.

I've opened https://github.com/hashicorp/packer/issues/7364 to raise awareness in the Packer repo, but I also tried to find out what the root cause is.

Here is my take how to improve the detection. I know that now the first SSH command to any Linux machine will be `cmd /c ver` instead of `uname -s`.

Maybe somebody else can find a better "Linux first, but don't forget Windows" approach as I don't know the codebase.


With that change I can run Inspec tests in the Windows VM from my MBP. 🎉 

```
$ /usr/local/bin/inspec exec my_win10 --backend ssh --host 127.0.0.1 --key-files /var/folders/gw/_ms1v_611gx58lnkdy9yxr100000gq/T/packer-provisioner-inspec.764520426.key --user stefanscherer --port 54086 --attrs /var/folders/gw/_ms1v_611gx58lnkdy9yxr100000gq/T/packer-provisioner-inspec.220892737.yml 

Profile: InSpec Profile (my_win10)
Version: 0.1.0
Target:  ssh://stefanscherer@127.0.0.1:54086

  ×  Chocolatey: Chocolatey installed
     ×  File C:/ProgramData/Chocolatey/bin/choco.exe should be file
     expected `File C:/ProgramData/Chocolatey/bin/choco.exe.file?` to return true, got false


Profile Summary: 0 successful controls, 1 control failure, 0 controls skipped
Test Summary: 0 successful, 1 failure, 0 skipped
```

The command would be the command created by the packer Inspec provisioner to talk to a temporary local SSH agent that forwards all commands to the Packer WinRM communicator. For Inspec it is a SSH connection and the Packer provisioner does the rest.
