### PR TITLE
add def forward_remote to Transports::SSH

### DIFF
--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -148,7 +148,7 @@ class Train::Transports::SSH
     end
 
     # remote_port_forwarding
-    def forward_remote(port, host, remote_port, remote_host="127.0.0.1")
+    def forward_remote(port, host, remote_port, remote_host = '127.0.0.1')
       @session.forward.remote(port, host, remote_port, remote_host)
     end
 

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -147,6 +147,11 @@ class Train::Transports::SSH
       "ssh://#{@username}@#{@hostname}:#{@port}"
     end
 
+    # remote_port_forwarding
+    def forward_remote(port, host, remote_port, remote_host="127.0.0.1")
+      @session.forward.remote(port, host, remote_port, remote_host)
+    end
+
     private
 
     PING_COMMAND = "echo '[SSH] Established'".freeze


### PR DESCRIPTION
Signed-off-by: sawanoboly <sawanoboriyu@higanworks.com>

Enable SSH remote port forwarding on the connection.

## Description

for example

```
require 'train'

train = Train.create('ssh',
  host: '127.0.0.1', port: 2222, user: 'vagrant', key_files: '/path/to/private_key')


conn = train.connection
conn.forward_remote(8080, '127.0.0.1', 8080)
puts conn.run_command('netstat -tnl').stdout

#=>
Proto Recv-Q Send-Q Local Address           Foreign Address         State      
tcp        0      0 0.0.0.0:111             0.0.0.0:*               LISTEN     
tcp        0      0 0.0.0.0:58962           0.0.0.0:*               LISTEN     
tcp        0      0 0.0.0.0:22              0.0.0.0:*               LISTEN     
tcp        0      0 127.0.0.1:8080          0.0.0.0:*               LISTEN     
tcp6       0      0 :::111                  :::*                    LISTEN     
tcp6       0      0 :::22                   :::*                    LISTEN     
tcp6       0      0 ::1:8080                :::*                    LISTEN     
tcp6       0      0 :::50041                :::*                    LISTEN     
```


## Related Issue

nothing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.