### PR TITLE
Use /etc/os-release for SUSE detection (Adopted)

### DIFF
--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -235,30 +235,29 @@ module Train::Platforms::Detect::Specifications
 
       # suse family
       plat.family("suse").in_family("linux")
-          .detect do
-            if linux_os_release && linux_os_release["ID_LIKE"] =~ /suse/i
-              @platform[:release] = linux_os_release["VERSION"]
-              true
-            elsif !(suse = unix_file_contents("/etc/SuSE-release")).nil?
-              # https://rubular.com/r/UKaYWolCYFMfp1
-              version = suse.scan(/VERSION = (\d+)\nPATCHLEVEL = (\d+)/).flatten.join(".")
-              # https://rubular.com/r/b5PN3hZDxa5amV
-              version = suse[/VERSION\s?=\s?"?([\d\.]{2,})"?/, 1] if version == ""
-              @platform[:release] = version
-              true
-            end
+        .detect do
+          if linux_os_release && linux_os_release["ID_LIKE"] =~ /suse/i
+            @platform[:release] = linux_os_release["VERSION"]
+            true
+          elsif !(suse = unix_file_contents("/etc/SuSE-release")).nil?
+            # https://rubular.com/r/UKaYWolCYFMfp1
+            version = suse.scan(/VERSION = (\d+)\nPATCHLEVEL = (\d+)/).flatten.join(".")
+            # https://rubular.com/r/b5PN3hZDxa5amV
+            version = suse[/VERSION\s?=\s?"?([\d\.]{2,})"?/, 1] if version == ""
+            @platform[:release] = version
+            true
           end
         end
       plat.name("opensuse").title("OpenSUSE Linux").in_family("suse")
-          .detect do
-            true if (linux_os_release && linux_os_release["NAME"] =~ /^opensuse/i) ||
-               unix_file_contents("/etc/SuSE-release") =~ /^opensuse/i
-          end
+        .detect do
+          true if (linux_os_release && linux_os_release["NAME"] =~ /^opensuse/i) ||
+            unix_file_contents("/etc/SuSE-release") =~ /^opensuse/i
+        end
       plat.name("suse").title("Suse Linux").in_family("suse")
-          .detect do
-            true if (linux_os_release && linux_os_release["NAME"] =~ /^sles/i) ||
-              unix_file_contents("/etc/SuSE-release") =~ /suse/i
-          end
+        .detect do
+          true if (linux_os_release && linux_os_release["NAME"] =~ /^sles/i) ||
+            unix_file_contents("/etc/SuSE-release") =~ /suse/i
+        end
 
       # arch
       plat.name("arch").title("Arch Linux").in_family("linux")

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -177,7 +177,7 @@ describe "os_detect" do
 
   describe "windows" do
     it "sets the correct family/release for windows " do
-      platform = scan_with_windows()
+      platform = scan_with_windows
 
       platform[:name].must_equal("windows_6.3.9600")
       platform[:family].must_equal("windows")


### PR DESCRIPTION
This is an adoption of #476, for rebasing. Following is the original PR description.

----

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

The file `/etc/SuSE-release` was deprecated in older SUSE versions and as of SUSE/SLES 15.X is no longer present.  This switches the detection to use the values in `/etc/os-release`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #377 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
