### PR TITLE
[Do not merge] Fixes the undefined method empty? for nil class error at the time of Windows ssh connection.

### DIFF
--- a/lib/train/platforms/detect/helpers/os_windows.rb
+++ b/lib/train/platforms/detect/helpers/os_windows.rb
@@ -2,7 +2,7 @@ module Train::Platforms::Detect::Helpers
   module Windows
     def detect_windows
       # try to detect windows, use cmd.exe to also support Microsoft OpenSSH
-      res = @backend.run_command("cmd.exe /c ver")
+      res = @backend.run_command("cmd.exe /c ver", pty: false)
       return false if (res.exit_status != 0) || res.stdout.empty?
 
       # if the ver contains `Windows`, we know its a Windows system
@@ -30,7 +30,7 @@ module Train::Platforms::Detect::Helpers
     # @see https://msdn.microsoft.com/en-us/library/bb742610.aspx#EEAA
     # Thanks to Matt Wrock (https://github.com/mwrock) for this hint
     def read_wmic
-      res = @backend.run_command("wmic os get * /format:list")
+      res = @backend.run_command("wmic os get * /format:list", pty: false)
       if res.exit_status == 0
         sys_info = {}
         res.stdout.lines.each do |line|
@@ -42,7 +42,7 @@ module Train::Platforms::Detect::Helpers
         # additional info on windows
         @platform[:build] = sys_info[:BuildNumber]
         @platform[:name] = sys_info[:Caption]
-        @platform[:name] = @platform[:name].gsub("Microsoft", "").strip unless @platform[:name].empty?
+        @platform[:name] = @platform[:name].gsub("Microsoft", "").strip unless @platform[:name].nil?
         @platform[:arch] = read_wmic_cpu
       end
     end
@@ -50,7 +50,7 @@ module Train::Platforms::Detect::Helpers
     # `OSArchitecture` from `read_wmic` does not match a normal standard
     # For example, `x86_64` shows as `64-bit`
     def read_wmic_cpu
-      res = @backend.run_command("wmic cpu get architecture /format:list")
+      res = @backend.run_command("wmic cpu get architecture /format:list", pty: false)
       if res.exit_status == 0
         sys_info = {}
         res.stdout.lines.each do |line|

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -126,6 +126,7 @@ class Train::Plugins::Transport
     # callers to receive and render updates from remote command execution.
     def run_command(cmd, **opts, &data_handler)
       return run_command_via_connection(cmd, opts, &data_handler) unless cache_enabled?(:command)
+
       @cache[:command][cmd] ||= run_command_via_connection(cmd, opts, &data_handler)
     end
 

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -124,10 +124,9 @@ class Train::Plugins::Transport
     # This command accepts an optional data handler block. When provided,
     # inbound data will be published vi `data_handler.call(data)`. This can allow
     # callers to receive and render updates from remote command execution.
-    def run_command(cmd, &data_handler)
-      return run_command_via_connection(cmd, &data_handler) unless cache_enabled?(:command)
-
-      @cache[:command][cmd] ||= run_command_via_connection(cmd, &data_handler)
+    def run_command(cmd, **opts, &data_handler)
+      return run_command_via_connection(cmd, opts, &data_handler) unless cache_enabled?(:command)
+      @cache[:command][cmd] ||= run_command_via_connection(cmd, opts, &data_handler)
     end
 
     # This is the main file call for all connections. This will call the private
@@ -166,7 +165,7 @@ class Train::Plugins::Transport
     # if they do not, the block is ignored and will not be used to report data back to the caller.
     #
     # @return [CommandResult] contains the result of running the command
-    def run_command_via_connection(_command, &_data_handler)
+    def run_command_via_connection(_command, **_opts, &_data_handler)
       raise NotImplementedError, "#{self.class} does not implement #run_command_via_connection()"
     end
 

--- a/lib/train/transports/cisco_ios_connection.rb
+++ b/lib/train/transports/cisco_ios_connection.rb
@@ -57,7 +57,7 @@ class Train::Transports::SSH
       @session
     end
 
-    def run_command_via_connection(cmd, &_data_handler)
+    def run_command_via_connection(cmd, **_opts, &_data_handler)
       # Ensure buffer is empty before sending data
       @buf = ""
 

--- a/lib/train/transports/docker.rb
+++ b/lib/train/transports/docker.rb
@@ -83,7 +83,7 @@ class Train::Transports::Docker
       end
     end
 
-    def run_command_via_connection(cmd, &_data_handler)
+    def run_command_via_connection(cmd, **_opts, &_data_handler)
       cmd = @cmd_wrapper.run(cmd) unless @cmd_wrapper.nil?
       stdout, stderr, exit_status = @container.exec(
         [

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -71,7 +71,7 @@ module Train::Transports
         end
       end
 
-      def run_command_via_connection(cmd, &_data_handler)
+      def run_command_via_connection(cmd, **_opts, &_data_handler)
         # Use the runner if it is available
         return @runner.run_command(cmd) if defined?(@runner)
 

--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -124,7 +124,7 @@ class Train::Transports::Mock
 
     private
 
-    def run_command_via_connection(cmd, &_data_handler)
+    def run_command_via_connection(cmd, **_opts, &_data_handler)
       @cache[:command][Digest::SHA256.hexdigest cmd.to_s] ||
         command_not_found(cmd)
     end

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -282,8 +282,10 @@ class Train::Transports::SSH
         # wrap commands if that is configured
         cmd = @cmd_wrapper.run(cmd) unless @cmd_wrapper.nil?
 
-        # In case of Windows SSH we are checking opts[:pty] flag
-        if opts[:pty].nil? ? opts[:pty] : @transport_options[:pty]
+        # Windows SSH need pty to be set to false so we are overiding deault pty value which is set to true by default.
+        pty = !opts[:pty].nil? ? opts[:pty] : @transport_options[:pty]
+
+        if pty
           channel.request_pty do |_ch, success|
             raise Train::Transports::SSHPTYFailed, "Requesting PTY failed" unless success
           end

--- a/lib/train/transports/vmware.rb
+++ b/lib/train/transports/vmware.rb
@@ -73,7 +73,7 @@ module Train::Transports
         force_platform!("vmware", @platform_details)
       end
 
-      def run_command_via_connection(cmd, &_data_handler)
+      def run_command_via_connection(cmd, **_opts, &_data_handler)
         if @powershell_binary == :pwsh
           result = parse_pwsh_output(cmd)
 

--- a/lib/train/transports/winrm_connection.rb
+++ b/lib/train/transports/winrm_connection.rb
@@ -97,7 +97,7 @@ class Train::Transports::WinRM
       Train::File::Remote::Windows.new(self, path)
     end
 
-    def run_command_via_connection(command, &data_handler)
+    def run_command_via_connection(command, **_opts, &data_handler)
       return if command.nil?
 
       logger.debug("[WinRM] #{self} (#{command})")


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Windows ssh with `pty: true` results in Error `undefined method empty? for nil class` 
Overriding `pty` value and set it to false before `request_pty` call on ssh channel resolves the issue.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#473
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
