### PR TITLE
Fix method called on string in os parse function

### DIFF
--- a/lib/train/platforms/detect/helpers/os_linux.rb
+++ b/lib/train/platforms/detect/helpers/os_linux.rb
@@ -41,7 +41,7 @@ module Train::Platforms::Detect::Helpers
         next if line.empty?
 
         key, value = line.split("=", 2)
-        memo[key] = value.gsub(/\A"|"\Z/, "") unless value.empty?
+        memo[key] = value.gsub(/\A"|"\Z/, "") unless value.nil?
       end
     end
 

--- a/lib/train/platforms/detect/helpers/os_linux.rb
+++ b/lib/train/platforms/detect/helpers/os_linux.rb
@@ -37,11 +37,11 @@ module Train::Platforms::Detect::Helpers
 
       raw.lines.each_with_object({}) do |line, memo|
         line.strip!
+        next if line.nil? || line.empty?
         next if line.start_with?("#")
-        next if line.empty?
 
         key, value = line.split("=", 2)
-        memo[key] = value.gsub(/\A"|"\Z/, "") unless value.nil?
+        memo[key] = value.gsub(/\A"|"\Z/, "") unless value.nil? || value.empty?
       end
     end
 


### PR DESCRIPTION
Encountered a syntax error when using the kitchen bootstrap command.

