### PR TITLE
Provide ssh option to enable host key verify

### DIFF
--- a/lib/train/platforms/detect/helpers/os_common.rb
+++ b/lib/train/platforms/detect/helpers/os_common.rb
@@ -14,8 +14,7 @@ module Train::Platforms::Detect::Helpers
     end
 
     def winrm?
-      Object.const_defined?('Train::Transports::WinRM::Connection') &&
-        @backend.class == Train::Transports::WinRM::Connection
+      @backend.class.to_s == 'Train::Transports::WinRM::Connection'
     end
 
     def unix_file_contents(path)

--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -168,7 +168,7 @@ module Train::Transports
       }
       # disable host key verification. The hash key to use
       # depends on the version of net-ssh in use.
-      connection_options[verify_host_key_option] = false
+      connection_options[verify_host_key_option] = opts[:verify_host_key] || false
 
       connection_options
     end

--- a/test/unit/platforms/detect/os_common_test.rb
+++ b/test/unit/platforms/detect/os_common_test.rb
@@ -22,10 +22,20 @@ describe 'os_common' do
       detector.winrm?.must_equal(true)
     end
 
-    it 'return winrm? false' do
+    it 'return winrm? false when winrm is loaded' do
+      require 'train/transports/winrm'
       be = mock('Backend')
       detector.instance_variable_set(:@backend, be)
       detector.winrm?.must_equal(false)
+    end
+
+    it 'return winrm? false when winrm is not loaded' do
+      require 'train/transports/winrm'
+      winrm = Train::Transports.send(:remove_const, 'WinRM')
+      be = mock('Backend')
+      detector.instance_variable_set(:@backend, be)
+      detector.winrm?.must_equal(false)
+      Train::Transports.const_set('WinRM', winrm)
     end
   end
 

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -44,14 +44,23 @@ describe 'ssh transport' do
 
   describe 'connection options' do
     let(:ssh) { cls.new({ host: 'dummy' }) }
-    let(:connection_options) { ssh.send(:connection_options, {}) }
+    let(:opts) { { } }
+    let(:connection_options) { ssh.send(:connection_options, opts) }
 
     it 'does not set a paranoid option - deprecated in net-ssh 4.2' do
       connection_options.key?(:paranoid).must_equal false
     end
 
-    it 'sets a verify_host_key option, replacement for paranoid' do
+    it 'defaults verify_host_key option to false, and does not set paranoid' do
       connection_options[:verify_host_key].must_equal false
+      connection_options.key?(:paranoid).must_equal false
+    end
+
+    describe "when caller sets verify_host_key in options" do
+      let(:opts) { { verify_host_key: true } }
+      it 'the provided value is used instead of the default' do
+        connection_options[:verify_host_key].must_equal true
+      end
     end
   end
 


### PR DESCRIPTION
For compatibility with knife bootstrap, this PR provides
a  verify_host_key config option that allows host key verification
to be enabled for ssh. Default remains disabled for back-compatibility.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>