### PR TITLE
Fix to raise specific error when ssh user is not provided and root is used as default user.

### DIFF
--- a/lib/train/extras/command_wrapper.rb
+++ b/lib/train/extras/command_wrapper.rb
@@ -162,16 +162,16 @@ module Train::Extras
     include_options WindowsCommand
 
     def self.load(transport, options)
-      if transport.os.unix?
+      if transport.platform.unix?
         return nil unless LinuxCommand.active?(options)
         res = LinuxCommand.new(transport, options)
         verification_res = res.verify
         if verification_res
           msg, reason = verification_res
-          raise Train::UserError.new("Sudo failed: #{msg}", reason)
+          raise Train::UserError, "Sudo failed: #{msg}", reason
         end
         res
-      elsif transport.os.windows?
+      elsif transport.platform.windows?
         res = WindowsCommand.new(transport, options)
         res
       end

--- a/lib/train/platforms/detect/helpers/os_common.rb
+++ b/lib/train/platforms/detect/helpers/os_common.rb
@@ -31,6 +31,12 @@ module Train::Platforms::Detect::Helpers
 
     def command_output(cmd)
       res = @backend.run_command(cmd).stdout
+      # When you try to execute command using ssh connction as root user and you have provided ssh user identity file
+      # it gives standard output to login as authorised user other than root. To show this standard ouput as an error
+      # to user we are matching the string of stdout and raising the error here so that user gets exact information.
+      if @backend.class.to_s == "Train::Transports::SSH::Connection" && res =~ /Please login as the user/
+        raise Train::UserError, "SSH failed: #{res}"
+      end
       res.strip! unless res.nil?
       res
     end


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
When ssh user is not provided while doing Train connection it throws following error 

```
Train::PlatformDetectionFailed (Sorry, we are unable to detect your platform)
```
This issue we come across when we trying to bootstrap the node using ssh connection in Chef as mentioned here https://github.com/chef/chef/issues/8550 

And while debugging realized that the fix should go in the Train 

Following are the way to reproduce the issue using train.
```
t = Train.create('ssh', host: "host-name", port: 22, user: "root", key_files: "/home/msys/.ssh/id_rsa", verify_host_key: :accept_new, sudo: true)
conn = t.connection
```
Below is the trackback of the error
```
Traceback (most recent call last):
       12: from /opt/chef/embedded/bin/irb:23:in `<main>'
       11: from /opt/chef/embedded/bin/irb:23:in `load'
       10: from /opt/chef/embedded/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        9: from (irb):2
        8: from /home/msys/workspace/train/lib/train/transports/ssh.rb:82:in `connection'
        7: from /home/msys/workspace/train/lib/train/transports/ssh.rb:238:in `create_new_connection'
        6: from /home/msys/workspace/train/lib/train/transports/ssh.rb:238:in `new'
        5: from /home/msys/workspace/train/lib/train/transports/ssh_connection.rb:53:in `initialize'
        4: from /home/msys/workspace/train/lib/train/extras/command_wrapper.rb:169:in `load'
        3: from /home/msys/workspace/train/lib/train/plugins/base_connection.rb:110:in `platform'
        2: from /home/msys/workspace/train/lib/train/platforms/detect.rb:9:in `scan'
        1: from /home/msys/workspace/train/lib/train/platforms/detect/scanner.rb:41:in `scan'
Train::PlatformDetectionFailed (Sorry, we are unable to detect your platform)
```

After giving the fix the output of the same on console:

```
Traceback (most recent call last):
        Traceback (most recent call last):
       16: from /home/msys/workspace/train/lib/train/transports/ssh.rb:238:in `create_new_connection'
       15: from /home/msys/workspace/train/lib/train/transports/ssh.rb:238:in `new'
       14: from /home/msys/workspace/train/lib/train/transports/ssh_connection.rb:53:in `initialize'
       13: from /home/msys/workspace/train/lib/train/extras/command_wrapper.rb:165:in `load'
       12: from /home/msys/workspace/train/lib/train/plugins/base_connection.rb:110:in `platform'
       11: from /home/msys/workspace/train/lib/train/platforms/detect.rb:9:in `scan'
       10: from /home/msys/workspace/train/lib/train/platforms/detect/scanner.rb:27:in `scan'
        9: from /home/msys/workspace/train/lib/train/platforms/detect/scanner.rb:27:in `each'
        8: from /home/msys/workspace/train/lib/train/platforms/detect/scanner.rb:33:in `block in scan'
        7: from /home/msys/workspace/train/lib/train/platforms/detect/scanner.rb:45:in `scan_children'
        6: from /home/msys/workspace/train/lib/train/platforms/detect/scanner.rb:45:in `each'
        5: from /home/msys/workspace/train/lib/train/platforms/detect/scanner.rb:46:in `block in scan_children'
        4: from /home/msys/workspace/train/lib/train/platforms/detect/scanner.rb:46:in `instance_eval'
        3: from /home/msys/workspace/train/lib/train/platforms/detect/specifications/os.rb:46:in `block in load'
        2: from /home/msys/workspace/train/lib/train/platforms/detect/helpers/os_common.rb:46:in `unix_uname_s'
        1: from /home/msys/workspace/train/lib/train/platforms/detect/helpers/os_common.rb:38:in `command_output'
Train::UserError (SSH failed: Please login as the user "azure" rather than the user "root".)

```
And this is the output of fix when using with knife bootstrap
```
bundle exec knife bootstrap <host-name> -N vj-test-ssh -c ~/workspace/chef-repo/.chef/knife.rb --ssh-identity-file ~/.ssh/id_rsa --sudo --yes
Connecting to 104.211.52.56
WARN: [SSH] PTY requested: stderr will be merged into stdout
WARN: [SSH] PTY requested: stderr will be merged into stdout
ERROR: Train::UserError: SSH failed: Please login as the user "azure" rather than the user "root".
```
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
chef/chef#8550
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