## Description
When running the following command:
```shell
knife bootstrap localhost -p 2202 -U vagrant --sudo -i /Users/michaelzion/Projects/chef-repo/.vagrant/machines/web2/virtualbox/private_key -N web1
```
I encountered the following error:
```
knife bootstrap ec2-18-136-196-113.ap-southeast-1.compute.amazonaws.com -U centos --sudo --ssh-identity-file ~/.ssh/aws.pem --node-name node1-centos --run-list 'recipe[learn_chef_https]' -VVV
INFO: Using configuration from /Users/user123/learn-chef/.chef/knife.rb
DEBUG: Checking if we need to accept Chef license to bootstrap node
DEBUG: Reading products and relationships...
DEBUG: Successfully read products and relationships
DEBUG: License acceptance required for chef version: 15
DEBUG: Searching for the following licenses: ["infra-client", "inspec"]
DEBUG: Found license chef_infra_client at /Users/user123/.chef/accepted_licenses/chef_infra_client
DEBUG: Found license inspec at /Users/user123/.chef/accepted_licenses/inspec
DEBUG: Missing licenses remaining: []
DEBUG: All licenses present
Connecting to ec2-18-136-196-113.ap-southeast-1.compute.amazonaws.com
WARN: [SSH] PTY requested: stderr will be merged into stdout
DEBUG: [SSH] centos@ec2-18-136-196-113.ap-southeast-1.compute.amazonaws.com<{:user_known_hosts_file=>"/dev/null", :port=>22, :compression=>false, :compression_level=>0, :keepalive=>true, :keepalive_interval=>60, :timeout=>60, :auth_methods=>["none", "publickey"], :keys_only=>true, :keys=>["/Users/user123/.ssh/aws.pem"], :password=>"<hidden>", :forward_agent=>nil, :non_interactive=>true, :verify_host_key=>:always}> (cmd.exe /c ver)
DEBUG: [SSH] opening connection to centos@ec2-18-136-196-113.ap-southeast-1.compute.amazonaws.com<{:user_known_hosts_file=>"/dev/null", :port=>22, :compression=>false, :compression_level=>0, :keepalive=>true, :keepalive_interval=>60, :timeout=>60, :auth_methods=>["none", "publickey"], :keys_only=>true, :keys=>["/Users/user123/.ssh/aws.pem"], :password=>"<hidden>", :forward_agent=>nil, :non_interactive=>true, :verify_host_key=>:always}>
The authenticity of host 'ec2-18-136-196-113.ap-southeast-1.compute.amazonaws.com (18.136.196.113)' can't be established.
fingerprint is SHA256:4lcv0kU7ukIAU2+pFKDxoxpq4kEvY25NxnM4kgRL4k0.

Are you sure you want to continue connecting
? (Y/N) Y
WARN: [SSH] PTY requested: stderr will be merged into stdout
DEBUG: [SSH] centos@ec2-18-136-196-113.ap-southeast-1.compute.amazonaws.com<{:user_known_hosts_file=>"/dev/null", :port=>22, :compression=>false, :compression_level=>0, :keepalive=>true, :keepalive_interval=>60, :timeout=>60, :auth_methods=>["none", "publickey"], :keys_only=>true, :keys=>["/Users/user123/.ssh/aws.pem"], :password=>"<hidden>", :forward_agent=>nil, :non_interactive=>true, :verify_host_key=>:accept_new}> (cmd.exe /c ver)
DEBUG: [SSH] opening connection to centos@ec2-18-136-196-113.ap-southeast-1.compute.amazonaws.com<{:user_known_hosts_file=>"/dev/null", :port=>22, :compression=>false, :compression_level=>0, :keepalive=>true, :keepalive_interval=>60, :timeout=>60, :auth_methods=>["none", "publickey"], :keys_only=>true, :keys=>["/Users/user123/.ssh/aws.pem"], :password=>"<hidden>", :forward_agent=>nil, :non_interactive=>true, :verify_host_key=>:accept_new}>
DEBUG: [SSH] centos@ec2-18-136-196-113.ap-southeast-1.compute.amazonaws.com<{:user_known_hosts_file=>"/dev/null", :port=>22, :compression=>false, :compression_level=>0, :keepalive=>true, :keepalive_interval=>60, :timeout=>60, :auth_methods=>["none", "publickey"], :keys_only=>true, :keys=>["/Users/user123/.ssh/aws.pem"], :password=>"<hidden>", :forward_agent=>nil, :non_interactive=>true, :verify_host_key=>:accept_new}> (uname -s)
DEBUG: [SSH] centos@ec2-18-136-196-113.ap-southeast-1.compute.amazonaws.com<{:user_known_hosts_file=>"/dev/null", :port=>22, :compression=>false, :compression_level=>0, :keepalive=>true, :keepalive_interval=>60, :timeout=>60, :auth_methods=>["none", "publickey"], :keys_only=>true, :keys=>["/Users/user123/.ssh/aws.pem"], :password=>"<hidden>", :forward_agent=>nil, :non_interactive=>true, :verify_host_key=>:accept_new}> (uname -m)
DEBUG: [SSH] centos@ec2-18-136-196-113.ap-southeast-1.compute.amazonaws.com<{:user_known_hosts_file=>"/dev/null", :port=>22, :compression=>false, :compression_level=>0, :keepalive=>true, :keepalive_interval=>60, :timeout=>60, :auth_methods=>["none", "publickey"], :keys_only=>true, :keys=>["/Users/user123/.ssh/aws.pem"], :password=>"<hidden>", :forward_agent=>nil, :non_interactive=>true, :verify_host_key=>:accept_new}> (test -f /etc/debian_version && cat /etc/debian_version)
DEBUG: [SSH] centos@ec2-18-136-196-113.ap-southeast-1.compute.amazonaws.com<{:user_known_hosts_file=>"/dev/null", :port=>22, :compression=>false, :compression_level=>0, :keepalive=>true, :keepalive_interval=>60, :timeout=>60, :auth_methods=>["none", "publickey"], :keys_only=>true, :keys=>["/Users/user123/.ssh/aws.pem"], :password=>"<hidden>", :forward_agent=>nil, :non_interactive=>true, :verify_host_key=>:accept_new}> (test -f /etc/os-release && cat /etc/os-release)
Traceback (most recent call last):
	48: from /usr/local/bin/knife:338:in `<main>'
	47: from /usr/local/bin/knife:338:in `load'
	46: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/bin/knife:24:in `<top (required)>'
	45: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/application/knife.rb:162:in `run'
	44: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife.rb:222:in `run'
	43: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife.rb:474:in `run_with_pretty_exceptions'
	42: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/local_mode.rb:42:in `with_server_connectivity'
	41: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife.rb:475:in `block in run_with_pretty_exceptions'
	40: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife/bootstrap.rb:569:in `run'
	39: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife/bootstrap.rb:620:in `connect!'
	38: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife/bootstrap.rb:674:in `do_connect'
	37: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife/bootstrap/train_connector.rb:70:in `connect!'
	36: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife/bootstrap/train_connector.rb:57:in `connection'
	35: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/transports/ssh.rb:82:in `connection'
	34: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/transports/ssh.rb:238:in `create_new_connection'
	33: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/transports/ssh.rb:238:in `new'
	32: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/transports/ssh_connection.rb:53:in `initialize'
	31: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/extras/command_wrapper.rb:166:in `load'
	30: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/plugins/base_connection.rb:116:in `platform'
	29: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect.rb:9:in `scan'
	28: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:27:in `scan'
	27: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:27:in `each'
	26: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:33:in `block in scan'
	25: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:45:in `scan_children'
	24: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:45:in `each'
	23: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:46:in `block in scan_children'
	22: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:46:in `instance_eval'
	21: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/specifications/os.rb:29:in `block in load'
	20: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/helpers/os_windows.rb:5:in `detect_windows'
	19: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/plugins/base_connection.rb:128:in `run_command'
	18: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/transports/ssh_connection.rb:218:in `run_command_via_connection'
	17: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/transports/ssh_connection.rb:249:in `session'
	16: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/transports/ssh_connection.rb:180:in `establish_connection'
	15: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/lib/net/ssh.rb:246:in `start'
	14: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/lib/net/ssh.rb:246:in `new'
	13: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/lib/net/ssh/transport/session.rb:90:in `initialize'
	12: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/lib/net/ssh/transport/session.rb:223:in `wait'
	11: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/lib/net/ssh/transport/session.rb:223:in `loop'
	10: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/lib/net/ssh/transport/session.rb:225:in `block in wait'
	 9: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/lib/net/ssh/transport/session.rb:190:in `poll_message'
	 8: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/lib/net/ssh/transport/session.rb:190:in `loop'
	 7: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/lib/net/ssh/transport/session.rb:210:in `block in poll_message'
	 6: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/lib/net/ssh/transport/algorithms.rb:167:in `accept_kexinit'
	 5: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/lib/net/ssh/transport/algorithms.rb:228:in `proceed!'
	 4: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/lib/net/ssh/transport/algorithms.rb:406:in `exchange_keys'
	 3: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/lib/net/ssh/transport/kex/diffie_hellman_group1_sha1.rb:72:in `exchange_keys'
	 2: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/lib/net/ssh/transport/kex/diffie_hellman_group1_sha1.rb:188:in `verify_server_key'
	 1: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/lib/net/ssh/verifiers/always.rb:21:in `verify'
/opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/lib/net/ssh/verifiers/always.rb:50:in `process_cache_miss': fingerprint SHA256:4lcv0kU7ukIAU2+pFKDxoxpq4kEvY25NxnM4kgRL4k0 is unknown for "ec2-18-136-196-113.ap-southeast-1.compute.amazonaws.com,18.136.196.113" (Net::SSH::HostKeyUnknown)
	31: from /usr/local/bin/knife:338:in `<main>'
	30: from /usr/local/bin/knife:338:in `load'
	29: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/bin/knife:24:in `<top (required)>'
	28: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/application/knife.rb:162:in `run'
	27: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife.rb:222:in `run'
	26: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife.rb:474:in `run_with_pretty_exceptions'
	25: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/local_mode.rb:42:in `with_server_connectivity'
	24: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife.rb:475:in `block in run_with_pretty_exceptions'
	23: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife/bootstrap.rb:569:in `run'
	22: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife/bootstrap.rb:620:in `connect!'
	21: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife/bootstrap.rb:674:in `do_connect'
	20: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife/bootstrap/train_connector.rb:70:in `connect!'
	19: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife/bootstrap/train_connector.rb:57:in `connection'
	18: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/transports/ssh.rb:82:in `connection'
	17: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/transports/ssh.rb:238:in `create_new_connection'
	16: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/transports/ssh.rb:238:in `new'
	15: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/transports/ssh_connection.rb:53:in `initialize'
	14: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/extras/command_wrapper.rb:166:in `load'
	13: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/plugins/base_connection.rb:116:in `platform'
	12: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect.rb:9:in `scan'
	11: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:27:in `scan'
	10: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:27:in `each'
	 9: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:33:in `block in scan'
	 8: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:45:in `scan_children'
	 7: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:45:in `each'
	 6: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:46:in `block in scan_children'
	 5: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:46:in `instance_eval'
	 4: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/specifications/os.rb:29:in `block in load'
	 3: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/helpers/os_windows.rb:5:in `detect_windows'
	 2: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/plugins/base_connection.rb:128:in `run_command'
	 1: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/transports/ssh_connection.rb:214:in `run_command_via_connection'
/opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/transports/ssh_connection.rb:226:in `rescue in run_command_via_connection': SSH command failed (fingerprint SHA256:4lcv0kU7ukIAU2+pFKDxoxpq4kEvY25NxnM4kgRL4k0 is unknown for "ec2-18-136-196-113.ap-southeast-1.compute.amazonaws.com,18.136.196.113") (Train::Transports::SSHFailed)
	41: from /usr/local/bin/knife:338:in `<main>'
	40: from /usr/local/bin/knife:338:in `load'
	39: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/bin/knife:24:in `<top (required)>'
	38: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/application/knife.rb:162:in `run'
	37: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife.rb:222:in `run'
	36: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife.rb:474:in `run_with_pretty_exceptions'
	35: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/local_mode.rb:42:in `with_server_connectivity'
	34: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife.rb:475:in `block in run_with_pretty_exceptions'
	33: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife/bootstrap.rb:569:in `run'
	32: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife/bootstrap.rb:617:in `connect!'
	31: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife/bootstrap.rb:641:in `rescue in connect!'
	30: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife/bootstrap.rb:674:in `do_connect'
	29: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife/bootstrap/train_connector.rb:70:in `connect!'
	28: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/knife/bootstrap/train_connector.rb:57:in `connection'
	27: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/transports/ssh.rb:82:in `connection'
	26: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/transports/ssh.rb:238:in `create_new_connection'
	25: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/transports/ssh.rb:238:in `new'
	24: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/transports/ssh_connection.rb:53:in `initialize'
	23: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/extras/command_wrapper.rb:166:in `load'
	22: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/plugins/base_connection.rb:116:in `platform'
	21: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect.rb:9:in `scan'
	20: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:27:in `scan'
	19: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:27:in `each'
	18: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:33:in `block in scan'
	17: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:45:in `scan_children'
	16: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:45:in `each'
	15: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:51:in `block in scan_children'
	14: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:60:in `scan_family_children'
	13: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:45:in `scan_children'
	12: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:45:in `each'
	11: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:51:in `block in scan_children'
	10: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:60:in `scan_family_children'
	 9: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:45:in `scan_children'
	 8: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:45:in `each'
	 7: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:46:in `block in scan_children'
	 6: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/scanner.rb:46:in `instance_eval'
	 5: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/specifications/os.rb:103:in `block in load'
	 4: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/helpers/os_linux.rb:26:in `linux_os_release'
	 3: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/helpers/os_linux.rb:38:in `parse_os_release_info'
	 2: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/helpers/os_linux.rb:38:in `each_with_object'
	 1: from /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/helpers/os_linux.rb:38:in `each'
/opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/train-core-2.1.19/lib/train/platforms/detect/helpers/os_linux.rb:44:in `block in parse_os_release_info': undefined method `empty?' for nil:NilClass (NoMethodError)
```
## Related Issue
https://github.com/chef/chef/issues/8886

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
