### PR TITLE
[SUSTAIN-955] Add kerberos and additional winrm options

### DIFF
--- a/test/unit/transports/winrm_test.rb
+++ b/test/unit/transports/winrm_test.rb
@@ -82,7 +82,7 @@ describe 'winrm transport' do
   describe 'options validation' do
     let(:winrm) { cls.new(conf) }
     it 'raises an error when a non-supported winrm_transport is specificed' do
-      conf[:winrm_transport] = 'kerberos'
+      conf[:winrm_transport] = 'invalid'
       proc { winrm.connection }.must_raise Train::ClientError
     end
   end


### PR DESCRIPTION
For compatibility with knife bootstrap's conversion to train,
this PR adds kerberos as a supported protocol, and includes the
additional kerberos options kerberos_realm, kerberos_service

This also adds 'ssl_peer_fingerprint' and  'ca_trust_file' support.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>