### PR TITLE
Remove dependency on ed25519 gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ group :integration do
   gem 'berkshelf', '>= 6.3.4'
   gem 'test-kitchen', '>= 1.2.4'
   gem 'kitchen-vagrant'
+  gem 'ed25519' # ed25519 ssh key support
+  gem 'bcrypt_pbkdf' # ed25519 ssh key support
 end
 
 group :tools do

--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -34,8 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mixlib-shellout', '>= 2.0', '< 4.0'
   spec.add_dependency 'net-ssh', '>= 2.9', '< 6.0'
   spec.add_dependency 'net-scp', '>= 1.2', '< 3.0'
-  spec.add_dependency 'ed25519', '~> 1.2' # ed25519 ssh key support
-  spec.add_dependency 'bcrypt_pbkdf', '~> 1.0' # ed25519 ssh key support
   spec.add_dependency 'winrm', '~> 2.0'
   spec.add_dependency 'winrm-fs', '~> 1.0'
 end

--- a/train.gemspec
+++ b/train.gemspec
@@ -25,8 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mixlib-shellout', '>= 2.0', '< 4.0'
   spec.add_dependency 'net-ssh', '>= 2.9', '< 6.0'
   spec.add_dependency 'net-scp', '>= 1.2', '< 3.0'
-  spec.add_dependency 'ed25519', '~> 1.2' # ed25519 ssh key support
-  spec.add_dependency 'bcrypt_pbkdf', '~> 1.0' # ed25519 ssh key support
   spec.add_dependency 'winrm', '~> 2.0'
   spec.add_dependency 'winrm-fs', '~> 1.0'
   spec.add_dependency 'docker-api', '~> 1.26'


### PR DESCRIPTION
Having this here in train means that inspec requires it. That means that
an installation of InSpec into an existing Chef install requires
compilation tools on the node, which is not an option for many of our
users. We need to instead require this in chef-core and in the inspec
omnibus setup..

Signed-off-by: Tim Smith <tsmith@chef.io>