### PR TITLE
Ensure UserError is raised with a reason value

### DIFF
--- a/lib/train/extras/command_wrapper.rb
+++ b/lib/train/extras/command_wrapper.rb
@@ -169,8 +169,8 @@ module Train::Extras
         res = LinuxCommand.new(transport, options)
         verification_res = res.verify
         if verification_res
-          msg, _reason = verification_res
-          raise Train::UserError, "Sudo failed: #{msg}"
+          msg, reason = verification_res
+          raise Train::UserError.new("Sudo failed: #{msg}", reason)
         end
         res
       elsif transport.platform.windows?


### PR DESCRIPTION
This commit addresses the issue fixed in
416cf282c2f8c0bf4b0f5df818146bd6596323dd; however that commit
discarded the reason attached to the exception.  This should be kept,
since Train::UserError covers a lot of ground and the reason
code can help clients differentiate cause without resorting to
their own parsing of error string.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
