### PR TITLE
Rename ca_trust_file to ca_trust_path

### DIFF
--- a/lib/train/transports/winrm.rb
+++ b/lib/train/transports/winrm.rb
@@ -63,7 +63,7 @@ module Train::Transports
     option :ssl_peer_fingerprint, default: nil
     option :kerberos_realm, default: nil
     option :kerberos_service, default: nil
-    option :ca_trust_file, default: nil
+    option :ca_trust_path, default: nil
     # The amount of time in SECONDS for which each operation must get an ack
     # from the winrm endpoint. Does not mean that the command has
     # completed in this time, only that the server has ack'd the request.
@@ -132,7 +132,7 @@ module Train::Transports
         no_ssl_peer_verification: opts[:self_signed],
         realm:                    opts[:kerberos_realm],
         service:                  opts[:kerberos_service],
-        ca_trust_file:            opts[:ca_trust_file],
+        ca_trust_path:            opts[:ca_trust_path],
         ssl_peer_fingerprint:     opts[:ssl_peer_fingerprint],
       }
     end

--- a/test/unit/transports/winrm_test.rb
+++ b/test/unit/transports/winrm_test.rb
@@ -62,10 +62,15 @@ describe 'winrm transport' do
     it 'has default user' do
       winrm.options[:user].must_equal 'administrator'
     end
+    it 'has default ca_trust_path set' do
+      winrm.options.key?(:ca_trust_path).must_equal true
+      winrm.options[:ca_trust_path].must_equal nil
+    end
   end
 
   describe 'winrm options' do
     let(:winrm) { cls.new(conf) }
+
     let(:connection) { winrm.connection }
     it 'without ssl genrates uri' do
       conf[:host] = 'dummy_host'
@@ -76,6 +81,34 @@ describe 'winrm transport' do
       conf[:ssl] = true
       conf[:host] = 'dummy_host_ssl'
       connection.uri.must_equal 'winrm://administrator@https://dummy_host_ssl:5986/wsman:3389'
+    end
+
+  end
+
+  describe 'when configuring the connection' do
+    let(:winrm) {
+      puts "Insantiating cls.new with #{conf}"
+      cls.new(conf)
+    }
+
+    let(:conf) {{
+      winrm_transport: :negotiate,
+      host: rand.to_s,
+      password: rand.to_s,
+    }}
+
+    def connection_option_value(name)
+      winrm.send(:connection_options, conf)[name]
+    end
+
+    it "transport is configured as the correct symbol from provided value" do
+      conf[:winrm_transport] = "testing"
+      connection_option_value(:transport).must_equal conf[:winrm_transport].to_sym
+    end
+
+    it "ca_trust_path is configured from provided value" do
+      conf[:ca_trust_path] = 'C:\some\path.pem'
+      connection_option_value(:ca_trust_path).must_equal conf[:ca_trust_path]
     end
   end
 


### PR DESCRIPTION
WinRM expects `ca_trust_path` not `ca_trust_file`

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>