### PR TITLE
Fix raise invalid arguments

### DIFF
--- a/lib/train/extras/command_wrapper.rb
+++ b/lib/train/extras/command_wrapper.rb
@@ -169,8 +169,8 @@ module Train::Extras
         res = LinuxCommand.new(transport, options)
         verification_res = res.verify
         if verification_res
-          msg, reason = verification_res
-          raise Train::UserError, "Sudo failed: #{msg}", reason
+          msg, _reason = verification_res
+          raise Train::UserError, "Sudo failed: #{msg}"
         end
         res
       elsif transport.platform.windows?


### PR DESCRIPTION
Fixed improper error msg raised  `backtrace must be Array of String (TypeError)`

Before Fix: 
```
backtrace must be Array of String (TypeError)
```

After Fix: 

```
Sudo failed: Sudo requires a TTY. Please see the README on how to configure sudo to allow for non-interactive usage. (Train::UserError)
```

## Description 
 - Kernel#raise takes caller string array as a third argument
 - But it appeared `reason` String passed while raising an error.
 - Reference https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise

## Related Issue
https://github.com/inspec/train/issues/506

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>
