### PR TITLE
Add missed cisco_ios_connection to train-core.

### DIFF
--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -8,6 +8,7 @@ CORE_TRANSPORTS = [
   'lib/train/transports/mock.rb',
   'lib/train/transports/ssh.rb',
   'lib/train/transports/ssh_connection.rb',
+  'lib/train/transports/cisco_ios_connection.rb',
   'lib/train/transports/winrm.rb',
   'lib/train/transports/winrm_connection.rb',
 ].freeze


### PR DESCRIPTION
This is required in transports/ssh.rb, so
needs to be included in the gem.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>