### PR TITLE
Fix inspec detect on SLES

### DIFF
--- a/lib/train/platforms/detect/helpers/os_common.rb
+++ b/lib/train/platforms/detect/helpers/os_common.rb
@@ -24,7 +24,6 @@ module Train::Platforms::Detect::Helpers
       return @files[path] if @files.key?(path)
 
       res = @backend.run_command("test -f #{path} && cat #{path}")
-
       # ignore files that can't be read
       @files[path] = res.exit_status == 0 ? res.stdout : nil
       @files[path]

--- a/lib/train/platforms/detect/helpers/os_common.rb
+++ b/lib/train/platforms/detect/helpers/os_common.rb
@@ -24,7 +24,7 @@ module Train::Platforms::Detect::Helpers
       return @files[path] if @files.key?(path)
 
       res = @backend.run_command("test -f #{path} && cat #{path}")
-      
+
       # ignore files that can't be read
       @files[path] = res.exit_status == 0 ? res.stdout : nil
       @files[path]
@@ -49,6 +49,7 @@ module Train::Platforms::Detect::Helpers
 
     def unix_uname_s
       return @uname[:s] if @uname.key?(:s)
+
       @uname[:s] = command_output("uname -s")
     end
 
@@ -60,7 +61,7 @@ module Train::Platforms::Detect::Helpers
 
     def unix_uname_m
       return @uname[:m] if @uname.key?(:m)
-      
+
       @uname[:m] = command_output("uname -m")
     end
 

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -287,7 +287,7 @@ class Train::Transports::SSH
         # wrap commands if that is configured
         if !@cmd_wrapper.nil?
           cmd = @cmd_wrapper.run(cmd)
-        # else check if sudo is configured so we assume Linux is at least the platform so we use Linux wrapper 
+        # else check if sudo is configured so we assume Linux is at least the platform so we use Linux wrapper
         elsif @transport_options[:sudo]
           cmd = LinuxCommand.new(self, @transport_options).run(cmd)
         end

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -287,8 +287,8 @@ class Train::Transports::SSH
         # wrap commands if that is configured
         if !@cmd_wrapper.nil?
           cmd = @cmd_wrapper.run(cmd)
-        else if @transport_options[:sudo] || @transport_options[:shell]
-          # if sudo or shell is in the options we can assume Linux/Unix as platform
+        elsif @transport_options[:sudo] || @transport_options[:shell]
+          # if sudo or shell is in the options we can assume Linux/Unix
           cmd = LinuxCommand.new(self, @transport_options).run(cmd)
         end
 

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -287,8 +287,9 @@ class Train::Transports::SSH
         # wrap commands if that is configured
         if !@cmd_wrapper.nil?
           cmd = @cmd_wrapper.run(cmd)
-        # else check if sudo is configured so we assume Linux is at least the platform so we use Linux wrapper
-        elsif @transport_options[:sudo]
+        # check if sudo or specific is configured so we can assume Linux/Unix
+	# so we use should use Linux wrapper to use the corresponding options
+        elsif @transport_options[:sudo] || @transport_options[:shell]
           cmd = LinuxCommand.new(self, @transport_options).run(cmd)
         end
 

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -287,9 +287,8 @@ class Train::Transports::SSH
         # wrap commands if that is configured
         if !@cmd_wrapper.nil?
           cmd = @cmd_wrapper.run(cmd)
-        # check if sudo or specific is configured so we can assume Linux/Unix
-	# so we use should use Linux wrapper to use the corresponding options
-        elsif @transport_options[:sudo] || @transport_options[:shell]
+        else if @transport_options[:sudo] || @transport_options[:shell]
+          # if sudo or shell is in the options we can assume Linux/Unix as platform
           cmd = LinuxCommand.new(self, @transport_options).run(cmd)
         end
 

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -285,7 +285,12 @@ class Train::Transports::SSH
       exit_status = nil
       session.open_channel do |channel|
         # wrap commands if that is configured
-        cmd = @cmd_wrapper.run(cmd) unless @cmd_wrapper.nil?
+        if !@cmd_wrapper.nil?
+          cmd = @cmd_wrapper.run(cmd)
+        # else check if sudo is configured so we assume Linux is at least the platform so we use Linux wrapper 
+        elsif @transport_options[:sudo]
+          cmd = LinuxCommand.new(self, @transport_options).run(cmd)
+        end
 
         if @transport_options[:pty]
           channel.request_pty do |_ch, success|


### PR DESCRIPTION
This is a fix for the broken remote execution of Inspec on SUSE SLES 12.

## Description
More details can be found in https://github.com/inspec/inspec/issues/4384

Basically the problem appears for non-root users with sudosh blocking OS detection without sudo and blocks any inspec run for remote operations. Neither the /etc/os-release file is readable nor the uname command is executable without sudo in such an environment.

This has been verified working with Inspec CLI and also Inspec Library Runner Class.

## Related Issue
https://github.com/inspec/inspec/issues/4384

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
