### PR TITLE
[SUSTAIN-955] Provide ssh option to enable host key verify

### DIFF
--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -63,6 +63,7 @@ module Train::Transports
     option :bastion_user, default: 'root'
     option :bastion_port, default: 22
     option :non_interactive, default: false
+    option :verify_host_key, default: false
 
     option :compression_level do |opts|
       # on nil or false: set compression level to 0
@@ -168,7 +169,7 @@ module Train::Transports
       }
       # disable host key verification. The hash key to use
       # depends on the version of net-ssh in use.
-      connection_options[verify_host_key_option] = false
+      connection_options[verify_host_key_option] = opts[:verify_host_key] || false
 
       connection_options
     end

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -44,14 +44,23 @@ describe 'ssh transport' do
 
   describe 'connection options' do
     let(:ssh) { cls.new({ host: 'dummy' }) }
-    let(:connection_options) { ssh.send(:connection_options, {}) }
+    let(:opts) { { } }
+    let(:connection_options) { ssh.send(:connection_options, opts) }
 
     it 'does not set a paranoid option - deprecated in net-ssh 4.2' do
       connection_options.key?(:paranoid).must_equal false
     end
 
-    it 'sets a verify_host_key option, replacement for paranoid' do
+    it 'defaults verify_host_key option to false, and does not set paranoid' do
       connection_options[:verify_host_key].must_equal false
+      connection_options.key?(:paranoid).must_equal false
+    end
+
+    describe "when caller sets verify_host_key in options" do
+      let(:opts) { { verify_host_key: true } }
+      it 'the provided value is used instead of the default' do
+        connection_options[:verify_host_key].must_equal true
+      end
     end
   end
 


### PR DESCRIPTION
For compatibility with knife bootstrap, this PR provides
a  verify_host_key config option that allows host key verification
to be enabled for ssh. Default remains disabled for back-compatibility.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>