### PR TITLE
Add data callbacks to WinRM and SSH

### DIFF
--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -63,11 +63,11 @@ module Train::Transports
     option :bastion_user, default: 'root'
     option :bastion_port, default: 22
     option :non_interactive, default: false
-
     option :compression_level do |opts|
       # on nil or false: set compression level to 0
       opts[:compression] ? 6 : 0
     end
+    option :data_callback, default: nil
 
     # (see Base#connection)
     def connection(state = {}, &block)
@@ -164,6 +164,7 @@ module Train::Transports
         bastion_user:           opts[:bastion_user],
         bastion_port:           opts[:bastion_port],
         non_interactive:        opts[:non_interactive],
+        data_callback:          opts[:data_callback],
         transport_options:      opts,
       }
       # disable host key verification. The hash key to use

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -50,6 +50,7 @@ class Train::Transports::SSH
       @bastion_host           = @options.delete(:bastion_host)
       @bastion_user           = @options.delete(:bastion_user)
       @bastion_port           = @options.delete(:bastion_port)
+      @data_callback          = @options.delete(:data_callback)
       @cmd_wrapper            = CommandWrapper.load(self, @transport_options)
     end
 
@@ -228,10 +229,12 @@ class Train::Transports::SSH
           abort 'Couldn\'t execute command on SSH.' unless success
 
           channel.on_data do |_, data|
+            @data_callback.call(data) if @data_callback
             stdout += data
           end
 
           channel.on_extended_data do |_, _type, data|
+            @data_callback.call(data) if @data_callback
             stderr += data
           end
 

--- a/lib/train/transports/winrm.rb
+++ b/lib/train/transports/winrm.rb
@@ -62,6 +62,7 @@ module Train::Transports
     option :connection_retries, default: 5
     option :connection_retry_sleep, default: 1
     option :max_wait_until_ready, default: 600
+    option :data_callback, default: nil
 
     def initialize(opts)
       super(opts)
@@ -124,6 +125,7 @@ module Train::Transports
         connection_retry_sleep:   opts[:connection_retry_sleep],
         max_wait_until_ready:     opts[:max_wait_until_ready],
         no_ssl_peer_verification: opts[:self_signed],
+        data_callback:            opts[:data_callback],
       }
     end
 

--- a/lib/train/transports/winrm_connection.rb
+++ b/lib/train/transports/winrm_connection.rb
@@ -36,6 +36,7 @@ class Train::Transports::WinRM
       @connection_retries     = @options.delete(:connection_retries)
       @connection_retry_sleep = @options.delete(:connection_retry_sleep)
       @max_wait_until_ready   = @options.delete(:max_wait_until_ready)
+      @data_callback          = @options.delete(:data_callback)
     end
 
     # (see Base::Connection#close)
@@ -101,6 +102,7 @@ class Train::Transports::WinRM
       out = ''
 
       response = session.run(command) do |stdout, _|
+        @data_callback.call(stdout) if stdout && @data_callback
         out << stdout if stdout
       end
 


### PR DESCRIPTION
In order to support existing bootstrap functionality for `knife
bootstrap`s conversion to Train, clients need a method to receive
data from the target host as it is being generated.

This callback will be invoked for SSH when data arrives on the channel,
and for WinRM when data is returned on stdout.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>