### PR TITLE
[SUSTAIN-955] Add data callbacks to WinRM and SSH

### DIFF
--- a/lib/train/transports/cisco_ios_connection.rb
+++ b/lib/train/transports/cisco_ios_connection.rb
@@ -56,7 +56,7 @@ class Train::Transports::SSH
       @session
     end
 
-    def run_command_via_connection(cmd)
+    def run_command_via_connection(cmd, &_data_handler)
       # Ensure buffer is empty before sending data
       @buf = ''
 

--- a/lib/train/transports/docker.rb
+++ b/lib/train/transports/docker.rb
@@ -89,7 +89,7 @@ class Train::Transports::Docker
       end
     end
 
-    def run_command_via_connection(cmd)
+    def run_command_via_connection(cmd, &_data_handler)
       cmd = @cmd_wrapper.run(cmd) unless @cmd_wrapper.nil?
       stdout, stderr, exit_status = @container.exec(
         [

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -71,7 +71,7 @@ module Train::Transports
         end
       end
 
-      def run_command_via_connection(cmd)
+      def run_command_via_connection(cmd, &_data_handler)
         # Use the runner if it is available
         return @runner.run_command(cmd) if defined?(@runner)
 

--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -124,7 +124,7 @@ class Train::Transports::Mock
 
     private
 
-    def run_command_via_connection(cmd)
+    def run_command_via_connection(cmd, &_data_handler)
       @cache[:command][Digest::SHA256.hexdigest cmd.to_s] ||
         command_not_found(cmd)
     end

--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -67,7 +67,6 @@ module Train::Transports
       # on nil or false: set compression level to 0
       opts[:compression] ? 6 : 0
     end
-    option :data_callback, default: nil
 
     # (see Base#connection)
     def connection(state = {}, &block)
@@ -164,7 +163,6 @@ module Train::Transports
         bastion_user:           opts[:bastion_user],
         bastion_port:           opts[:bastion_port],
         non_interactive:        opts[:non_interactive],
-        data_callback:          opts[:data_callback],
         transport_options:      opts,
       }
       # disable host key verification. The hash key to use

--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -63,11 +63,11 @@ module Train::Transports
     option :bastion_user, default: 'root'
     option :bastion_port, default: 22
     option :non_interactive, default: false
-
     option :compression_level do |opts|
       # on nil or false: set compression level to 0
       opts[:compression] ? 6 : 0
     end
+    option :data_callback, default: nil
 
     # (see Base#connection)
     def connection(state = {}, &block)
@@ -164,6 +164,7 @@ module Train::Transports
         bastion_user:           opts[:bastion_user],
         bastion_port:           opts[:bastion_port],
         non_interactive:        opts[:non_interactive],
+        data_callback:          opts[:data_callback],
         transport_options:      opts,
       }
       # disable host key verification. The hash key to use

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -50,6 +50,7 @@ class Train::Transports::SSH
       @bastion_host           = @options.delete(:bastion_host)
       @bastion_user           = @options.delete(:bastion_user)
       @bastion_port           = @options.delete(:bastion_port)
+      @data_callback          = @options.delete(:data_callback)
       @cmd_wrapper            = CommandWrapper.load(self, @transport_options)
     end
 
@@ -228,10 +229,12 @@ class Train::Transports::SSH
           abort 'Couldn\'t execute command on SSH.' unless success
 
           channel.on_data do |_, data|
+            @data_callback.call(data) if @data_callback
             stdout += data
           end
 
           channel.on_extended_data do |_, _type, data|
+            @data_callback.call(data) if @data_callback
             stderr += data
           end
 

--- a/lib/train/transports/vmware.rb
+++ b/lib/train/transports/vmware.rb
@@ -73,7 +73,7 @@ module Train::Transports
         force_platform!('vmware', @platform_details)
       end
 
-      def run_command_via_connection(cmd)
+      def run_command_via_connection(cmd, &_data_handler)
         if @powershell_binary == :pwsh
           result = parse_pwsh_output(cmd)
 

--- a/lib/train/transports/winrm.rb
+++ b/lib/train/transports/winrm.rb
@@ -62,7 +62,6 @@ module Train::Transports
     option :connection_retries, default: 5
     option :connection_retry_sleep, default: 1
     option :max_wait_until_ready, default: 600
-    option :data_callback, default: nil
 
     def initialize(opts)
       super(opts)
@@ -125,7 +124,6 @@ module Train::Transports
         connection_retry_sleep:   opts[:connection_retry_sleep],
         max_wait_until_ready:     opts[:max_wait_until_ready],
         no_ssl_peer_verification: opts[:self_signed],
-        data_callback:            opts[:data_callback],
       }
     end
 

--- a/lib/train/transports/winrm.rb
+++ b/lib/train/transports/winrm.rb
@@ -62,6 +62,7 @@ module Train::Transports
     option :connection_retries, default: 5
     option :connection_retry_sleep, default: 1
     option :max_wait_until_ready, default: 600
+    option :data_callback, default: nil
 
     def initialize(opts)
       super(opts)
@@ -124,6 +125,7 @@ module Train::Transports
         connection_retry_sleep:   opts[:connection_retry_sleep],
         max_wait_until_ready:     opts[:max_wait_until_ready],
         no_ssl_peer_verification: opts[:self_signed],
+        data_callback:            opts[:data_callback],
       }
     end
 

--- a/lib/train/transports/winrm_connection.rb
+++ b/lib/train/transports/winrm_connection.rb
@@ -36,6 +36,7 @@ class Train::Transports::WinRM
       @connection_retries     = @options.delete(:connection_retries)
       @connection_retry_sleep = @options.delete(:connection_retry_sleep)
       @max_wait_until_ready   = @options.delete(:max_wait_until_ready)
