### PR TITLE
 Require ed25519 and bcrypt_pbkdf gems for ed25519 support 

### DIFF
--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -30,10 +30,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'json', '>= 1.8', '< 3.0'
+  spec.add_dependency 'mixlib-shellout', '>= 2.0', '< 4.0'
   spec.add_dependency 'net-ssh', '>= 2.9', '< 6.0'
   spec.add_dependency 'net-scp', '>= 1.2', '< 3.0'
+  spec.add_dependency "ed25519", "~> 1.2" # ed25519 ssh key support
+  spec.add_dependency "bcrypt_pbkdf", "~> 1.0" # ed25519 ssh key support
   spec.add_dependency 'winrm', '~> 2.0'
   spec.add_dependency 'winrm-fs', '~> 1.0'
-  spec.add_dependency 'mixlib-shellout', '>= 2.0', '< 4.0'
-  spec.add_dependency 'json', '>= 1.8', '< 3.0'
 end

--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -34,8 +34,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mixlib-shellout', '>= 2.0', '< 4.0'
   spec.add_dependency 'net-ssh', '>= 2.9', '< 6.0'
   spec.add_dependency 'net-scp', '>= 1.2', '< 3.0'
-  spec.add_dependency "ed25519", "~> 1.2" # ed25519 ssh key support
-  spec.add_dependency "bcrypt_pbkdf", "~> 1.0" # ed25519 ssh key support
+  spec.add_dependency 'ed25519', '~> 1.2' # ed25519 ssh key support
+  spec.add_dependency 'bcrypt_pbkdf', '~> 1.0' # ed25519 ssh key support
   spec.add_dependency 'winrm', '~> 2.0'
   spec.add_dependency 'winrm-fs', '~> 1.0'
 end

--- a/train.gemspec
+++ b/train.gemspec
@@ -22,10 +22,11 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
-  # chef-client < 12.4.1 require mixlib-shellout-2.0.1
   spec.add_dependency 'mixlib-shellout', '>= 2.0', '< 4.0'
   spec.add_dependency 'net-ssh', '>= 2.9', '< 6.0'
   spec.add_dependency 'net-scp', '>= 1.2', '< 3.0'
+  spec.add_dependency "ed25519", "~> 1.2" # ed25519 ssh key support
+  spec.add_dependency "bcrypt_pbkdf", "~> 1.0" # ed25519 ssh key support
   spec.add_dependency 'winrm', '~> 2.0'
   spec.add_dependency 'winrm-fs', '~> 1.0'
   spec.add_dependency 'docker-api', '~> 1.26'

--- a/train.gemspec
+++ b/train.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mixlib-shellout', '>= 2.0', '< 4.0'
   spec.add_dependency 'net-ssh', '>= 2.9', '< 6.0'
   spec.add_dependency 'net-scp', '>= 1.2', '< 3.0'
-  spec.add_dependency "ed25519", "~> 1.2" # ed25519 ssh key support
-  spec.add_dependency "bcrypt_pbkdf", "~> 1.0" # ed25519 ssh key support
+  spec.add_dependency 'ed25519', '~> 1.2' # ed25519 ssh key support
+  spec.add_dependency 'bcrypt_pbkdf', '~> 1.0' # ed25519 ssh key support
   spec.add_dependency 'winrm', '~> 2.0'
   spec.add_dependency 'winrm-fs', '~> 1.0'
   spec.add_dependency 'docker-api', '~> 1.26'


### PR DESCRIPTION
Modern distros are switching to ed25519 ssh keys and we need to make
sure train supports this out of the box.

I also shuffled the deps around so we can easily diff the train and train-core gemspecs.

Signed-off-by: Tim Smith <tsmith@chef.io>