### PR TITLE
Use /etc/os-release for SUSE detection

### DIFF
--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -236,22 +236,18 @@ module Train::Platforms::Detect::Specifications
       # suse family
       plat.family("suse").in_family("linux")
           .detect do
-            if !(suse = unix_file_contents("/etc/SuSE-release")).nil?
-              # https://rubular.com/r/UKaYWolCYFMfp1
-              version = suse.scan(/VERSION = (\d+)\nPATCHLEVEL = (\d+)/).flatten.join(".")
-              # https://rubular.com/r/b5PN3hZDxa5amV
-              version = suse[/VERSION\s?=\s?"?([\d\.]{2,})"?/, 1] if version == ""
-              @platform[:release] = version
+            if linux_os_release && linux_os_release["ID_LIKE"] =~ /suse/i
+              @platform[:release] = linux_os_release["VERSION"]
               true
             end
           end
       plat.name("opensuse").title("OpenSUSE Linux").in_family("suse")
           .detect do
-            true if unix_file_contents("/etc/SuSE-release") =~ /^opensuse/i
+            true if linux_os_release && linux_os_release["NAME"] =~ /^opensuse/i
           end
       plat.name("suse").title("Suse Linux").in_family("suse")
           .detect do
-            true if unix_file_contents("/etc/SuSE-release") =~ /suse/i
+            true if linux_os_release && linux_os_release["NAME"] =~ /^sles/i
           end
 
       # arch

--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -239,15 +239,24 @@ module Train::Platforms::Detect::Specifications
             if linux_os_release && linux_os_release["ID_LIKE"] =~ /suse/i
               @platform[:release] = linux_os_release["VERSION"]
               true
+            elsif !(suse = unix_file_contents("/etc/SuSE-release")).nil?
+              # https://rubular.com/r/UKaYWolCYFMfp1
+              version = suse.scan(/VERSION = (\d+)\nPATCHLEVEL = (\d+)/).flatten.join(".")
+              # https://rubular.com/r/b5PN3hZDxa5amV
+              version = suse[/VERSION\s?=\s?"?([\d\.]{2,})"?/, 1] if version == ""
+              @platform[:release] = version
+              true
             end
           end
       plat.name("opensuse").title("OpenSUSE Linux").in_family("suse")
           .detect do
-            true if linux_os_release && linux_os_release["NAME"] =~ /^opensuse/i
+            true if (linux_os_release && linux_os_release["NAME"] =~ /^opensuse/i) ||
+               unix_file_contents("/etc/SuSE-release") =~ /^opensuse/i
           end
       plat.name("suse").title("Suse Linux").in_family("suse")
           .detect do
-            true if linux_os_release && linux_os_release["NAME"] =~ /^sles/i
+            true if (linux_os_release && linux_os_release["NAME"] =~ /^sles/i) ||
+              unix_file_contents("/etc/SuSE-release") =~ /suse/i
           end
 
       # arch

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -217,6 +217,30 @@ describe "os_detect" do
         platform[:release].must_equal("cisco123")
       end
     end
+
+    describe "when on a suse build" do
+      it "sets the correct family/release for SLES" do
+        files = {
+          "/etc/os-release" => "NAME=\"SLES\"\nVERSION=\"15.1\"\nID=\"sles\"\nID_LIKE=\"suse\"\n",
+        }
+        platform = scan_with_files("linux", files)
+
+        platform[:name].must_equal("suse")
+        platform[:family].must_equal("suse")
+        platform[:release].must_equal("15.1")
+      end
+
+      it "sets the correct family/release for openSUSE" do
+        files = {
+          "/etc/os-release" => "NAME=\"openSUSE Leap\"\nVERSION=\"15.1\"\nID=\"opensuse-leap\"\nID_LIKE=\"suse opensuse\"\n",
+        }
+        platform = scan_with_files("linux", files)
+
+        platform[:name].must_equal("opensuse")
+        platform[:family].must_equal("suse")
+        platform[:release].must_equal("15.1")
+      end
+    end
   end
 
   describe "qnx" do

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -219,26 +219,51 @@ describe "os_detect" do
     end
 
     describe "when on a suse build" do
