### PR TITLE
Silence verify_host_key warning from net-ssh

### DIFF
--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -199,7 +199,6 @@ module Train::Transports
     def verify_host_key_value(given)
       current_net_ssh = Net::SSH::Version::CURRENT
       new_value_version = Net::SSH::Version[5, 0, 0]
-
       if current_net_ssh >= new_value_version
         # 5.0+ style
         {
@@ -217,6 +216,7 @@ module Train::Transports
         {
           'true' => true,
           'false' => false,
+          nil => false,
         }.fetch(given, given)
       end
     end

--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -210,6 +210,7 @@ module Train::Transports
           # May be correct value, but strings from JSON config
           'always' => :always,
           'never' => :never,
+          nil => :never,
         }.fetch(given, given)
       else
         # up to 4.2 style

--- a/test/unit/helper.rb
+++ b/test/unit/helper.rb
@@ -2,6 +2,7 @@
 
 require 'minitest/autorun'
 require 'minitest/spec'
+require 'mocha/minitest'
 require 'mocha/setup'
 require 'byebug'
 


### PR DESCRIPTION
The SSH transport always wants to disable host key verification. In net-ssh 5+, the acceptable values for verify_host_key changed ;we currently set it to `false`, which now results in a deprecation warning from `net-ssh`
```
verify_host_key: false is deprecated, use :never
```

We already choose what option name to use based on the net-ssh version; this PR now chooses the value dynamically, as well.

As I found when passing values from a config file, there is a good chance the values will come in as Strings, so the PR does some questionable remapping of things to try to catch the common cases.

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>