### PR TITLE
Add reason field while raising Train::ClientError.

### DIFF
--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -103,8 +103,10 @@ module Train::Transports
 
       if options[:auth_methods] == ["none"]
         if ssh_known_identities.empty?
-          raise Train::ClientError,
-            "Your SSH Agent has no keys added, and you have not specified a password or a key file"
+          raise Train::ClientError.new(
+            "Your SSH Agent has no keys added, and you have not specified a password or a key file",
+            :no_ssh_password_or_key_available
+          )
         else
           logger.debug("[SSH] Using Agent keys as no password or key file have been specified")
           options[:auth_methods].push("publickey")


### PR DESCRIPTION
Signed-off-by: Amol Shinde <amol.shinde@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->
Added reason field in raising `Train::ClientError.` Reason field can be used to identify the error instead of string comparison. So that there would not be any dependency on the error message.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #516 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