-      it "sets the correct family/release for SLES" do
-        files = {
-          "/etc/os-release" => "NAME=\"SLES\"\nVERSION=\"15.1\"\nID=\"sles\"\nID_LIKE=\"suse\"\n",
-        }
-        platform = scan_with_files("linux", files)
+      describe "when /etc/os-release is present" do
+        it "sets the correct family/release for SLES" do
+          files = {
+            "/etc/os-release" => "NAME=\"SLES\"\nVERSION=\"15.1\"\nID=\"sles\"\nID_LIKE=\"suse\"\n",
+          }
+          platform = scan_with_files("linux", files)
 
-        platform[:name].must_equal("suse")
-        platform[:family].must_equal("suse")
-        platform[:release].must_equal("15.1")
+          platform[:name].must_equal("suse")
+          platform[:family].must_equal("suse")
+          platform[:release].must_equal("15.1")
+        end
+
+        it "sets the correct family/release for openSUSE" do
+          files = {
+            "/etc/os-release" => "NAME=\"openSUSE Leap\"\nVERSION=\"15.1\"\nID=\"opensuse-leap\"\nID_LIKE=\"suse opensuse\"\n",
+          }
+          platform = scan_with_files("linux", files)
+
+          platform[:name].must_equal("opensuse")
+          platform[:family].must_equal("suse")
+          platform[:release].must_equal("15.1")
+        end
       end
+      describe "when /etc/os-release is not present" do
+        it "sets the correct family/release for SLES" do
+          files = {
+            "/etc/SuSE-release" => "SUSE Linux Enterprise Server 11 (x86_64)\nVERSION = 11\nPATCHLEVEL = 2",
+          }
+          platform = scan_with_files("linux", files)
 
-      it "sets the correct family/release for openSUSE" do
-        files = {
-          "/etc/os-release" => "NAME=\"openSUSE Leap\"\nVERSION=\"15.1\"\nID=\"opensuse-leap\"\nID_LIKE=\"suse opensuse\"\n",
-        }
-        platform = scan_with_files("linux", files)
+          platform[:name].must_equal("suse")
+          platform[:family].must_equal("suse")
+          platform[:release].must_equal("11.2")
+        end
 
-        platform[:name].must_equal("opensuse")
-        platform[:family].must_equal("suse")
-        platform[:release].must_equal("15.1")
+        it "sets the correct family/release for openSUSE" do
+          files = {
+            "/etc/SuSE-release" => "openSUSE 10.2 (x86_64)\nVERSION = 10.2",
+          }
+          platform = scan_with_files("linux", files)
+
+          platform[:name].must_equal("opensuse")
+          platform[:family].must_equal("suse")
+          platform[:release].must_equal("10.2")
+        end
       end
     end
   end

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -154,16 +154,6 @@ describe "os_detect" do
       end
     end
 
-    describe "windows" do
-      it "sets the correct family/release for windows " do
-        platform = scan_with_windows()
-
-        platform[:name].must_equal("windows_6.3.9600")
-        platform[:family].must_equal("windows")
-        platform[:release].must_equal("6.3.9600")
-      end
-    end
-
     describe "everything else" do
       it "sets the correct family/release for debian " do
         platform = debian_scan("some_debian", "12.99")
@@ -172,6 +162,16 @@ describe "os_detect" do
         platform[:family].must_equal("debian")
         platform[:release].must_equal("11")
       end
+    end
+  end
+
+  describe "windows" do
+    it "sets the correct family/release for windows " do
+      platform = scan_with_windows()
+
+      platform[:name].must_equal("windows_6.3.9600")
+      platform[:family].must_equal("windows")
+      platform[:release].must_equal("6.3.9600")
     end
   end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

The file `/etc/SuSE-release` was deprecated in older SUSE versions and as of SUSE/SLES 15.X is no longer present.  This switches the detection to use the values in `/etc/os-release`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

#377 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