+      @data_callback          = @options.delete(:data_callback)
     end
 
     # (see Base::Connection#close)
@@ -101,6 +102,7 @@ class Train::Transports::WinRM
       out = ''
 
       response = session.run(command) do |stdout, _|
+        @data_callback.call(stdout) if stdout && @data_callback
         out << stdout if stdout
       end
 

--- a/lib/train/transports/winrm_connection.rb
+++ b/lib/train/transports/winrm_connection.rb
@@ -36,7 +36,6 @@ class Train::Transports::WinRM
       @connection_retries     = @options.delete(:connection_retries)
       @connection_retry_sleep = @options.delete(:connection_retry_sleep)
       @max_wait_until_ready   = @options.delete(:max_wait_until_ready)
-      @data_callback          = @options.delete(:data_callback)
     end
 
     # (see Base::Connection#close)
@@ -96,13 +95,13 @@ class Train::Transports::WinRM
       Train::File::Remote::Windows.new(self, path)
     end
 
-    def run_command_via_connection(command)
+    def run_command_via_connection(command, &data_handler)
       return if command.nil?
       logger.debug("[WinRM] #{self} (#{command})")
       out = ''
 
       response = session.run(command) do |stdout, _|
-        @data_callback.call(stdout) if stdout && @data_callback
+        yield(stdout) if data_handler && stdout
         out << stdout if stdout
       end
 

--- a/test/unit/transports/ssh_connection_test.rb
+++ b/test/unit/transports/ssh_connection_test.rb
@@ -1,0 +1,74 @@
+require 'train/transports/ssh'
+require 'train/transports/ssh_connection'
+
+# Mocha limitations don't let us mock a function
+# such that it can receive a block, so here's a minimal
+# class that simulates Net::SSH::Connection::Channel to the
+# extent required by Transports::SSH::Connection
+class MockChannel
+  def exec(cmd)
+    @cmd = cmd
+    yield("ignored", true)
+  end
+  def data_handler
+    @handler
+  end
+
+  def on_data(&block)
+    @handler = block
+  end
+
+  def mock_inbound_data(data)
+    # trigger the 'on-data' event off of the channel.
+    @handler.call("ignored", data)
+  end
+
+  def on_extended_data; end
+  def on_request(any); end
+end
+
+
+describe 'ssh connection' do
+  let(:cls) do
+    plat = Train::Platforms.name('mock').in_family('linux')
+    plat.add_platform_methods
+    Train::Platforms::Detect.stubs(:scan).returns(plat)
+    Train::Transports::SSH::Connection
+  end
+  let(:conf) {{
+    host: rand.to_s,
+    password: rand.to_s,
+    transport_options: {}
+  }}
+
+  describe '#run_command_via_connection through BaseConnection::run_command' do
+    let(:ssh) { cls.new(conf) }
+    # A bit more mocking than I'd like to see, but there's no sane way around
+    # it if we want to test output handling behavior.
+    let(:inbound_data) { "testdata" }
+    let(:channel_mock) { MockChannel.new }
+
+    let(:session_mock) {
+      session_mock = mock
+      session_mock.stubs(:closed?).returns false
+      session_mock.stubs(:open_channel).yields(channel_mock)
+      # Simulate the way that Net::SSH::Session processes request(s) on invoking #loop.
+      session_mock.stubs(:loop).with do
+        channel_mock.mock_inbound_data(inbound_data)
+      end
+      session_mock
+    }
+
+    it "invokes the provided block when a block is provided and data is received" do
+      ssh.stubs(:session).returns(session_mock)
+      called = false
+      # run_command b/c run_command_via_connection is private.
+      ssh.run_command("test") do |data|
+        called = true
+        data.must_equal inbound_data
+      end
+      called.must_equal true
+
+    end
+  end
+end

--- a/test/unit/transports/winrm_connection_test.rb
+++ b/test/unit/transports/winrm_connection_test.rb
@@ -1,0 +1,42 @@
+
+require 'helper'
+require 'train/transports/winrm'
+require 'train/transports/winrm_connection'
+require 'winrm/output'
+
+describe 'winrm connection' do
+  let(:cls) do
+    plat = Train::Platforms.name('mock').in_family('windows')
+    plat.add_platform_methods
+    Train::Platforms::Detect.stubs(:scan).returns(plat)
+    Train::Transports::WinRM::Connection
+  end
+  let(:conf) {{
+    hostname: rand.to_s,
+  }}
+  describe '#run_command_via_connection through BaseConnection::run_command' do
+    let(:winrm) { cls.new(conf) }
+    let(:session_mock) {
+      session_mock = mock
+      session_mock.expects(:run).
+        with("test").
+        yields('testdata', 'ignored').
+        returns(WinRM::Output.new)
+
+      session_mock
+    }
+    it "invokes the provided block when a block is provided and data is received" do
+      called = false
+      winrm.expects(:session).returns(session_mock)
+
+      # We need to test run_command b/c run_command_via_connection is proviate.
+      winrm.run_command("test") do |data|
+        called = true
+        data.must_equal 'testdata'
+      end
+      called.must_equal true
+    end
+  end
+
+end
+


### PR DESCRIPTION
In order to support existing bootstrap functionality for `knife
bootstrap`s conversion to Train, clients need a method to receive
data from the target host as it is being generated.

This callback will be invoked for SSH when data arrives on the channel,
and for WinRM when data is returned on stdout.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>