### PR TITLE
Stop using global expectation methods and switch to using _.

### DIFF
--- a/test/integration/tests/path_block_device_test.rb
+++ b/test/integration/tests/path_block_device_test.rb
@@ -7,68 +7,68 @@ describe "file interface" do
     let(:file) { backend.file("/tmp/block_device") }
 
     it "exists" do
-      file.exist?.must_equal(true)
+      _(file.exist?).must_equal(true)
     end
 
     it "is a block device" do
-      file.block_device?.must_equal(true)
+      _(file.block_device?).must_equal(true)
     end
 
     it "has type :block_device" do
-      file.type.must_equal(:block_device)
+      _(file.type).must_equal(:block_device)
     end
 
     it "has no content" do
-      file.content.must_equal("")
+      _(file.content).must_equal("")
     end
 
     it "has owner name root" do
-      file.owner.must_equal("root")
+      _(file.owner).must_equal("root")
     end
 
     it "has group name" do
-      file.group.must_equal(Test.root_group(backend.os))
+      _(file.group).must_equal(Test.root_group(backend.os))
     end
 
     it "has mode 0666" do
-      file.mode.must_equal(00666)
+      _(file.mode).must_equal(00666)
     end
 
     it "checks mode? 0666" do
-      file.mode?(00666).must_equal(true)
+      _(file.mode?(00666)).must_equal(true)
     end
 
     it "has no link_path" do
-      file.link_path.must_be_nil
+      _(file.link_path).must_be_nil
     end
 
     it "has the correct md5sum" do
-      file.md5sum.must_equal("d41d8cd98f00b204e9800998ecf8427e")
+      _(file.md5sum).must_equal("d41d8cd98f00b204e9800998ecf8427e")
     end
 
     it "has the correct sha256sum" do
-      file.sha256sum.must_equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+      _(file.sha256sum).must_equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
     end
 
     it "has a modified time" do
-      file.mtime.must_be_close_to(Time.now.to_i - Test.mtime / 2, Test.mtime)
+      _(file.mtime).must_be_close_to(Time.now.to_i - Test.mtime / 2, Test.mtime)
     end
 
     it "has inode size of 0" do
-      file.size.must_equal(0)
+      _(file.size).must_equal(0)
     end
 
     it "has selinux label handling" do
       res = Test.selinux_label(backend, file.path)
-      file.selinux_label.must_equal(res)
+      _(file.selinux_label).must_equal(res)
     end
 
     it "has no product_version" do
-      file.product_version.must_be_nil
+      _(file.product_version).must_be_nil
     end
 
     it "has no file_version" do
-      file.file_version.must_be_nil
+      _(file.file_version).must_be_nil
     end
   end
 end

--- a/test/integration/tests/path_character_device_test.rb
+++ b/test/integration/tests/path_character_device_test.rb
@@ -7,68 +7,68 @@ describe "file interface" do
     let(:file) { backend.file("/dev/null") }
 
     it "exists" do
-      file.exist?.must_equal(true)
+      _(file.exist?).must_equal(true)
     end
 
     it "is a character device" do
-      file.character_device?.must_equal(true)
+      _(file.character_device?).must_equal(true)
     end
 
     it "has type :character_device" do
-      file.type.must_equal(:character_device)
+      _(file.type).must_equal(:character_device)
     end
 
     it "has empty content" do
-      file.content.must_equal("")
+      _(file.content).must_equal("")
     end
 
     it "has owner name root" do
-      file.owner.must_equal("root")
+      _(file.owner).must_equal("root")
     end
 
     it "has group name" do
-      file.group.must_equal(Test.root_group(backend.os))
+      _(file.group).must_equal(Test.root_group(backend.os))
     end
 
     it "has mode 0666" do
-      file.mode.must_equal(00666)
+      _(file.mode).must_equal(00666)
     end
 
     it "checks mode? 0666" do
-      file.mode?(00666).must_equal(true)
+      _(file.mode?(00666)).must_equal(true)
     end
 
     it "has no link_path" do
-      file.link_path.must_be_nil
+      _(file.link_path).must_be_nil
     end
 
     it "has an md5sum" do
-      file.md5sum.must_equal("d41d8cd98f00b204e9800998ecf8427e")
+      _(file.md5sum).must_equal("d41d8cd98f00b204e9800998ecf8427e")
     end
 
     it "has an sha256sum" do
-      file.sha256sum.must_equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+      _(file.sha256sum).must_equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
     end
 
     it "has a modified time" do
-      file.mtime.must_be_close_to(Time.now.to_i - Test.mtime / 2, Test.mtime)
+      _(file.mtime).must_be_close_to(Time.now.to_i - Test.mtime / 2, Test.mtime)
     end
 
     it "has inode size of 0" do
-      file.size.must_equal(0)
+      _(file.size).must_equal(0)
     end
 
     it "has selinux label handling" do
       res = Test.selinux_label(backend, file.path)
-      file.selinux_label.must_equal(res)
+      _(file.selinux_label).must_equal(res)
     end
 
     it "has no product_version" do
-      file.product_version.must_be_nil
+      _(file.product_version).must_be_nil
     end
 
     it "has no file_version" do
-      file.file_version.must_be_nil
+      _(file.file_version).must_be_nil
     end
   end
 end

--- a/test/integration/tests/path_file_test.rb
+++ b/test/integration/tests/path_file_test.rb
@@ -7,93 +7,93 @@ describe "file interface" do
     let(:file) { backend.file("/tmp/file") }
 
     it "exists" do
-      file.exist?.must_equal(true)
+      _(file.exist?).must_equal(true)
     end
 
     it "is a file" do
-      file.file?.must_equal(true)
+      _(file.file?).must_equal(true)
     end
 
     it "has type :file" do
-      file.type.must_equal(:file)
+      _(file.type).must_equal(:file)
     end
 
     it "has content" do
-      file.content.must_equal("hello world")
+      _(file.content).must_equal("hello world")
     end
 
     it "has owner name root" do
-      file.owner.must_equal("root")
+      _(file.owner).must_equal("root")
     end
 
     it "has group name" do
-      file.group.must_equal(Test.root_group(backend.os))
+      _(file.group).must_equal(Test.root_group(backend.os))
     end
 
     it "has mode 0765" do
-      file.mode.must_equal(00765)
+      _(file.mode).must_equal(00765)
     end
 
     it "checks mode? 0765" do
-      file.mode?(00765).must_equal(true)
+      _(file.mode?(00765)).must_equal(true)
     end
 
     it "doesnt check mode? 0764" do
-      file.mode?(00764).must_equal(false)
+      _(file.mode?(00764)).must_equal(false)
     end
 
     it "has no link_path" do
-      file.link_path.must_be_nil
+      _(file.link_path).must_be_nil
     end
 
     it "has an md5sum" do
-      file.md5sum.must_equal("5eb63bbbe01eeed093cb22bb8f5acdc3")
+      _(file.md5sum).must_equal("5eb63bbbe01eeed093cb22bb8f5acdc3")
     end
 
     it "has an sha256sum" do
-      file.sha256sum.must_equal("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9")
+      _(file.sha256sum).must_equal("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9")
     end
 
     it "has a modified time" do
-      file.mtime.must_be_close_to(Time.now.to_i - Test.mtime / 2, Test.mtime)
+      _(file.mtime).must_be_close_to(Time.now.to_i - Test.mtime / 2, Test.mtime)
     end
 
     it "has size" do
       # Must be around 11 Bytes, +- 4
-      file.size.must_be_close_to(11, 4)
+      _(file.size).must_be_close_to(11, 4)
     end
 
     it "has selinux label handling" do
       res = Test.selinux_label(backend, file.path)
-      file.selinux_label.must_equal(res)
+      _(file.selinux_label).must_equal(res)
     end
 
     it "has no product_version" do
-      file.product_version.must_be_nil
+      _(file.product_version).must_be_nil
     end
 
     it "has no file_version" do
-      file.file_version.must_be_nil
+      _(file.file_version).must_be_nil
     end
 
     it "provides a json representation" do
       j = file.to_json
-      j.must_be_kind_of Hash
-      j["type"].must_equal :file
+      _(j).must_be_kind_of Hash
+      _(j["type"]).must_equal :file
     end
   end
 
   describe "regular file" do
     let(:file) { backend.file("/tmp/sfile") }
     it "has mode 7765" do
-      file.mode.must_equal(07765)
+      _(file.mode).must_equal(07765)
     end
   end
 
   describe "regular file" do
     let(:file) { backend.file("/tmp/spaced file") }
     it "has content" do
-      file.content.must_equal("hello space")
+      _(file.content).must_equal("hello space")
     end
   end
 end

--- a/test/integration/tests/path_folder_test.rb
+++ b/test/integration/tests/path_folder_test.rb
@@ -7,84 +7,84 @@ describe "file interface" do
     let(:file) { backend.file("/tmp/folder") }
 
     it "exists" do
-      file.exist?.must_equal(true)
+      _(file.exist?).must_equal(true)
     end
 
     it "is a directory" do
-      file.directory?.must_equal(true)
+      _(file.directory?).must_equal(true)
     end
 
     it "has type :directory" do
-      file.type.must_equal(:directory)
+      _(file.type).must_equal(:directory)
     end
 
     case get_backend.call.os[:family]
     when "freebsd"
       it "has freebsd folder content behavior" do
-        file.content.must_equal("\u0003\u0000")
+        _(file.content).must_equal("\u0003\u0000")
       end
 
       it "has an md5sum" do
-        file.md5sum.must_equal("598f4fe64aefab8f00bcbea4c9239abf")
+        _(file.md5sum).must_equal("598f4fe64aefab8f00bcbea4c9239abf")
       end
 
       it "has an sha256sum" do
-        file.sha256sum.must_equal("9b4fb24edd6d1d8830e272398263cdbf026b97392cc35387b991dc0248a628f9")
+        _(file.sha256sum).must_equal("9b4fb24edd6d1d8830e272398263cdbf026b97392cc35387b991dc0248a628f9")
       end
 
     else
       it "has no content" do
-        file.content.must_be_nil
+        _(file.content).must_be_nil
       end
 
       it "raises an error if md5sum is attempted" do
-        proc { file.md5sum }.must_raise RuntimeError
+        _ { file.md5sum }.must_raise RuntimeError
       end
 
       it "raises an error if sha256sum is attempted" do
-        proc { file.sha256sum }.must_raise RuntimeError
+        _ { file.sha256sum }.must_raise RuntimeError
       end
     end
 
     it "has owner name root" do
-      file.owner.must_equal("root")
+      _(file.owner).must_equal("root")
     end
 
     it "has group name" do
-      file.group.must_equal(Test.root_group(backend.os))
+      _(file.group).must_equal(Test.root_group(backend.os))
     end
 
     it "has mode 0567" do
-      file.mode.must_equal(00567)
+      _(file.mode).must_equal(00567)
     end
 
     it "checks mode? 0567" do
-      file.mode?(00567).must_equal(true)
+      _(file.mode?(00567)).must_equal(true)
     end
 
     it "has no link_path" do
-      file.link_path.must_be_nil
+      _(file.link_path).must_be_nil
     end
 
     it "has a modified time" do
-      file.mtime.must_be_close_to(Time.now.to_i - Test.mtime / 2, Test.mtime)
+      _(file.mtime).must_be_close_to(Time.now.to_i - Test.mtime / 2, Test.mtime)
     end
 
     it "has inode size" do
-      file.size.must_be_close_to(4096, 4096)
+      _(file.size).must_be_close_to(4096, 4096)
     end
 
     it "has selinux label handling" do
       res = Test.selinux_label(backend, file.path)
-      file.selinux_label.must_equal(res)
+      _(file.selinux_label).must_equal(res)
     end
 
     it "has no product_version" do
-      file.product_version.must_be_nil
+      _(file.product_version).must_be_nil
     end
 
     it "has no file_version" do
-      file.file_version.must_be_nil
+      _(file.file_version).must_be_nil
     end
   end
 end

--- a/test/integration/tests/path_missing_test.rb
+++ b/test/integration/tests/path_missing_test.rb
@@ -9,68 +9,68 @@ describe "file interface" do
     end
 
     it "does not exist" do
-      file.exist?.must_equal(false)
+      _(file.exist?).must_equal(false)
     end
 
     it "is not a file" do
-      file.file?.must_equal(false)
+      _(file.file?).must_equal(false)
     end
 
     it "has type nil" do
-      file.type.must_be_nil
+      _(file.type).must_be_nil
     end
 
     it "has no content" do
-      file.content.must_be_nil
+      _(file.content).must_be_nil
     end
 
     it "has no owner" do
-      file.owner.must_be_nil
+      _(file.owner).must_be_nil
     end
 
     it "has no group" do
-      file.group.must_be_nil
+      _(file.group).must_be_nil
     end
 
     it "has mode nil" do
-      file.mode.must_be_nil
+      _(file.mode).must_be_nil
     end
 
     it "checks mode? nil" do
-      file.mode?(nil).must_equal(true)
+      _(file.mode?(nil)).must_equal(true)
     end
 
     it "has no link_path" do
-      file.link_path.must_be_nil
+      _(file.link_path).must_be_nil
     end
 
     it "raises an error if md5sum is attempted" do
-      proc { file.md5sum }.must_raise RuntimeError
+      _ { file.md5sum }.must_raise RuntimeError
     end
 
     it "raises an error if sha256sum is attempted" do
-      proc { file.sha256sum }.must_raise RuntimeError
+      _ { file.sha256sum }.must_raise RuntimeError
     end
 
     it "has a modified time" do
-      file.mtime.must_be_nil
+      _(file.mtime).must_be_nil
     end
 
     it "has inode size" do
       # Must be around 11 Bytes, +- 4
-      file.size.must_be_nil
+      _(file.size).must_be_nil
     end
 
     it "has no selinux_label" do
-      file.selinux_label.must_be_nil
+      _(file.selinux_label).must_be_nil
     end
 
     it "has no product_version" do
-      file.product_version.must_be_nil
+      _(file.product_version).must_be_nil
     end
 
     it "has no file_version" do
-      file.file_version.must_be_nil
+      _(file.file_version).must_be_nil
     end
   end
 end

--- a/test/integration/tests/path_pipe_test.rb
+++ b/test/integration/tests/path_pipe_test.rb
@@ -7,56 +7,56 @@ describe "file interface" do
     let(:file) { backend.file("/tmp/pipe") }
 
     it "exists" do
-      file.exist?.must_equal(true)
+      _(file.exist?).must_equal(true)
     end
 
     it "is a pipe" do
-      file.pipe?.must_equal(true)
+      _(file.pipe?).must_equal(true)
     end
 
     it "has type :pipe" do
-      file.type.must_equal(:pipe)
+      _(file.type).must_equal(:pipe)
     end
 
     it "has owner name root" do
-      file.owner.must_equal("root")
+      _(file.owner).must_equal("root")
     end
 
     it "has group name" do
-      file.group.must_equal(Test.root_group(backend.os))
+      _(file.group).must_equal(Test.root_group(backend.os))
     end
 
     it "has mode 0644" do
-      file.mode.must_equal(00644)
+      _(file.mode).must_equal(00644)
     end
 
     it "checks mode? 0644" do
-      file.mode?(00644).must_equal(true)
+      _(file.mode?(00644)).must_equal(true)
     end
 
     it "has no link_path" do
-      file.link_path.must_be_nil
+      _(file.link_path).must_be_nil
     end
 
     it "has a modified time" do
-      file.mtime.must_be_close_to(Time.now.to_i - Test.mtime / 2, Test.mtime)
+      _(file.mtime).must_be_close_to(Time.now.to_i - Test.mtime / 2, Test.mtime)
     end
 
     it "has inode size of 0" do
-      file.size.must_equal(0)
+      _(file.size).must_equal(0)
     end
 
     it "has selinux label handling" do
       res = Test.selinux_label(backend, file.path)
-      file.selinux_label.must_equal(res)
+      _(file.selinux_label).must_equal(res)
     end
 
     it "has no product_version" do
-      file.product_version.must_be_nil
+      _(file.product_version).must_be_nil
     end
 
     it "has no file_version" do
-      file.file_version.must_be_nil
+      _(file.file_version).must_be_nil
     end
   end
 end

--- a/test/integration/tests/path_symlink_test.rb
+++ b/test/integration/tests/path_symlink_test.rb
@@ -7,89 +7,89 @@ describe "file interface" do
     let(:file) { backend.file("/tmp/symlink") }
 
     it "exists" do
-      file.exist?.must_equal(true)
+      _(file.exist?).must_equal(true)
     end
 
     it "is a symlink" do
-      file.symlink?.must_equal(true)
+      _(file.symlink?).must_equal(true)
     end
 
     it "is pointing to a file" do
-      file.file?.must_equal(true)
+      _(file.file?).must_equal(true)
     end
 
     it "is not pointing to a folder" do
-      file.directory?.must_equal(false)
+      _(file.directory?).must_equal(false)
     end
 
     it "has type :file" do
-      file.type.must_equal(:file)
+      _(file.type).must_equal(:file)
     end
 
     it "has content" do
-      file.content.must_equal("hello world")
+      _(file.content).must_equal("hello world")
     end
 
     it "has owner name root" do
-      file.owner.must_equal("root")
+      _(file.owner).must_equal("root")
     end
 
     it "has uid 0" do
-      file.uid.must_equal(0)
+      _(file.uid).must_equal(0)
     end
 
     it "has group name" do
-      file.group.must_equal(Test.root_group(backend.os))
+      _(file.group).must_equal(Test.root_group(backend.os))
     end
 
     it "has gid 0" do
-      file.gid.must_equal(0)
+      _(file.gid).must_equal(0)
     end
 
     it "has mode 0777" do
-      file.source.mode.must_equal(00777)
+      _(file.source.mode).must_equal(00777)
     end
 
     it "has mode 0765" do
-      file.mode.must_equal(00765)
+      _(file.mode).must_equal(00765)
     end
 
     it "checks mode? 0765" do
-      file.mode?(00765).must_equal(true)
+      _(file.mode?(00765)).must_equal(true)
     end
 
     it "has link_path" do
-      file.link_path.must_equal("/tmp/file")
+      _(file.link_path).must_equal("/tmp/file")
     end
 
     it "has an md5sum" do
-      file.md5sum.must_equal("5eb63bbbe01eeed093cb22bb8f5acdc3")
+      _(file.md5sum).must_equal("5eb63bbbe01eeed093cb22bb8f5acdc3")
     end
 
     it "has an sha256sum" do
-      file.sha256sum.must_equal("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9")
+      _(file.sha256sum).must_equal("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9")
     end
 
     it "has a modified time" do
-      file.mtime.must_be_close_to(Time.now.to_i - Test.mtime / 2, Test.mtime)
+      _(file.mtime).must_be_close_to(Time.now.to_i - Test.mtime / 2, Test.mtime)
     end
 
     it "has size" do
       # Must be around 11 Bytes, +- 4
-      file.size.must_be_close_to(11, 4)
+      _(file.size).must_be_close_to(11, 4)
     end
 
     it "has selinux label handling" do
       res = Test.selinux_label(backend, file.path)
-      file.selinux_label.must_equal(res)
+      _(file.selinux_label).must_equal(res)
     end
 
     it "has no product_version" do
-      file.product_version.must_be_nil
+      _(file.product_version).must_be_nil
     end
 
     it "has no file_version" do
-      file.file_version.must_be_nil
+      _(file.file_version).must_be_nil
     end
   end
 end

--- a/test/integration/tests/run_command_test.rb
+++ b/test/integration/tests/run_command_test.rb
@@ -5,31 +5,31 @@ describe "run_command" do
 
   it "can echo commands" do
     res = backend.run_command("echo hello world")
-    res.stdout.must_equal("hello world\n")
-    res.stderr.must_equal("")
-    res.exit_status.must_equal(0)
+    _(res.stdout).must_equal("hello world\n")
+    _(res.stderr).must_equal("")
+    _(res.exit_status).must_equal(0)
   end
 
   it "can run frozen commands" do
     res = backend.run_command("echo hello world".freeze)
-    res.stdout.must_equal("hello world\n")
-    res.stderr.must_equal("")
-    res.exit_status.must_equal(0)
+    _(res.stdout).must_equal("hello world\n")
+    _(res.stderr).must_equal("")
+    _(res.exit_status).must_equal(0)
   end
 
   it "can echo commands to stderr" do
     # TODO: Specinfra often fails on this test.
     # Fix and re-enable it.
     res = backend.run_command(">&2 echo hello world")
-    res.stdout.must_equal("")
-    res.stderr.must_equal("hello world\n")
-    res.exit_status.must_equal(0)
+    _(res.stdout).must_equal("")
+    _(res.stderr).must_equal("hello world\n")
+    _(res.exit_status).must_equal(0)
   end
 
   it "prints a correct exit status" do
     res = backend.run_command("exit 123")
-    res.stdout.must_equal("")
-    res.stderr.must_equal("")
-    res.exit_status.must_equal(123)
+    _(res.stdout).must_equal("")
+    _(res.stderr).must_equal("")
+    _(res.exit_status).must_equal(123)
   end
 end

--- a/test/unit/extras/command_wrapper_test.rb
+++ b/test/unit/extras/command_wrapper_test.rb
@@ -19,38 +19,38 @@ describe "linux command" do
   describe "sudo wrapping" do
     it "wraps commands in sudo" do
       lc = cls.new(backend, { sudo: true })
-      lc.run(cmd).must_equal "sudo #{cmd}"
+      _(lc.run(cmd)).must_equal "sudo #{cmd}"
     end
 
     it "doesnt wrap commands in sudo if user == root" do
       lc = cls.new(backend, { sudo: true, user: "root" })
-      lc.run(cmd).must_equal cmd
+      _(lc.run(cmd)).must_equal cmd
     end
 
     it "wraps commands in sudo with all options" do
       opts = rand.to_s
       lc = cls.new(backend, { sudo: true, sudo_options: opts })
-      lc.run(cmd).must_equal "sudo #{opts} #{cmd}"
+      _(lc.run(cmd)).must_equal "sudo #{opts} #{cmd}"
     end
 
     it "runs commands in sudo with password" do
       pw = rand.to_s
       lc = cls.new(backend, { sudo: true, sudo_password: pw })
       bpw = Base64.strict_encode64(pw + "\n")
-      lc.run(cmd).must_equal "echo #{bpw} | base64 --decode | sudo -S #{cmd}"
+      _(lc.run(cmd)).must_equal "echo #{bpw} | base64 --decode | sudo -S #{cmd}"
     end
 
     it "wraps commands in sudo_command instead of sudo" do
       sudo_command = rand.to_s
       lc = cls.new(backend, { sudo: true, sudo_command: sudo_command })
-      lc.run(cmd).must_equal "#{sudo_command} #{cmd}"
+      _(lc.run(cmd)).must_equal "#{sudo_command} #{cmd}"
     end
 
     it "wraps commands in sudo_command with all options" do
       opts = rand.to_s
       sudo_command = rand.to_s
       lc = cls.new(backend, { sudo: true, sudo_command: sudo_command, sudo_options: opts })
-      lc.run(cmd).must_equal "#{sudo_command} #{opts} #{cmd}"
+      _(lc.run(cmd)).must_equal "#{sudo_command} #{opts} #{cmd}"
     end
 
     it "runs commands in sudo_command with password" do
@@ -58,7 +58,7 @@ describe "linux command" do
       sudo_command = rand.to_s
       lc = cls.new(backend, { sudo: true, sudo_command: sudo_command, sudo_password: pw })
       bpw = Base64.strict_encode64(pw + "\n")
-      lc.run(cmd).must_equal "echo #{bpw} | base64 --decode | #{sudo_command} -S #{cmd}"
+      _(lc.run(cmd)).must_equal "echo #{bpw} | base64 --decode | #{sudo_command} -S #{cmd}"
     end
   end
 
@@ -66,13 +66,13 @@ describe "linux command" do
     it "wraps commands in a default shell with login" do
       lc = cls.new(backend, { shell: true, shell_options: "--login" })
       bcmd = Base64.strict_encode64(cmd)
-      lc.run(cmd).must_equal "echo #{bcmd} | base64 --decode | $SHELL --login"
+      _(lc.run(cmd)).must_equal "echo #{bcmd} | base64 --decode | $SHELL --login"
     end
 
     it "wraps sudo commands in a default shell with login" do
       lc = cls.new(backend, { sudo: true, shell: true, shell_options: "--login" })
       bcmd = Base64.strict_encode64("sudo #{cmd}")
-      lc.run(cmd).must_equal "echo #{bcmd} | base64 --decode | $SHELL --login"
+      _(lc.run(cmd)).must_equal "echo #{bcmd} | base64 --decode | $SHELL --login"
     end
 
     it "wraps sudo commands and sudo passwords in a default shell with login" do
@@ -80,30 +80,30 @@ describe "linux command" do
       lc = cls.new(backend, { sudo: true, sudo_password: pw, shell: true, shell_options: "--login" })
       bpw = Base64.strict_encode64(pw + "\n")
       bcmd = Base64.strict_encode64("echo #{bpw} | base64 --decode | sudo -S #{cmd}")
-      lc.run(cmd).must_equal "echo #{bcmd} | base64 --decode | $SHELL --login"
+      _(lc.run(cmd)).must_equal "echo #{bcmd} | base64 --decode | $SHELL --login"
     end
 
     it "wraps commands in a default shell when shell is true" do
       lc = cls.new(backend, { shell: true })
       bcmd = Base64.strict_encode64(cmd)
-      lc.run(cmd).must_equal "echo #{bcmd} | base64 --decode | $SHELL"
+      _(lc.run(cmd)).must_equal "echo #{bcmd} | base64 --decode | $SHELL"
     end
 
     it "doesnt wrap commands in a shell when shell is false" do
       lc = cls.new(backend, { shell: false })
-      lc.run(cmd).must_equal cmd
+      _(lc.run(cmd)).must_equal cmd
     end
 
     it "wraps commands in a `shell` instead of default shell" do
       lc = cls.new(backend, { shell: true, shell_command: "/bin/bash" })
       bcmd = Base64.strict_encode64(cmd)
-      lc.run(cmd).must_equal "echo #{bcmd} | base64 --decode | /bin/bash"
+      _(lc.run(cmd)).must_equal "echo #{bcmd} | base64 --decode | /bin/bash"
     end
 
     it "wraps commands in a default shell with login" do
       lc = cls.new(backend, { shell: true, shell_command: "/bin/bash", shell_options: "--login" })
       bcmd = Base64.strict_encode64(cmd)
-      lc.run(cmd).must_equal "echo #{bcmd} | base64 --decode | /bin/bash --login"
+      _(lc.run(cmd)).must_equal "echo #{bcmd} | base64 --decode | /bin/bash --login"
     end
   end
 end
@@ -122,7 +122,7 @@ describe "windows command" do
       lc = cls.new(backend, { shell: true })
       wcmd = "$ProgressPreference='SilentlyContinue';" + cmd
       bcmd = Base64.strict_encode64(wcmd.encode("UTF-16LE", "UTF-8"))
-      lc.run(cmd).must_equal "powershell -NoProfile -EncodedCommand #{bcmd}"
+      _(lc.run(cmd)).must_equal "powershell -NoProfile -EncodedCommand #{bcmd}"
     end
   end
 end

--- a/test/unit/extras/stat_test.rb
+++ b/test/unit/extras/stat_test.rb
@@ -9,35 +9,35 @@ describe "stat" do
     let(:random_mode) { (rand * 1000).to_i }
 
     it "detects :unknown types" do
-      cls.find_type(random_mode).must_equal :unknown
+      _(cls.find_type(random_mode)).must_equal :unknown
     end
 
     it "detects sockets" do
-      cls.find_type(00140755).must_equal :socket
+      _(cls.find_type(00140755)).must_equal :socket
     end
 
     it "detects symlinks" do
-      cls.find_type(00120755).must_equal :symlink
+      _(cls.find_type(00120755)).must_equal :symlink
     end
 
     it "detects files" do
-      cls.find_type(00100755).must_equal :file
+      _(cls.find_type(00100755)).must_equal :file
     end
 
     it "detects block devices" do
-      cls.find_type(00060755).must_equal :block_device
+      _(cls.find_type(00060755)).must_equal :block_device
     end
 
     it "detects directories" do
-      cls.find_type(00040755).must_equal :directory
+      _(cls.find_type(00040755)).must_equal :directory
     end
 
     it "detects character devices" do
-      cls.find_type(00020755).must_equal :character_device
+      _(cls.find_type(00020755)).must_equal :character_device
     end
 
     it "detects pipes" do
-      cls.find_type(00010755).must_equal :pipe
+      _(cls.find_type(00010755)).must_equal :pipe
     end
   end
 
@@ -53,11 +53,11 @@ describe "stat" do
     end
 
     it "ignores wrong stat results" do
-      cls.linux_stat("/path", backend, false).must_equal({})
+      _(cls.linux_stat("/path", backend, false)).must_equal({})
     end
 
     it "reads correct stat results" do
-      cls.linux_stat("/path-stat", backend, false).must_equal({
+      _(cls.linux_stat("/path-stat", backend, false)).must_equal({
         type: :directory,
         mode: 01777,
         owner: "root",
@@ -83,11 +83,11 @@ describe "stat" do
     end
 
     it "ignores wrong stat results" do
-      cls.linux_stat("/path", backend, false).must_equal({})
+      _(cls.linux_stat("/path", backend, false)).must_equal({})
     end
 
     it "reads correct stat results" do
-      cls.linux_stat("/path-stat", backend, false).must_equal({
+      _(cls.linux_stat("/path-stat", backend, false)).must_equal({
         type: :directory,
         mode: 01777,
         owner: "root",
@@ -113,11 +113,11 @@ describe "stat" do
     end
 
     it "ignores wrong stat results" do
-      cls.linux_stat("/path", backend, false).must_equal({})
+      _(cls.linux_stat("/path", backend, false)).must_equal({})
     end
 
     it "reads correct stat results" do
-      cls.linux_stat("/path-stat", backend, false).must_equal({
+      _(cls.linux_stat("/path-stat", backend, false)).must_equal({
         type: :directory,
         mode: 01777,
         owner: "root",
@@ -139,7 +139,7 @@ describe "stat" do
       res.expect :stdout, "....."
       res.expect :exit_status, 1
       backend.expect :run_command, res, [String]
-      cls.bsd_stat("/path", backend, false).must_equal({})
+      _(cls.bsd_stat("/path", backend, false)).must_equal({})
     end
 
     it "ignores wrong stat results" do
@@ -147,7 +147,7 @@ describe "stat" do
       res.expect :stdout, ""
       res.expect :exit_status, 0
       backend.expect :run_command, res, [String]
-      cls.bsd_stat("/path", backend, false).must_equal({})
+      _(cls.bsd_stat("/path", backend, false)).must_equal({})
     end
 
     it "reads correct stat results" do
@@ -155,7 +155,7 @@ describe "stat" do
       res.expect :stdout, "360\n41777\nroot\n0\nrootz\n1\n1444520846\n1444522445"
       res.expect :exit_status, 0
       backend.expect :run_command, res, [String]
-      cls.bsd_stat("/path", backend, false).must_equal({
+      _(cls.bsd_stat("/path", backend, false)).must_equal({
         type: :directory,
         mode: 01777,
         owner: "root",
@@ -177,7 +177,7 @@ describe "stat" do
       res.expect :stdout, "....."
       res.expect :exit_status, 1
       backend.expect :run_command, res, [String]
-      cls.aix_stat("/path", backend, false).must_equal({})
+      _(cls.aix_stat("/path", backend, false)).must_equal({})
     end
 
     it "ignores wrong stat results" do
@@ -185,7 +185,7 @@ describe "stat" do
       res.expect :stdout, ""
       res.expect :exit_status, 0
       backend.expect :run_command, res, [String]
-      cls.aix_stat("/path", backend, false).must_equal({})
+      _(cls.aix_stat("/path", backend, false)).must_equal({})
     end
 
     it "reads correct stat results" do
@@ -193,7 +193,7 @@ describe "stat" do
       res.expect :stdout, "41777\nroot\n0\nrootz\n1\n1444522445\n360\n"
       res.expect :exit_status, 0
       backend.expect :run_command, res, [String]
-      cls.aix_stat("/path", backend, false).must_equal({
+      _(cls.aix_stat("/path", backend, false)).must_equal({
         type: :directory,
         mode: 01777,
         owner: "root",

--- a/test/unit/file/local/unix_test.rb
+++ b/test/unit/file/local/unix_test.rb
@@ -14,7 +14,7 @@ describe Train::File::Local::Unix do
 
   it "checks a mounted path" do
     backend.mock_command("mount | grep -- ' on /mount/path '", rand.to_s)
-    cls.new(backend, "/mount/path").mounted?.must_equal true
+    _(cls.new(backend, "/mount/path").mounted?).must_equal true
   end
 
   describe "file metadata" do
@@ -44,55 +44,55 @@ describe Train::File::Local::Unix do
 
     it "recognizes type" do
       meta_stub :stat, statres do
-        connection.file(rand.to_s).stat[:type].must_equal :socket
+        _(connection.file(rand.to_s).stat[:type]).must_equal :socket
       end
     end
 
     it "recognizes mode" do
       meta_stub :stat, statres do
-        connection.file(rand.to_s).stat[:mode].must_equal 00755
+        _(connection.file(rand.to_s).stat[:mode]).must_equal 00755
       end
     end
 
     it "recognizes mtime" do
       meta_stub :stat, statres do
-        connection.file(rand.to_s).stat[:mtime].must_equal statres.mtime
+        _(connection.file(rand.to_s).stat[:mtime]).must_equal statres.mtime
       end
     end
 
     it "recognizes size" do
       meta_stub :stat, statres do
-        connection.file(rand.to_s).stat[:size].must_equal statres.size
+        _(connection.file(rand.to_s).stat[:size]).must_equal statres.size
       end
     end
 
     it "recognizes uid" do
       meta_stub :stat, statres do
-        connection.file(rand.to_s).stat[:uid].must_equal uid
+        _(connection.file(rand.to_s).stat[:uid]).must_equal uid
       end
     end
 
     it "recognizes gid" do
       meta_stub :stat, statres do
-        connection.file(rand.to_s).stat[:gid].must_equal gid
+        _(connection.file(rand.to_s).stat[:gid]).must_equal gid
       end
     end
 
     it "recognizes owner" do
       meta_stub :stat, statres do
-        connection.file(rand.to_s).owner.must_equal "owner"
+        _(connection.file(rand.to_s).owner).must_equal "owner"
       end
     end
 
     it "recognizes group" do
       meta_stub :stat, statres do
-        connection.file(rand.to_s).group.must_equal "group"
+        _(connection.file(rand.to_s).group).must_equal "group"
       end
     end
 
     it "grouped_into" do
       meta_stub :stat, statres do
-        connection.file(rand.to_s).grouped_into?("group").must_equal true
+        _(connection.file(rand.to_s).grouped_into?("group")).must_equal true
       end
     end
 
@@ -101,7 +101,7 @@ describe Train::File::Local::Unix do
         label = rand.to_s
         res = Train::Extras::CommandResult.new(label, nil, 0)
         connection.stub :run_command, res do
-          connection.file(rand.to_s).selinux_label.must_equal label
+          _(connection.file(rand.to_s).selinux_label).must_equal label
         end
       end
     end
@@ -111,7 +111,7 @@ describe Train::File::Local::Unix do
         label = rand.to_s
         res = Train::Extras::CommandResult.new(label, nil, 0)
         connection.stub :run_command, res do
-          connection.file(rand.to_s).source.selinux_label.must_equal label
+          _(connection.file(rand.to_s).source.selinux_label).must_equal label
         end
       end
     end
@@ -127,27 +127,27 @@ describe Train::File::Local::Unix do
     end
 
     it "check owner mode calculation" do
-      file_tester.unix_mode_mask("owner", "x").must_equal 0100
-      file_tester.unix_mode_mask("owner", "w").must_equal 0200
-      file_tester.unix_mode_mask("owner", "r").must_equal 0400
+      _(file_tester.unix_mode_mask("owner", "x")).must_equal 0100
+      _(file_tester.unix_mode_mask("owner", "w")).must_equal 0200
+      _(file_tester.unix_mode_mask("owner", "r")).must_equal 0400
     end
 
     it "check group mode calculation" do
-      file_tester.unix_mode_mask("group", "x").must_equal 0010
-      file_tester.unix_mode_mask("group", "w").must_equal 0020
-      file_tester.unix_mode_mask("group", "r").must_equal 0040
+      _(file_tester.unix_mode_mask("group", "x")).must_equal 0010
+      _(file_tester.unix_mode_mask("group", "w")).must_equal 0020
+      _(file_tester.unix_mode_mask("group", "r")).must_equal 0040
     end
 
     it "check other mode calculation" do
-      file_tester.unix_mode_mask("other", "x").must_equal 0001
-      file_tester.unix_mode_mask("other", "w").must_equal 0002
-      file_tester.unix_mode_mask("other", "r").must_equal 0004
+      _(file_tester.unix_mode_mask("other", "x")).must_equal 0001
+      _(file_tester.unix_mode_mask("other", "w")).must_equal 0002
+      _(file_tester.unix_mode_mask("other", "r")).must_equal 0004
     end
 
     it "check all mode calculation" do
-      file_tester.unix_mode_mask("all", "x").must_equal 0111
-      file_tester.unix_mode_mask("all", "w").must_equal 0222
-      file_tester.unix_mode_mask("all", "r").must_equal 0444
+      _(file_tester.unix_mode_mask("all", "x")).must_equal 0111
+      _(file_tester.unix_mode_mask("all", "w")).must_equal 0222
+      _(file_tester.unix_mode_mask("all", "r")).must_equal 0444
     end
   end
 
@@ -164,20 +164,20 @@ describe Train::File::Local::Unix do
     it "defaults to a Ruby based checksum if other methods fail" do
       backend.mock_command("md5sum /tmp/testfile", "", "", 1)
       Digest::MD5.expects(:new).returns(ruby_md5_mock)
-      cls.new(backend, "/tmp/testfile").md5sum.must_equal md5_checksum
+      _(cls.new(backend, "/tmp/testfile").md5sum).must_equal md5_checksum
     end
 
     it "calculates the correct md5sum on the `linux` platform family" do
       output = "#{md5_checksum} /tmp/testfile"
       backend.mock_command("md5sum /tmp/testfile", output)
-      cls.new(backend, "/tmp/testfile").md5sum.must_equal md5_checksum
+      _(cls.new(backend, "/tmp/testfile").md5sum).must_equal md5_checksum
     end
 
     it "calculates the correct md5sum on the `darwin` platform family" do
       output = "#{md5_checksum} /tmp/testfile"
       backend.mock_os(family: "darwin")
       backend.mock_command("md5 -r /tmp/testfile", output)
-      cls.new(backend, "/tmp/testfile").md5sum.must_equal md5_checksum
+      _(cls.new(backend, "/tmp/testfile").md5sum).must_equal md5_checksum
     end
 
     it "calculates the correct md5sum on the `solaris` platform family" do
@@ -185,7 +185,7 @@ describe Train::File::Local::Unix do
       output = "#{md5_checksum}"
       backend.mock_os(family: "solaris")
       backend.mock_command("digest -a md5 /tmp/testfile", output)
-      cls.new(backend, "/tmp/testfile").md5sum.must_equal md5_checksum
+      _(cls.new(backend, "/tmp/testfile").md5sum).must_equal md5_checksum
     end
   end
 
@@ -204,20 +204,20 @@ describe Train::File::Local::Unix do
     it "defaults to a Ruby based checksum if other methods fail" do
       backend.mock_command("sha256sum /tmp/testfile", "", "", 1)
       Digest::SHA256.expects(:new).returns(ruby_sha256_mock)
-      cls.new(backend, "/tmp/testfile").sha256sum.must_equal sha256_checksum
+      _(cls.new(backend, "/tmp/testfile").sha256sum).must_equal sha256_checksum
     end
 
     it "calculates the correct sha256sum on the `linux` platform family" do
       output = "#{sha256_checksum} /tmp/testfile"
       backend.mock_command("sha256sum /tmp/testfile", output)
-      cls.new(backend, "/tmp/testfile").sha256sum.must_equal sha256_checksum
+      _(cls.new(backend, "/tmp/testfile").sha256sum).must_equal sha256_checksum
     end
 
     it "calculates the correct sha256sum on the `darwin` platform family" do
       output = "#{sha256_checksum} /tmp/testfile"
       backend.mock_os(family: "darwin")
       backend.mock_command("shasum -a 256 /tmp/testfile", output)
-      cls.new(backend, "/tmp/testfile").sha256sum.must_equal sha256_checksum
+      _(cls.new(backend, "/tmp/testfile").sha256sum).must_equal sha256_checksum
     end
 
     it "calculates the correct sha256sum on the `solaris` platform family" do
@@ -225,7 +225,7 @@ describe Train::File::Local::Unix do
       output = "#{sha256_checksum}"
       backend.mock_os(family: "solaris")
       backend.mock_command("digest -a sha256 /tmp/testfile", output)
-      cls.new(backend, "/tmp/testfile").sha256sum.must_equal sha256_checksum
+      _(cls.new(backend, "/tmp/testfile").sha256sum).must_equal sha256_checksum
     end
   end
 end

--- a/test/unit/file/local/windows_test.rb
+++ b/test/unit/file/local/windows_test.rb
@@ -14,29 +14,29 @@ describe "file common" do
 
   it "check escaping of invalid chars in path" do
     wf = cls.new(nil, nil)
-    wf.sanitize_filename("c:/test") .must_equal "c:/test"
-    wf.sanitize_filename("c:/test directory") .must_equal "c:/test directory"
+    _(wf.sanitize_filename("c:/test") ).must_equal "c:/test"
+    _(wf.sanitize_filename("c:/test directory") ).must_equal "c:/test directory"
     %w{ < > " * ?}.each do |char|
-      wf.sanitize_filename("c:/test#{char}directory") .must_equal "c:/testdirectory"
+      _(wf.sanitize_filename("c:/test#{char}directory") ).must_equal "c:/testdirectory"
     end
   end
 
   it "returns file version" do
     out = rand.to_s
     backend.mock_command('[System.Diagnostics.FileVersionInfo]::GetVersionInfo("path").FileVersion', out)
-    cls.new(backend, "path").file_version.must_equal out
+    _(cls.new(backend, "path").file_version).must_equal out
   end
 
   it "returns product version" do
     out = rand.to_s
     backend.mock_command('[System.Diagnostics.FileVersionInfo]::GetVersionInfo("path").FileVersion', out)
-    cls.new(backend, "path").file_version.must_equal out
+    _(cls.new(backend, "path").file_version).must_equal out
   end
 
   it "returns owner of file" do
     out = rand.to_s
     backend.mock_command('Get-Acl "path" | select -expand Owner', out)
-    cls.new(backend, "path").owner.must_equal out
+    _(cls.new(backend, "path").owner).must_equal out
   end
 
   describe "#md5sum" do
@@ -53,7 +53,7 @@ describe "file common" do
     it "defaults to a Ruby based checksum if other methods fail" do
       backend.mock_command("CertUtil -hashfile #{filepath} MD5", "", "", 1)
       Digest::MD5.expects(:new).returns(ruby_md5_mock)
-      cls.new(backend, "/tmp/testfile").md5sum.must_equal md5_checksum
+      _(cls.new(backend, "/tmp/testfile").md5sum).must_equal md5_checksum
     end
 
     it "calculates the correct md5sum on the `windows` platform family" do
@@ -64,7 +64,7 @@ describe "file common" do
       EOC
 
       backend.mock_command("CertUtil -hashfile #{filepath} MD5", output)
-      cls.new(backend, filepath).md5sum.must_equal md5_checksum
+      _(cls.new(backend, filepath).md5sum).must_equal md5_checksum
     end
   end
 
@@ -84,7 +84,7 @@ describe "file common" do
     it "defaults to a Ruby based checksum if other methods fail" do
       backend.mock_command('CertUtil -hashfile #{filepath} SHA256', "", "", 1)
       Digest::SHA256.expects(:new).returns(ruby_sha256_mock)
-      cls.new(backend, "/tmp/testfile").sha256sum.must_equal sha256_checksum
+      _(cls.new(backend, "/tmp/testfile").sha256sum).must_equal sha256_checksum
     end
 
     it "calculates the correct sha256sum on the `windows` platform family" do
@@ -95,7 +95,7 @@ describe "file common" do
       EOC
 
       backend.mock_command("CertUtil -hashfile #{filepath} SHA256", output)
-      cls.new(backend, filepath).sha256sum.must_equal sha256_checksum
+      _(cls.new(backend, filepath).sha256sum).must_equal sha256_checksum
     end
   end
 end

--- a/test/unit/file/local_test.rb
+++ b/test/unit/file/local_test.rb
@@ -8,7 +8,7 @@ describe Train::File::Local do
   it "gets file contents" do
     res = rand.to_s
     File.stub :read, res do
-      connection.file(rand.to_s).content.must_equal(res)
+      _(connection.file(rand.to_s).content).must_equal(res)
     end
   end
 
@@ -24,7 +24,7 @@ describe Train::File::Local do
   }.each do |method, file_method|
     it "checks if file is a #{method}" do
       File.stub file_method.to_sym, true do
-        connection.file(rand.to_s).method(method.to_sym).call.must_equal(true)
+        _(connection.file(rand.to_s).method(method.to_sym).call).must_equal(true)
       end
     end
   end
@@ -32,49 +32,49 @@ describe Train::File::Local do
   describe "#type" do
     it "returns the type block_device if it is block device" do
       File.stub :ftype, "blockSpecial" do
-        connection.file(rand.to_s).type.must_equal :block_device
+        _(connection.file(rand.to_s).type).must_equal :block_device
       end
     end
 
     it "returns the type character_device if it is character device" do
       File.stub :ftype, "characterSpecial" do
-        connection.file(rand.to_s).type.must_equal :character_device
+        _(connection.file(rand.to_s).type).must_equal :character_device
       end
     end
 
     it "returns the type symlink if it is symlink" do
       File.stub :ftype, "link" do
-        connection.file(rand.to_s).type.must_equal :symlink
+        _(connection.file(rand.to_s).type).must_equal :symlink
       end
     end
 
     it "returns the type file if it is file" do
       File.stub :ftype, "file" do
-        connection.file(rand.to_s).type.must_equal :file
+        _(connection.file(rand.to_s).type).must_equal :file
       end
     end
 
     it "returns the type directory if it is block directory" do
       File.stub :ftype, "directory" do
-        connection.file(rand.to_s).type.must_equal :directory
+        _(connection.file(rand.to_s).type).must_equal :directory
       end
     end
 
     it "returns the type pipe if it is pipe" do
       File.stub :ftype, "fifo" do
-        connection.file(rand.to_s).type.must_equal :pipe
+        _(connection.file(rand.to_s).type).must_equal :pipe
       end
     end
 
     it "returns the type socket if it is socket" do
       File.stub :ftype, "socket" do
-        connection.file(rand.to_s).type.must_equal :socket
+        _(connection.file(rand.to_s).type).must_equal :socket
       end
     end
 
     it "returns the unknown if not known" do
       File.stub :ftype, "unknown" do
-        connection.file(rand.to_s).type.must_equal :unknown
+        _(connection.file(rand.to_s).type).must_equal :unknown
       end
     end
   end
@@ -83,7 +83,7 @@ describe Train::File::Local do
     it "returns the path if it is not a symlink" do
       File.stub :symlink?, false do
         filename = rand.to_s
-        connection.file(filename).path.must_equal filename
+        _(connection.file(filename).path).must_equal filename
       end
     end
 
@@ -91,7 +91,7 @@ describe Train::File::Local do
       File.stub :symlink?, true do
         file_obj = connection.file(rand.to_s)
         file_obj.stub :link_path, "/path/to/resolved_link" do
-          file_obj.path.must_equal "/path/to/resolved_link"
+          _(file_obj.path).must_equal "/path/to/resolved_link"
         end
       end
     end
@@ -102,7 +102,7 @@ describe Train::File::Local do
       out = rand.to_s
       File.stub :realpath, out do
         File.stub :symlink?, true do
-          connection.file(rand.to_s).link_path.must_equal out
+          _(connection.file(rand.to_s).link_path).must_equal out
         end
       end
     end
@@ -113,7 +113,7 @@ describe Train::File::Local do
       out = rand.to_s
       File.stub :readlink, out do
         File.stub :symlink?, true do
-          connection.file(rand.to_s).shallow_link_path.must_equal out
+          _(connection.file(rand.to_s).shallow_link_path).must_equal out
         end
       end
     end

--- a/test/unit/file/remote/aix_test.rb
+++ b/test/unit/file/remote/aix_test.rb
@@ -14,21 +14,21 @@ describe Train::File::Remote::Aix do
   it "returns a nil link_path if the object is not a symlink" do
     file = cls.new(backend, "path")
     file.stubs(:symlink?).returns(false)
-    file.link_path.must_be_nil
+    _(file.link_path).must_be_nil
   end
 
   it "returns a correct link_path" do
     file = cls.new(backend, "path")
     file.stubs(:symlink?).returns(true)
     backend.mock_command("perl -e 'print readlink shift' path", "our_link_path")
-    file.link_path.must_equal "our_link_path"
+    _(file.link_path).must_equal "our_link_path"
   end
 
   it "returns a correct shallow_link_path" do
     file = cls.new(backend, "path")
     file.stubs(:symlink?).returns(true)
     backend.mock_command("perl -e 'print readlink shift' path", "our_link_path")
-    file.link_path.must_equal "our_link_path"
+    _(file.link_path).must_equal "our_link_path"
   end
 
   describe "#md5sum" do
@@ -44,13 +44,13 @@ describe Train::File::Remote::Aix do
     it "defaults to a Ruby based checksum if other methods fail" do
       backend.mock_command("md5sum /tmp/testfile", "", "", 1)
       Digest::MD5.expects(:new).returns(ruby_md5_mock)
-      cls.new(backend, "/tmp/testfile").md5sum.must_equal md5_checksum
+      _(cls.new(backend, "/tmp/testfile").md5sum).must_equal md5_checksum
     end
 
     it "calculates the correct md5sum on the `aix` platform family" do
       output = "#{md5_checksum} /tmp/testfile"
       backend.mock_command("md5sum /tmp/testfile", output)
-      cls.new(backend, "/tmp/testfile").md5sum.must_equal md5_checksum
+      _(cls.new(backend, "/tmp/testfile").md5sum).must_equal md5_checksum
     end
   end
 
@@ -69,13 +69,13 @@ describe Train::File::Remote::Aix do
     it "defaults to a Ruby based checksum if other methods fail" do
       backend.mock_command("sha256sum /tmp/testfile", "", "", 1)
       Digest::SHA256.expects(:new).returns(ruby_sha256_mock)
-      cls.new(backend, "/tmp/testfile").sha256sum.must_equal sha256_checksum
+      _(cls.new(backend, "/tmp/testfile").sha256sum).must_equal sha256_checksum
     end
 
     it "calculates the correct sha256sum on the `aix` platform family" do
       output = "#{sha256_checksum} /tmp/testfile"
       backend.mock_command("sha256sum /tmp/testfile", output)
-      cls.new(backend, "/tmp/testfile").sha256sum.must_equal sha256_checksum
+      _(cls.new(backend, "/tmp/testfile").sha256sum).must_equal sha256_checksum
     end
   end
 end

--- a/test/unit/file/remote/linux_test.rb
+++ b/test/unit/file/remote/linux_test.rb
@@ -19,74 +19,74 @@ describe Train::File::Remote::Linux do
   end
 
   it "works on nil path" do
-    cls.new(backend, nil).path.must_equal ""
+    _(cls.new(backend, nil).path).must_equal ""
   end
 
   it "provides the full path" do
-    cls.new(backend, "/dir/file").path.must_equal "/dir/file"
+    _(cls.new(backend, "/dir/file").path).must_equal "/dir/file"
   end
 
   it "provides the basename to a unix path" do
-    cls.new(backend, "/dir/file").basename.must_equal "file"
+    _(cls.new(backend, "/dir/file").basename).must_equal "file"
   end
 
   it "reads file contents" do
     out = rand.to_s
     backend.mock_command("cat path || echo -n", out)
-    cls.new(backend, "path").content.must_equal out
+    _(cls.new(backend, "path").content).must_equal out
   end
 
   it "reads file contents" do
     backend.mock_command("cat path || echo -n", "")
     mock_stat("-L path", "", "some error...", 1)
-    cls.new(backend, "path").content.must_be_nil
+    _(cls.new(backend, "path").content).must_be_nil
   end
 
   it "reads file contents" do
     out = rand.to_s
     backend.mock_command('cat /spaced\\ path || echo -n', out)
-    cls.new(backend, "/spaced path").content.must_equal out
+    _(cls.new(backend, "/spaced path").content).must_equal out
   end
 
   it "checks for file existance" do
     backend.mock_command("test -e path", true)
-    cls.new(backend, "path").exist?.must_equal true
+    _(cls.new(backend, "path").exist?).must_equal true
   end
 
   it "checks for file existance" do
     backend.mock_command("test -e path", nil, nil, 1)
-    cls.new(backend, "path").exist?.must_equal false
+    _(cls.new(backend, "path").exist?).must_equal false
   end
 
   it "retrieves the link path via #path()" do
     out = rand.to_s
     mock_stat("path", "13\na1ff\nz\n1001\nz\n1001\n1444573475\n1444573475\n?")
     backend.mock_command("readlink -n path -f", out)
-    cls.new(backend, "path").path.must_equal File.join(Dir.pwd, out)
+    _(cls.new(backend, "path").path).must_equal File.join(Dir.pwd, out)
   end
 
   it "retrieves the link path" do
     out = rand.to_s
     mock_stat("path", "13\na1ff\nz\n1001\nz\n1001\n1444573475\n1444573475\n?")
     backend.mock_command("readlink -n path -f", out)
-    cls.new(backend, "path").link_path.must_equal File.join(Dir.pwd, out)
+    _(cls.new(backend, "path").link_path).must_equal File.join(Dir.pwd, out)
   end
 
   it "provide the source path" do
-    cls.new(backend, "path").source_path.must_equal "path"
+    _(cls.new(backend, "path").source_path).must_equal "path"
   end
 
   it "checks a mounted path" do
     backend.mock_command("mount | grep -- ' on /mount/path '", rand.to_s)
-    cls.new(backend, "/mount/path").mounted?.must_equal true
+    _(cls.new(backend, "/mount/path").mounted?).must_equal true
   end
 
   it "has nil product version" do
-    cls.new(backend, "path").product_version.must_be_nil
+    _(cls.new(backend, "path").product_version).must_be_nil
   end
 
   it "has nil file version" do
-    cls.new(backend, "path").file_version.must_be_nil
+    _(cls.new(backend, "path").file_version).must_be_nil
   end
 
   describe "stat on a file" do
@@ -94,39 +94,39 @@ describe Train::File::Remote::Linux do
     let(:f) { cls.new(backend, "path") }
 
     it "retrieves the file type" do
-      f.type.must_equal :symlink
+      _(f.type).must_equal :symlink
     end
 
     it "retrieves the file mode" do
-      f.mode.must_equal 00777
+      _(f.mode).must_equal 00777
     end
 
     it "retrieves the file owner" do
-      f.owner.must_equal "z"
+      _(f.owner).must_equal "z"
     end
 
     it "retrieves the file uid" do
-      f.uid.must_equal 1001
+      _(f.uid).must_equal 1001
     end
 
     it "retrieves the file group" do
-      f.group.must_equal "z2"
+      _(f.group).must_equal "z2"
     end
 
     it "retrieves the file gid" do
-      f.gid.must_equal 1002
+      _(f.gid).must_equal 1002
     end
 
     it "retrieves the file mtime" do
-      f.mtime.must_equal 1444573475
+      _(f.mtime).must_equal 1444573475
     end
 
     it "retrieves the file size" do
-      f.size.must_equal 13
+      _(f.size).must_equal 13
     end
 
     it "retrieves the file selinux_label" do
-      f.selinux_label.must_equal "labels"
+      _(f.selinux_label).must_equal "labels"
     end
   end
 
@@ -135,39 +135,39 @@ describe Train::File::Remote::Linux do
     let(:f) { cls.new(backend, "path").source }
 
     it "retrieves the file type" do
-      f.type.must_equal :symlink
+      _(f.type).must_equal :symlink
     end
 
     it "retrieves the file mode" do
-      f.mode.must_equal 00777
+      _(f.mode).must_equal 00777
     end
 
     it "retrieves the file owner" do
-      f.owner.must_equal "z"
+      _(f.owner).must_equal "z"
     end
 
     it "retrieves the file uid" do
-      f.uid.must_equal 1001
+      _(f.uid).must_equal 1001
     end
 
     it "retrieves the file group" do
-      f.group.must_equal "z2"
+      _(f.group).must_equal "z2"
     end
 
     it "retrieves the file gid" do
-      f.gid.must_equal 1002
+      _(f.gid).must_equal 1002
     end
 
     it "retrieves the file mtime" do
-      f.mtime.must_equal 1444573475
+      _(f.mtime).must_equal 1444573475
     end
 
     it "retrieves the file size" do
-      f.size.must_equal 13
+      _(f.size).must_equal 13
     end
 
     it "retrieves the file selinux_label" do
-      f.selinux_label.must_equal "labels"
+      _(f.selinux_label).must_equal "labels"
     end
   end
 
@@ -184,13 +184,13 @@ describe Train::File::Remote::Linux do
     it "defaults to a Ruby based checksum if other methods fail" do
       backend.mock_command("md5sum /tmp/testfile", "", "", 1)
       Digest::MD5.expects(:new).returns(ruby_md5_mock)
-      cls.new(backend, "/tmp/testfile").md5sum.must_equal md5_checksum
+      _(cls.new(backend, "/tmp/testfile").md5sum).must_equal md5_checksum
     end
 
     it "calculates the correct md5sum on the `linux` platform family" do
       output = "#{md5_checksum} /tmp/testfile"
       backend.mock_command("md5sum /tmp/testfile", output)
-      cls.new(backend, "/tmp/testfile").md5sum.must_equal md5_checksum
+      _(cls.new(backend, "/tmp/testfile").md5sum).must_equal md5_checksum
     end
   end
 
@@ -209,13 +209,13 @@ describe Train::File::Remote::Linux do
     it "defaults to a Ruby based checksum if other methods fail" do
       backend.mock_command("sha256sum /tmp/testfile", "", "", 1)
       Digest::SHA256.expects(:new).returns(ruby_sha256_mock)
-      cls.new(backend, "/tmp/testfile").sha256sum.must_equal sha256_checksum
+      _(cls.new(backend, "/tmp/testfile").sha256sum).must_equal sha256_checksum
     end
 
     it "calculates the correct sha256sum on the `linux` platform family" do
       output = "#{sha256_checksum} /tmp/testfile"
       backend.mock_command("sha256sum /tmp/testfile", output)
-      cls.new(backend, "/tmp/testfile").sha256sum.must_equal sha256_checksum
+      _(cls.new(backend, "/tmp/testfile").sha256sum).must_equal sha256_checksum
     end
   end
 end

--- a/test/unit/file/remote/qnx_test.rb
+++ b/test/unit/file/remote/qnx_test.rb
@@ -16,29 +16,29 @@ describe Train::File::Remote::Qnx do
     backend.mock_command("cat path", out)
     file = cls.new(backend, "path")
     file.stubs(:exist?).returns(true)
-    file.content.must_equal out
+    _(file.content).must_equal out
   end
 
   it "returns nil contents when the file does not exist" do
     file = cls.new(backend, "path")
     file.stubs(:exist?).returns(false)
-    file.content.must_be_nil
+    _(file.content).must_be_nil
   end
 
   it "returns a file type" do
     backend.mock_command("file path", "blah directory blah")
-    cls.new(backend, "path").type.must_equal :directory
+    _(cls.new(backend, "path").type).must_equal :directory
   end
 
   it "returns a directory type" do
     backend.mock_command("file path", "blah regular file blah")
-    cls.new(backend, "path").type.must_equal :file
+    _(cls.new(backend, "path").type).must_equal :file
   end
 
   it "raises exception for unimplemented methods" do
     file = cls.new(backend, "path")
     %w{mode owner group uid gid mtime size selinux_label link_path mounted stat}.each do |m|
-      proc { file.send(m) }.must_raise NotImplementedError
+      _ { file.send(m) }.must_raise NotImplementedError
     end
   end
 
@@ -55,7 +55,7 @@ describe Train::File::Remote::Qnx do
     it "defaults to a Ruby based checksum if other methods fail" do
       backend.mock_command("md5sum /tmp/testfile", "", "", 1)
       Digest::MD5.expects(:new).returns(ruby_md5_mock)
-      cls.new(backend, "/tmp/testfile").md5sum.must_equal md5_checksum
+      _(cls.new(backend, "/tmp/testfile").md5sum).must_equal md5_checksum
     end
   end
 
@@ -74,7 +74,7 @@ describe Train::File::Remote::Qnx do
     it "defaults to a Ruby based checksum if other methods fail" do
       backend.mock_command("sha256sum /tmp/testfile", "", "", 1)
       Digest::SHA256.expects(:new).returns(ruby_sha256_mock)
-      cls.new(backend, "/tmp/testfile").sha256sum.must_equal sha256_checksum
+      _(cls.new(backend, "/tmp/testfile").sha256sum).must_equal sha256_checksum
     end
   end
 end

--- a/test/unit/file/remote/unix_test.rb
+++ b/test/unit/file/remote/unix_test.rb
@@ -25,27 +25,27 @@ describe Train::File::Remote::Unix do
     let(:fc) { mockup(type: :file) }
 
     it "check owner mode calculation" do
-      fc.unix_mode_mask("owner", "x").must_equal 0100
-      fc.unix_mode_mask("owner", "w").must_equal 0200
-      fc.unix_mode_mask("owner", "r").must_equal 0400
+      _(fc.unix_mode_mask("owner", "x")).must_equal 0100
+      _(fc.unix_mode_mask("owner", "w")).must_equal 0200
+      _(fc.unix_mode_mask("owner", "r")).must_equal 0400
     end
 
     it "check group mode calculation" do
-      fc.unix_mode_mask("group", "x").must_equal 0010
-      fc.unix_mode_mask("group", "w").must_equal 0020
-      fc.unix_mode_mask("group", "r").must_equal 0040
+      _(fc.unix_mode_mask("group", "x")).must_equal 0010
+      _(fc.unix_mode_mask("group", "w")).must_equal 0020
+      _(fc.unix_mode_mask("group", "r")).must_equal 0040
     end
 
     it "check other mode calculation" do
-      fc.unix_mode_mask("other", "x").must_equal 0001
-      fc.unix_mode_mask("other", "w").must_equal 0002
-      fc.unix_mode_mask("other", "r").must_equal 0004
+      _(fc.unix_mode_mask("other", "x")).must_equal 0001
+      _(fc.unix_mode_mask("other", "w")).must_equal 0002
+      _(fc.unix_mode_mask("other", "r")).must_equal 0004
     end
 
     it "check all mode calculation" do
-      fc.unix_mode_mask("all", "x").must_equal 0111
-      fc.unix_mode_mask("all", "w").must_equal 0222
-      fc.unix_mode_mask("all", "r").must_equal 0444
+      _(fc.unix_mode_mask("all", "x")).must_equal 0111
+      _(fc.unix_mode_mask("all", "w")).must_equal 0222
+      _(fc.unix_mode_mask("all", "r")).must_equal 0444
     end
   end
 
@@ -62,14 +62,14 @@ describe Train::File::Remote::Unix do
     it "defaults to a Ruby based checksum if other methods fail" do
       backend.mock_command("md5 -r /tmp/testfile", "", "", 1)
       Digest::MD5.expects(:new).returns(ruby_md5_mock)
-      cls.new(backend, "/tmp/testfile").md5sum.must_equal md5_checksum
+      _(cls.new(backend, "/tmp/testfile").md5sum).must_equal md5_checksum
     end
 
     it "calculates the correct md5sum on the `darwin` platform family" do
       output = "#{md5_checksum} /tmp/testfile"
       backend.mock_os(family: "darwin")
       backend.mock_command("md5 -r /tmp/testfile", output)
-      cls.new(backend, "/tmp/testfile").md5sum.must_equal md5_checksum
+      _(cls.new(backend, "/tmp/testfile").md5sum).must_equal md5_checksum
     end
 
     it "calculates the correct md5sum on the `solaris` platform family" do
@@ -77,7 +77,7 @@ describe Train::File::Remote::Unix do
       output = "#{md5_checksum}"
       backend.mock_os(family: "solaris")
       backend.mock_command("digest -a md5 /tmp/testfile", output)
-      cls.new(backend, "/tmp/testfile").md5sum.must_equal md5_checksum
+      _(cls.new(backend, "/tmp/testfile").md5sum).must_equal md5_checksum
     end
   end
 
@@ -96,14 +96,14 @@ describe Train::File::Remote::Unix do
     it "defaults to a Ruby based checksum if other methods fail" do
       backend.mock_command("shasum -a 256 /tmp/testfile", "", "", 1)
       Digest::SHA256.expects(:new).returns(ruby_sha256_mock)
-      cls.new(backend, "/tmp/testfile").sha256sum.must_equal sha256_checksum
+      _(cls.new(backend, "/tmp/testfile").sha256sum).must_equal sha256_checksum
     end
 
     it "calculates the correct sha256sum on the `darwin` platform family" do
       output = "#{sha256_checksum} /tmp/testfile"
       backend.mock_os(family: "darwin")
       backend.mock_command("shasum -a 256 /tmp/testfile", output)
-      cls.new(backend, "/tmp/testfile").sha256sum.must_equal sha256_checksum
+      _(cls.new(backend, "/tmp/testfile").sha256sum).must_equal sha256_checksum
     end
 
     it "calculates the correct sha256sum on the `solaris` platform family" do
@@ -111,7 +111,7 @@ describe Train::File::Remote::Unix do
       output = "#{sha256_checksum}"
       backend.mock_os(family: "solaris")
       backend.mock_command("digest -a sha256 /tmp/testfile", output)
-      cls.new(backend, "/tmp/testfile").sha256sum.must_equal sha256_checksum
+      _(cls.new(backend, "/tmp/testfile").sha256sum).must_equal sha256_checksum
     end
   end
 end

--- a/test/unit/file/remote/windows_test.rb
+++ b/test/unit/file/remote/windows_test.rb
@@ -24,7 +24,7 @@ describe Train::File::Remote::Windows do
     it "defaults to a Ruby based checksum if other methods fail" do
       backend.mock_command("CertUtil -hashfile #{filepath} MD5", "", "", 1)
       Digest::MD5.expects(:new).returns(ruby_md5_mock)
-      cls.new(backend, "/tmp/testfile").md5sum.must_equal md5_checksum
+      _(cls.new(backend, "/tmp/testfile").md5sum).must_equal md5_checksum
     end
 
     it "calculates the correct md5sum on the `windows` platform family" do
@@ -35,7 +35,7 @@ describe Train::File::Remote::Windows do
       EOC
 
       backend.mock_command("CertUtil -hashfile #{filepath} MD5", output)
-      cls.new(backend, filepath).md5sum.must_equal md5_checksum
+      _(cls.new(backend, filepath).md5sum).must_equal md5_checksum
     end
   end
 
@@ -55,7 +55,7 @@ describe Train::File::Remote::Windows do
     it "defaults to a Ruby based checksum if other methods fail" do
       backend.mock_command("CertUtil -hashfile #{filepath} SHA256", "", "", 1)
       Digest::SHA256.expects(:new).returns(ruby_sha256_mock)
-      cls.new(backend, "/tmp/testfile").sha256sum.must_equal sha256_checksum
+      _(cls.new(backend, "/tmp/testfile").sha256sum).must_equal sha256_checksum
     end
 
     it "calculates the correct sha256sum on the `windows` platform family" do
@@ -66,7 +66,7 @@ describe Train::File::Remote::Windows do
       EOC
 
       backend.mock_command("CertUtil -hashfile #{filepath} SHA256", output)
-      cls.new(backend, filepath).sha256sum.must_equal sha256_checksum
+      _(cls.new(backend, filepath).sha256sum).must_equal sha256_checksum
     end
   end
 end

--- a/test/unit/file/remote_test.rb
+++ b/test/unit/file/remote_test.rb
@@ -20,43 +20,43 @@ describe Train::File::Remote do
     end
 
     it "works with an empty path" do
-      fc("").basename.must_equal ""
+      _(fc("").basename).must_equal ""
     end
 
     it "separates a simple path (defaults to unix mode)" do
-      fc("/dir/file").basename.must_equal "file"
+      _(fc("/dir/file").basename).must_equal "file"
     end
 
     it "separates a simple path (Unix mode)" do
-      fc("/dir/file").basename(nil, "/").must_equal "file"
+      _(fc("/dir/file").basename(nil, "/")).must_equal "file"
     end
 
     it "separates a simple path (Windows mode)" do
-      fc('C:\dir\file').basename(nil, '\\').must_equal "file"
+      _(fc('C:\dir\file').basename(nil, '\\')).must_equal "file"
     end
 
     it "identifies a folder name (Unix mode)" do
-      fc("/dir/file/").basename(nil, "/").must_equal "file"
+      _(fc("/dir/file/").basename(nil, "/")).must_equal "file"
     end
 
     it "identifies a folder name (Windows mode)" do
-      fc('C:\dir\file\\').basename(nil, '\\').must_equal "file"
+      _(fc('C:\dir\file\\').basename(nil, '\\')).must_equal "file"
     end
 
     it "ignores tailing separators (Unix mode)" do
-      fc("/dir/file///").basename(nil, "/").must_equal "file"
+      _(fc("/dir/file///").basename(nil, "/")).must_equal "file"
     end
 
     it "ignores tailing separators (Windows mode)" do
-      fc('C:\dir\file\\\\\\').basename(nil, '\\').must_equal "file"
+      _(fc('C:\dir\file\\\\\\').basename(nil, '\\')).must_equal "file"
     end
 
     it "doesnt work with backward slashes (Unix mode)" do
-      fc('C:\dir\file').basename(nil, "/").must_equal 'C:\\dir\file'
+      _(fc('C:\dir\file').basename(nil, "/")).must_equal 'C:\\dir\file'
     end
 
     it "doesnt work with forward slashes (Windows mode)" do
-      fc("/dir/file").basename(nil, '\\').must_equal "/dir/file"
+      _(fc("/dir/file").basename(nil, '\\')).must_equal "/dir/file"
     end
   end
 end

--- a/test/unit/file_test.rb
+++ b/test/unit/file_test.rb
@@ -15,115 +15,115 @@ describe Train::File do
   end
 
   it "has the default type of unknown" do
-    new_cls.type.must_equal :unknown
+    _(new_cls.type).must_equal :unknown
   end
 
   it "throws Not implemented error for exist?" do
     # proc { Train.validate_backend({ host: rand }) }.must_raise Train::UserError
-    proc { new_cls.exist? }.must_raise NotImplementedError
+    _ { new_cls.exist? }.must_raise NotImplementedError
   end
 
   it "throws Not implemented error for mode" do
-    proc { new_cls.mode }.must_raise NotImplementedError
+    _ { new_cls.mode }.must_raise NotImplementedError
   end
 
   it "throws Not implemented error for owner" do
-    proc { new_cls.owner }.must_raise NotImplementedError
+    _ { new_cls.owner }.must_raise NotImplementedError
   end
 
   it "throws Not implemented error for group" do
-    proc { new_cls.group }.must_raise NotImplementedError
+    _ { new_cls.group }.must_raise NotImplementedError
   end
 
   it "throws Not implemented error for uid" do
-    proc { new_cls.uid }.must_raise NotImplementedError
+    _ { new_cls.uid }.must_raise NotImplementedError
   end
 
   it "throws Not implemented error for gid" do
-    proc { new_cls.gid }.must_raise NotImplementedError
+    _ { new_cls.gid }.must_raise NotImplementedError
   end
 
   it "throws Not implemented error for content" do
-    proc { new_cls.content }.must_raise NotImplementedError
+    _ { new_cls.content }.must_raise NotImplementedError
   end
 
   it "throws Not implemented error for mtime" do
-    proc { new_cls.mtime }.must_raise NotImplementedError
+    _ { new_cls.mtime }.must_raise NotImplementedError
   end
 
   it "throws Not implemented error for size" do
-    proc { new_cls.size }.must_raise NotImplementedError
+    _ { new_cls.size }.must_raise NotImplementedError
   end
 
   it "throws Not implemented error for selinux_label" do
-    proc { new_cls.selinux_label }.must_raise NotImplementedError
+    _ { new_cls.selinux_label }.must_raise NotImplementedError
   end
 
   it "return path of file" do
-    new_cls.path.must_equal("/temp/file")
+    _(new_cls.path).must_equal("/temp/file")
   end
 
   it "set product_version to nil" do
-    new_cls.product_version.must_be_nil
+    _(new_cls.product_version).must_be_nil
   end
 
   it "set product_version to nil" do
-    new_cls.file_version.must_be_nil
+    _(new_cls.file_version).must_be_nil
   end
 
   describe "type" do
     it "recognized type == file" do
       fc = mockup(type: :file)
-      fc.file?.must_equal true
+      _(fc.file?).must_equal true
     end
 
     it "recognized type == block_device" do
       fc = mockup(type: :block_device)
-      fc.block_device?.must_equal true
+      _(fc.block_device?).must_equal true
     end
 
     it "recognized type == character_device" do
       fc = mockup(type: :character_device)
-      fc.character_device?.must_equal true
+      _(fc.character_device?).must_equal true
     end
 
     it "recognized type == socket" do
       fc = mockup(type: :socket)
-      fc.socket?.must_equal true
+      _(fc.socket?).must_equal true
     end
 
     it "recognized type == directory" do
       fc = mockup(type: :directory)
-      fc.directory?.must_equal true
+      _(fc.directory?).must_equal true
     end
 
     it "recognized type == pipe" do
       fc = mockup(type: :pipe)
-      fc.pipe?.must_equal true
+      _(fc.pipe?).must_equal true
     end
 
     it "recognized type == symlink" do
       fc = mockup(type: :symlink)
-      fc.symlink?.must_equal true
+      _(fc.symlink?).must_equal true
     end
   end
 
   describe "version" do
     it "recognized wrong version" do
       fc = mockup(product_version: rand, file_version: rand)
-      fc.version?(rand).must_equal false
+      _(fc.version?(rand)).must_equal false
     end
 
     it "recognized product_version" do
       x = rand
       fc = mockup(product_version: x, file_version: rand)
-      fc.version?(x).must_equal true
+      _(fc.version?(x)).must_equal true
     end
 
     it "recognized file_version" do
       x = rand
       fc = mockup(product_version: rand, file_version: x)
-      fc.version?(x).must_equal true
+      _(fc.version?(x)).must_equal true
     end
   end
 end

--- a/test/unit/platforms/detect/os_common_test.rb
+++ b/test/unit/platforms/detect/os_common_test.rb
@@ -17,12 +17,12 @@ describe "os_common" do
   describe "winrm? check" do
     it "return winrm? true" do
       OsDetectLinuxTester.any_instance.stubs(:backend_name).returns("TrainPlugins::WinRM::Connection")
-      detector.winrm?.must_equal(true)
+      _(detector.winrm?).must_equal(true)
     end
 
     it "return winrm? false when winrm is not loaded" do
       OsDetectLinuxTester.any_instance.stubs(:backend_name).returns("Something::Else")
-      detector.winrm?.must_equal(false)
+      _(detector.winrm?).must_equal(false)
     end
   end
 
@@ -34,14 +34,14 @@ describe "os_common" do
       be.stubs(:run_command).with("test -f /etc/fstab && cat /etc/fstab").returns(output)
       detector.instance_variable_set(:@backend, be)
       detector.instance_variable_set(:@files, {})
-      detector.unix_file_contents("/etc/fstab").must_equal("test")
+      _(detector.unix_file_contents("/etc/fstab")).must_equal("test")
     end
 
     it "return new file contents cached" do
       be = mock("Backend")
       detector.instance_variable_set(:@backend, be)
       detector.instance_variable_set(:@files, { "/etc/profile" => "test" })
-      detector.unix_file_contents("/etc/profile").must_equal("test")
+      _(detector.unix_file_contents("/etc/profile")).must_equal("test")
     end
   end
 
@@ -50,7 +50,7 @@ describe "os_common" do
       be = mock("Backend")
       be.stubs(:run_command).with("test -f /etc/test").returns(mock("Output", exit_status: 0))
       detector.instance_variable_set(:@backend, be)
-      detector.unix_file_exist?("/etc/test").must_equal(true)
+      _(detector.unix_file_exist?("/etc/test")).must_equal(true)
     end
   end
 
@@ -60,7 +60,7 @@ describe "os_common" do
       be.stubs(:run_command).with("uname -m").returns(mock("Output", stdout: "x86_64\n"))
       detector.instance_variable_set(:@backend, be)
       detector.instance_variable_set(:@uname, {})
-      detector.unix_uname_m.must_equal("x86_64")
+      _(detector.unix_uname_m).must_equal("x86_64")
     end
 
     it "uname s call" do
@@ -68,7 +68,7 @@ describe "os_common" do
       be.stubs(:run_command).with("uname -s").returns(mock("Output", stdout: "linux"))
       detector.instance_variable_set(:@backend, be)
       detector.instance_variable_set(:@uname, {})
-      detector.unix_uname_s.must_equal("linux")
+      _(detector.unix_uname_s).must_equal("linux")
     end
 
     it "uname r call" do
@@ -76,7 +76,7 @@ describe "os_common" do
       be.stubs(:run_command).with("uname -r").returns(mock("Output", stdout: "17.0.0\n"))
       detector.instance_variable_set(:@backend, be)
       detector.instance_variable_set(:@uname, {})
-      detector.unix_uname_r.must_equal("17.0.0")
+      _(detector.unix_uname_r).must_equal("17.0.0")
     end
   end
 end

--- a/test/unit/platforms/detect/os_linux_test.rb
+++ b/test/unit/platforms/detect/os_linux_test.rb
@@ -12,29 +12,29 @@ describe "os_linux" do
 
   describe "redhatish_platform cleaner" do
     it "normal redhat" do
-      detector.redhatish_platform("Red Hattter").must_equal("redhat")
+      _(detector.redhatish_platform("Red Hattter")).must_equal("redhat")
     end
 
     it "custom redhat" do
-      detector.redhatish_platform("Centos Pro 11").must_equal("centos")
+      _(detector.redhatish_platform("Centos Pro 11")).must_equal("centos")
     end
   end
 
   describe "redhatish_version cleaner" do
     it "normal rawhide" do
-      detector.redhatish_version("18 (Rawhide) Pro").must_equal("18 (rawhide)")
+      _(detector.redhatish_version("18 (Rawhide) Pro")).must_equal("18 (rawhide)")
     end
 
     it "normal linux" do
-      detector.redhatish_version("derived from Ubuntu Linux 11").must_equal("11")
+      _(detector.redhatish_version("derived from Ubuntu Linux 11")).must_equal("11")
     end
 
     it "amazon linux 2 new release naming schema" do
-      detector.redhatish_version("Amazon Linux release 2 (Karoo)").must_equal("2")
+      _(detector.redhatish_version("Amazon Linux release 2 (Karoo)")).must_equal("2")
     end
 
     it "amazon linux 2 old release naming schema" do
-      detector.redhatish_version("Amazon Linux 2").must_equal("2")
+      _(detector.redhatish_version("Amazon Linux 2")).must_equal("2")
     end
   end
 
@@ -42,13 +42,13 @@ describe "os_linux" do
     it "lsb config" do
       lsb = "DISTRIB_ID=Ubuntu\nDISTRIB_RELEASE=14.06\nDISTRIB_CODENAME=xenial"
       expect = { id: "Ubuntu", release: "14.06", codename: "xenial" }
-      detector.lsb_config(lsb).must_equal(expect)
+      _(detector.lsb_config(lsb)).must_equal(expect)
     end
 
     it "lsb releasel" do
       lsb = "Distributor ID: Ubuntu\nRelease: 14.06\nCodename: xenial"
       expect = { id: "Ubuntu", release: "14.06", codename: "xenial" }
-      detector.lsb_release(lsb).must_equal(expect)
+      _(detector.lsb_release(lsb)).must_equal(expect)
     end
   end
 
@@ -56,7 +56,7 @@ describe "os_linux" do
     describe "when no os-release data is available" do
       it "returns nil" do
         detector.expects(:unix_file_contents).with("/etc/os-release").returns(nil)
-        detector.linux_os_release.must_be_nil
+        _(detector.linux_os_release).must_be_nil
       end
     end
   end
@@ -67,7 +67,7 @@ describe "os_linux" do
     it "returns a correct hash" do
       detector.expects(:unix_file_contents).with("/etc/os-release").returns("os-release data")
       detector.expects(:parse_os_release_info).with("os-release data").returns(os_release)
-      detector.linux_os_release["KEY1"].must_equal("VALUE1")
+      _(detector.linux_os_release["KEY1"]).must_equal("VALUE1")
     end
   end
 
@@ -82,15 +82,15 @@ describe "os_linux" do
       detector.expects(:parse_os_release_info).with("cisco data").returns(cisco_release)
 
       os_info = detector.linux_os_release
-      os_info["KEY1"].must_equal("NEWVALUE1")
-      os_info["KEY2"].must_equal("VALUE2")
+      _(os_info["KEY1"]).must_equal("NEWVALUE1")
+      _(os_info["KEY2"]).must_equal("VALUE2")
     end
   end
 
   describe "#parse_os_release_info" do
     describe "when nil is supplied" do
       it "returns an empty hash" do
-        detector.parse_os_release_info(nil).must_equal({})
+        _(detector.parse_os_release_info(nil)).must_equal({})
       end
     end
 
@@ -103,7 +103,7 @@ describe "os_linux" do
       end
 
       it "returns an empty hash" do
-        detector.parse_os_release_info(nil).must_equal({})
+        _(detector.parse_os_release_info(nil)).must_equal({})
       end
     end
 
@@ -121,11 +121,11 @@ describe "os_linux" do
       it "parses the data correctly" do
         parsed_data = detector.parse_os_release_info(data)
 
-        parsed_data["KEY1"].must_equal("value1")
-        parsed_data.key?("KEY2").must_equal(false)
-        parsed_data["KEY3"].must_equal("value3")
-        parsed_data["KEY4"].must_equal("value4 with spaces")
-        parsed_data["KEY5"].must_equal("value5 with a = sign")
+        _(parsed_data["KEY1"]).must_equal("value1")
+        _(parsed_data.key?("KEY2")).must_equal(false)
+        _(parsed_data["KEY3"]).must_equal("value3")
+        _(parsed_data["KEY4"]).must_equal("value4 with spaces")
+        _(parsed_data["KEY5"]).must_equal("value5 with a = sign")
       end
     end
   end

--- a/test/unit/platforms/detect/os_windows_test.rb
+++ b/test/unit/platforms/detect/os_windows_test.rb
@@ -26,10 +26,10 @@ describe "os_detect_windows" do
 
     it "sets the correct family/release for windows" do
       detector.detect_windows
-      detector.platform[:family].must_equal("windows")
-      detector.platform[:name].must_equal("Windows Server 2012 R2 Standard")
-      detector.platform[:arch].must_equal("x86_64")
-      detector.platform[:release].must_equal("6.3.9600")
+      _(detector.platform[:family]).must_equal("windows")
+      _(detector.platform[:name]).must_equal("Windows Server 2012 R2 Standard")
+      _(detector.platform[:arch]).must_equal("x86_64")
+      _(detector.platform[:release]).must_equal("6.3.9600")
     end
   end
 
@@ -44,10 +44,10 @@ describe "os_detect_windows" do
 
     it "sets the correct family/release for windows" do
       detector.detect_windows
-      detector.platform[:family].must_equal("windows")
-      detector.platform[:name].must_equal("Windows Server 2008 R2 Standard")
-      detector.platform[:arch].must_equal("x86_64")
-      detector.platform[:release].must_equal("6.1.7601")
+      _(detector.platform[:family]).must_equal("windows")
+      _(detector.platform[:name]).must_equal("Windows Server 2008 R2 Standard")
+      _(detector.platform[:arch]).must_equal("x86_64")
+      _(detector.platform[:release]).must_equal("6.1.7601")
     end
   end
 
@@ -62,10 +62,10 @@ describe "os_detect_windows" do
 
     it "sets the correct family/release for windows" do
       detector.detect_windows
-      detector.platform[:family].must_equal("windows")
-      detector.platform[:name].must_equal("Windows 7 Enterprise")
-      detector.platform[:arch].must_equal("i386")
-      detector.platform[:release].must_equal("6.1.7601")
+      _(detector.platform[:family]).must_equal("windows")
+      _(detector.platform[:name]).must_equal("Windows 7 Enterprise")
+      _(detector.platform[:arch]).must_equal("i386")
+      _(detector.platform[:release]).must_equal("6.1.7601")
     end
   end
 
@@ -80,10 +80,10 @@ describe "os_detect_windows" do
 
     it "sets the correct family/release for windows" do
       detector.detect_windows
-      detector.platform[:family].must_equal("windows")
-      detector.platform[:name].must_equal("Windows 10 Pro")
-      detector.platform[:arch].must_equal("x86_64")
-      detector.platform[:release].must_equal("10.0.10240")
+      _(detector.platform[:family]).must_equal("windows")
+      _(detector.platform[:name]).must_equal("Windows 10 Pro")
+      _(detector.platform[:arch]).must_equal("x86_64")
+      _(detector.platform[:release]).must_equal("10.0.10240")
     end
   end
 
@@ -98,10 +98,10 @@ describe "os_detect_windows" do
 
     it "fallback to version number if wmic is not available" do
       detector.detect_windows
-      detector.platform[:family].must_equal("windows")
-      detector.platform[:name].must_equal("Windows 4.10.1998")
-      detector.platform[:arch].must_be_nil
-      detector.platform[:release].must_equal("4.10.1998")
+      _(detector.platform[:family]).must_equal("windows")
+      _(detector.platform[:name]).must_equal("Windows 4.10.1998")
+      _(detector.platform[:arch]).must_be_nil
+      _(detector.platform[:release]).must_equal("4.10.1998")
     end
   end
 end

--- a/test/unit/platforms/detect/scanner_test.rb
+++ b/test/unit/platforms/detect/scanner_test.rb
@@ -11,31 +11,31 @@ describe "scanner" do
   describe "scan family children" do
     it "return child" do
       family = Train::Platforms.family("linux")
-      scanner.scan_family_children(family).name.must_equal("linux")
-      scanner.instance_variable_get(:@family_hierarchy).must_equal(["linux"])
+      _(scanner.scan_family_children(family).name).must_equal("linux")
+      _(scanner.instance_variable_get(:@family_hierarchy)).must_equal(["linux"])
     end
 
     it "return nil" do
       family = Train::Platforms.family("fake-fam")
-      scanner.scan_family_children(family).must_be_nil
-      scanner.instance_variable_get(:@family_hierarchy).must_be_empty
+      _(scanner.scan_family_children(family)).must_be_nil
+      _(scanner.instance_variable_get(:@family_hierarchy)).must_be_empty
     end
   end
 
   describe "check condition" do
     it "return true equal" do
       scanner.instance_variable_set(:@platform, { arch: "x86_64" })
-      scanner.check_condition({ arch: "= x86_64" }).must_equal(true)
+      _(scanner.check_condition({ arch: "= x86_64" })).must_equal(true)
     end
 
     it "return true greater then" do
       scanner.instance_variable_set(:@platform, { release: "8.2" })
-      scanner.check_condition({ release: ">= 7" }).must_equal(true)
+      _(scanner.check_condition({ release: ">= 7" })).must_equal(true)
     end
 
     it "return false greater then" do
       scanner.instance_variable_set(:@platform, { release: "2.2" })
-      scanner.check_condition({ release: "> 7" }).must_equal(false)
+      _(scanner.check_condition({ release: "> 7" })).must_equal(false)
     end
   end
 
@@ -43,9 +43,9 @@ describe "scanner" do
     it "return empty platform" do
       plat = Train::Platforms.name("linux")
       plat = scanner.get_platform(plat)
-      plat.platform.must_equal({})
-      plat.backend.must_equal(backend)
-      plat.family_hierarchy.must_equal([])
+      _(plat.platform).must_equal({})
+      _(plat.backend).must_equal(backend)
+      _(plat.family_hierarchy).must_equal([])
     end
 
     it "return full platform" do
@@ -53,9 +53,9 @@ describe "scanner" do
       scanner.instance_variable_set(:@family_hierarchy, %w{linux unix})
       plat = Train::Platforms.name("linux")
       plat = scanner.get_platform(plat)
-      plat.platform.must_equal({ family: "linux" })
-      plat.backend.must_equal(backend)
-      plat.family_hierarchy.must_equal(%w{linux unix})
+      _(plat.platform).must_equal({ family: "linux" })
+      _(plat.backend).must_equal(backend)
+      _(plat.family_hierarchy).must_equal(%w{linux unix})
     end
   end
 end

--- a/test/unit/platforms/detect/uuid_test.rb
+++ b/test/unit/platforms/detect/uuid_test.rb
@@ -42,33 +42,33 @@ describe "uuid" do
   it "finds a linux uuid from chef entity_uuid" do
     files = { "/var/chef/cache/data_collector_metadata.json" => '{"node_uuid":"d400073f-0920-41aa-8dd3-2ea59b18f5ce"}' }
     plat = mock_platform("linux", {}, files)
-    plat.uuid.must_equal "d400073f-0920-41aa-8dd3-2ea59b18f5ce"
+    _(plat.uuid).must_equal "d400073f-0920-41aa-8dd3-2ea59b18f5ce"
   end
 
   it "finds a windows uuid from chef entity_uuid" do
     ENV["SYSTEMDRIVE"] = "C:"
     files = { 'C:\chef\cache\data_collector_metadata.json' => '{"node_uuid":"d400073f-0920-41aa-8dd3-2ea59b18f5ce"}' }
     plat = mock_platform("windows", {}, files)
-    plat.uuid.must_equal "d400073f-0920-41aa-8dd3-2ea59b18f5ce"
+    _(plat.uuid).must_equal "d400073f-0920-41aa-8dd3-2ea59b18f5ce"
   end
 
   it "finds a linux uuid from /etc/chef/chef_guid" do
     files = { "/etc/chef/chef_guid" => "5e430326-b5aa-56f8-975f-c3ca1c21df91" }
     plat = mock_platform("linux", {}, files)
-    plat.uuid.must_equal "5e430326-b5aa-56f8-975f-c3ca1c21df91"
+    _(plat.uuid).must_equal "5e430326-b5aa-56f8-975f-c3ca1c21df91"
   end
 
   it "finds a linux uuid from /home/testuser/.chef/chef_guid" do
     ENV["HOME"] = "/home/testuser"
     files = { "/home/testuser/.chef/chef_guid" => "5e430326-b5aa-56f8-975f-c3ca1c21df91" }
     plat = mock_platform("linux", {}, files)
-    plat.uuid.must_equal "5e430326-b5aa-56f8-975f-c3ca1c21df91"
+    _(plat.uuid).must_equal "5e430326-b5aa-56f8-975f-c3ca1c21df91"
   end
 
   it "finds a linux uuid from /etc/machine-id" do
     files = { "/etc/machine-id" => "123141dsfadf" }
     plat = mock_platform("linux", {}, files)
-    plat.uuid.must_equal "5e430326-b5aa-56f8-975f-c3ca1c21df91"
+    _(plat.uuid).must_equal "5e430326-b5aa-56f8-975f-c3ca1c21df91"
   end
 
   it "finds a linux uuid from /var/lib/dbus/machine-id" do
@@ -77,32 +77,32 @@ describe "uuid" do
       "/var/lib/dbus/machine-id" => "123141dsfadf",
     }
     plat = mock_platform("linux", {}, files)
-    plat.uuid.must_equal "5e430326-b5aa-56f8-975f-c3ca1c21df91"
+    _(plat.uuid).must_equal "5e430326-b5aa-56f8-975f-c3ca1c21df91"
   end
 
   it "finds a linux uuid from /etc/machine-id" do
     files = { "/etc/machine-id" => "123141dsfadf" }
     plat = mock_platform("linux", {}, files)
-    plat.uuid.must_equal "5e430326-b5aa-56f8-975f-c3ca1c21df91"
+    _(plat.uuid).must_equal "5e430326-b5aa-56f8-975f-c3ca1c21df91"
   end
 
   it "finds a windows uuid from wmic" do
     commands = { "wmic csproduct get UUID" => "UUID\r\nd400073f-0920-41aa-8dd3-2ea59b18f5ce\r\n" }
     plat = mock_platform("windows", commands)
-    plat.uuid.must_equal "d400073f-0920-41aa-8dd3-2ea59b18f5ce"
+    _(plat.uuid).must_equal "d400073f-0920-41aa-8dd3-2ea59b18f5ce"
   end
 
   it "finds a windows uuid from registry" do
     commands = { '(Get-ItemProperty "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography" -Name "MachineGuid")."MachineGuid"' => "d400073f-0920-41aa-8dd3-2ea59b18f5ce\r\n" }
     plat = mock_platform("windows", commands)
-    plat.uuid.must_equal "d400073f-0920-41aa-8dd3-2ea59b18f5ce"
+    _(plat.uuid).must_equal "d400073f-0920-41aa-8dd3-2ea59b18f5ce"
   end
 
   it 'finds a windows uuid from C:\chef\chef_guid' do
     ENV["SYSTEMDRIVE"] = "C:"
     files = { 'C:\chef\chef_guid' => "5e430326-b5aa-56f8-975f-c3ca1c21df91" }
     plat = mock_platform("windows", {}, files)
-    plat.uuid.must_equal "5e430326-b5aa-56f8-975f-c3ca1c21df91"
+    _(plat.uuid).must_equal "5e430326-b5aa-56f8-975f-c3ca1c21df91"
   end
 
   it 'finds a windows uuid from C:\Users\test\.chef\chef_guid' do
@@ -110,24 +110,24 @@ describe "uuid" do
     ENV["HOMEPATH"] = 'Users\test'
     files = { 'C:\Users\test\.chef\chef_guid' => "5e430326-b5aa-56f8-975f-c3ca1c21df91" }
     plat = mock_platform("windows", {}, files)
-    plat.uuid.must_equal "5e430326-b5aa-56f8-975f-c3ca1c21df91"
+    _(plat.uuid).must_equal "5e430326-b5aa-56f8-975f-c3ca1c21df91"
   end
 
   it "generates a uuid from a string" do
     plat = mock_platform("linux")
     uuid = Train::Platforms::Detect::UUID.new(plat)
-    uuid.uuid_from_string("123141dsfadf").must_equal "5e430326-b5aa-56f8-975f-c3ca1c21df91"
+    _(uuid.uuid_from_string("123141dsfadf")).must_equal "5e430326-b5aa-56f8-975f-c3ca1c21df91"
   end
 
   it "finds a aws uuid" do
     plat = mock_platform("aws")
     plat.backend.stubs(:unique_identifier).returns("158551926027")
-    plat.uuid.must_equal "1d74ce61-ac15-5c48-9ee3-5aa8207ac37f"
+    _(plat.uuid).must_equal "1d74ce61-ac15-5c48-9ee3-5aa8207ac37f"
   end
 
   it "finds an azure uuid" do
     plat = mock_platform("azure")
     plat.backend.stubs(:unique_identifier).returns("1d74ce61-ac15-5c48-9ee3-5aa8207ac37f")
-    plat.uuid.must_equal "2c2e4fa9-7287-5dee-85a3-6527face7b7b"
+    _(plat.uuid).must_equal "2c2e4fa9-7287-5dee-85a3-6527face7b7b"
   end
 end

--- a/test/unit/platforms/family_test.rb
+++ b/test/unit/platforms/family_test.rb
@@ -10,23 +10,23 @@ describe "platform family" do
 
   it "set family title" do
     plat = mock_family("mock")
-    plat.title.must_equal("Mock Family")
+    _(plat.title).must_equal("Mock Family")
     plat.title("The Best Mock Family")
-    plat.title.must_equal("The Best Mock Family")
+    _(plat.title).must_equal("The Best Mock Family")
   end
 
   it "set family in a family" do
     plat = mock_family("family1")
     plat.in_family("family2")
-    plat.families.keys[0].name.must_equal("family2")
+    _(plat.families.keys[0].name).must_equal("family2")
 
     plat = mock_family("family2")
-    plat.children.keys[0].name.must_equal("family1")
+    _(plat.children.keys[0].name).must_equal("family1")
   end
 
   it "set family in a family with condition" do
     plat = Train::Platforms.family("family4", arch: "= x68_64").in_family("family5")
-    plat.families.keys[0].name.must_equal("family5")
-    plat.families.values[0].must_equal({ arch: "= x68_64" })
+    _(plat.families.keys[0].name).must_equal("family5")
+    _(plat.families.values[0]).must_equal({ arch: "= x68_64" })
   end
 end

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -32,9 +32,9 @@ describe "os_detect" do
       path = "/etc/enterprise-release"
       platform = scan_with_files("linux", { path => "release 7" })
 
-      platform[:name].must_equal("oracle")
-      platform[:family].must_equal("redhat")
-      platform[:release].must_equal("7")
+      _(platform[:name]).must_equal("oracle")
+      _(platform[:family]).must_equal("redhat")
+      _(platform[:release]).must_equal("7")
     end
   end
 
@@ -46,9 +46,9 @@ describe "os_detect" do
           "/etc/os-release" => "NAME=\"CentOS Linux\"\nVERSION=\"7 (Core)\"\nID=\"centos\"\nID_LIKE=\"rhel fedora\"\n",
         }
         platform = scan_with_files("linux", files)
-        platform[:name].must_equal("centos")
-        platform[:family].must_equal("redhat")
-        platform[:release].must_equal("7.2.1511")
+        _(platform[:name]).must_equal("centos")
+        _(platform[:family]).must_equal("redhat")
+        _(platform[:release]).must_equal("7.2.1511")
       end
       it "sets the correct family, name, and release on scientific linux" do
         files = {
@@ -56,9 +56,9 @@ describe "os_detect" do
           "/etc/os-release" => "NAME=\"Scientific Linux\"\nVERSION=\"7.4 (Nitrogen)\"\nID=\"rhel\"\nID_LIKE=\"scientific centos fedora\"\nVERSION_ID=\"7.4\"\nPRETTY_NAME=\"Scientific Linux 7.4 (Nitrogen)\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:scientificlinux:scientificlinux:7.4:GA\"\nHOME_URL=\"http://www.scientificlinux.org//\"\nBUG_REPORT_URL=\"mailto:scientific-linux-devel@listserv.fnal.gov\"\n\nREDHAT_BUGZILLA_PRODUCT=\"Scientific Linux 7\"\nREDHAT_BUGZILLA_PRODUCT_VERSION=7.4\nREDHAT_SUPPORT_PRODUCT=\"Scientific Linux\"\nREDHAT_SUPPORT_PRODUCT_VERSION=\"7.4\"\n",
         }
         platform = scan_with_files("linux", files)
-        platform[:name].must_equal("scientific")
-        platform[:family].must_equal("redhat")
-        platform[:release].must_equal("7.4")
+        _(platform[:name]).must_equal("scientific")
+        _(platform[:family]).must_equal("redhat")
+        _(platform[:release]).must_equal("7.4")
       end
       it "sets the correct family, name, and release on CloudLinux" do
         files = {
@@ -66,9 +66,9 @@ describe "os_detect" do
           "/etc/os-release" => "NAME=\"CloudLinux\"\nVERSION=\"7.4 (Georgy Grechko)\"\nID=\"cloudlinux\"\nID_LIKE=\"rhel fedora centos\"\nVERSION_ID=\"7.4\"\nPRETTY_NAME=\"CloudLinux 7.4 (Georgy Grechko)\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:cloudlinux:cloudlinux:7.4:GA:server\"\nHOME_URL=\"https://www.cloudlinux.com//\"\nBUG_REPORT_URL=\"https://www.cloudlinux.com/support\"\n",
         }
         platform = scan_with_files("linux", files)
-        platform[:name].must_equal("cloudlinux")
-        platform[:family].must_equal("redhat")
-        platform[:release].must_equal("7.4")
+        _(platform[:name]).must_equal("cloudlinux")
+        _(platform[:family]).must_equal("redhat")
+        _(platform[:release]).must_equal("7.4")
       end
       it "sets the correct family, name, and release on SLES ESR RHEL" do
         files = {
@@ -76,9 +76,9 @@ describe "os_detect" do
           "/etc/os-release" => "NAME=\"Red Hat Enterprise Linux Server\"\nVERSION=\"7.4 (Maipo)\"\nID=\"rhel\"\nID_LIKE=\"fedora\"\nVERSION_ID=\"7.4\"\nPRETTY_NAME=\"Red Hat Enterprise Linux Server 7.4\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:redhat:enterprise_linux:7.4:GA:server\"\nHOME_URL=\"https://www.redhat.com/\"\nBUG_REPORT_URL=\"https://bugzilla.redhat.com/\"\n\nREDHAT_BUGZILLA_PRODUCT=\"Red Hat Enterprise Linux 7\"\nREDHAT_BUGZILLA_PRODUCT_VERSION=7.4\nREDHAT_SUPPORT_PRODUCT=\"Red Hat Enterprise Linux\"\nREDHAT_SUPPORT_PRODUCT_VERSION=7.4\n# This is a \"SLES Expanded Support platform release 7.4\"\n# The above \"Red Hat Enterprise Linux Server\" string is only used to\n# keep software compatibility.\n",
         }
         platform = scan_with_files("linux", files)
-        platform[:name].must_equal("redhat")
-        platform[:family].must_equal("redhat")
-        platform[:release].must_equal("7.4")
+        _(platform[:name]).must_equal("redhat")
+        _(platform[:family]).must_equal("redhat")
+        _(platform[:release]).must_equal("7.4")
       end
     end
   end
@@ -90,9 +90,9 @@ describe "os_detect" do
           "/System/Library/CoreServices/SystemVersion.plist" => "<string>Mac OS X</string>",
         }
         platform = scan_with_files("darwin", files)
-        platform[:name].must_equal("mac_os_x")
-        platform[:family].must_equal("darwin")
-        platform[:release].must_equal("test-release")
+        _(platform[:name]).must_equal("mac_os_x")
+        _(platform[:family]).must_equal("darwin")
+        _(platform[:release]).must_equal("test-release")
       end
     end
 
@@ -102,10 +102,10 @@ describe "os_detect" do
           "/usr/bin/sw_vers" => "ProductVersion: 17.0.1\nBuildVersion: alpha.x1",
         }
         platform = scan_with_files("darwin", files)
-        platform[:name].must_equal("darwin")
-        platform[:family].must_equal("darwin")
-        platform[:release].must_equal("17.0.1")
-        platform[:build].must_equal("alpha.x1")
+        _(platform[:name]).must_equal("darwin")
+        _(platform[:family]).must_equal("darwin")
+        _(platform[:release]).must_equal("17.0.1")
+        _(platform[:build]).must_equal("alpha.x1")
       end
     end
   end
@@ -124,9 +124,9 @@ describe "os_detect" do
       it "sets the correct family/release for ubuntu" do
         platform = debian_scan("ubuntu", "16.04")
 
-        platform[:name].must_equal("ubuntu")
-        platform[:family].must_equal("debian")
-        platform[:release].must_equal("16.04")
+        _(platform[:name]).must_equal("ubuntu")
+        _(platform[:family]).must_equal("debian")
+        _(platform[:release]).must_equal("16.04")
       end
     end
 
@@ -134,9 +134,9 @@ describe "os_detect" do
       it "sets the correct family/release for linuxmint" do
         platform = debian_scan("linuxmint", "12")
 
-        platform[:name].must_equal("linuxmint")
-        platform[:family].must_equal("debian")
-        platform[:release].must_equal("12")
+        _(platform[:name]).must_equal("linuxmint")
+        _(platform[:family]).must_equal("debian")
+        _(platform[:release]).must_equal("12")
       end
     end
 
@@ -148,9 +148,9 @@ describe "os_detect" do
         }
         platform = scan_with_files("linux", files)
 
-        platform[:name].must_equal("raspbian")
-        platform[:family].must_equal("debian")
-        platform[:release].must_equal("13.6")
+        _(platform[:name]).must_equal("raspbian")
+        _(platform[:family]).must_equal("debian")
+        _(platform[:release]).must_equal("13.6")
       end
     end
 
@@ -158,9 +158,9 @@ describe "os_detect" do
       it "sets the correct family/release for windows " do
         platform = scan_with_windows
 
-        platform[:name].must_equal("windows_6.3.9600")
-        platform[:family].must_equal("windows")
-        platform[:release].must_equal("6.3.9600")
+        _(platform[:name]).must_equal("windows_6.3.9600")
+        _(platform[:family]).must_equal("windows")
+        _(platform[:release]).must_equal("6.3.9600")
       end
     end
 
@@ -168,9 +168,9 @@ describe "os_detect" do
       it "sets the correct family/release for debian " do
         platform = debian_scan("some_debian", "12.99")
 
-        platform[:name].must_equal("debian")
-        platform[:family].must_equal("debian")
-        platform[:release].must_equal("11")
+        _(platform[:name]).must_equal("debian")
+        _(platform[:family]).must_equal("debian")
+        _(platform[:release]).must_equal("11")
       end
     end
   end
@@ -179,9 +179,9 @@ describe "os_detect" do
     it "sets the correct family/release for windows " do
       platform = scan_with_windows
 
-      platform[:name].must_equal("windows_6.3.9600")
-      platform[:family].must_equal("windows")
-      platform[:release].must_equal("6.3.9600")
+      _(platform[:name]).must_equal("windows_6.3.9600")
+      _(platform[:family]).must_equal("windows")
+      _(platform[:release]).must_equal("6.3.9600")
     end
   end
 
@@ -194,9 +194,9 @@ describe "os_detect" do
       }
       platform = scan_with_files("linux", files)
 
-      platform[:name].must_equal("coreos")
-      platform[:family].must_equal("linux")
-      platform[:release].must_equal("27.9")
+      _(platform[:name]).must_equal("coreos")
+      _(platform[:family]).must_equal("linux")
+      _(platform[:release]).must_equal("27.9")
     end
   end
 
@@ -209,8 +209,8 @@ describe "os_detect" do
         }
         platform = scan_with_files("linux", files)
 
-        platform[:name].must_equal("linux")
-        platform[:family].must_equal("linux")
+        _(platform[:name]).must_equal("linux")
+        _(platform[:family]).must_equal("linux")
       end
     end
 
@@ -222,9 +222,9 @@ describe "os_detect" do
         }
         platform = scan_with_files("linux", files)
 
-        platform[:name].must_equal("wrlinux")
-        platform[:family].must_equal("redhat")
-        platform[:release].must_equal("cisco123")
+        _(platform[:name]).must_equal("wrlinux")
+        _(platform[:family]).must_equal("redhat")
+        _(platform[:release]).must_equal("cisco123")
       end
     end
 
@@ -236,9 +236,9 @@ describe "os_detect" do
           }
           platform = scan_with_files("linux", files)
 
-          platform[:name].must_equal("suse")
-          platform[:family].must_equal("suse")
-          platform[:release].must_equal("15.1")
+          _(platform[:name]).must_equal("suse")
+          _(platform[:family]).must_equal("suse")
+          _(platform[:release]).must_equal("15.1")
         end
 
         it "sets the correct family/release for openSUSE" do
@@ -247,9 +247,9 @@ describe "os_detect" do
           }
           platform = scan_with_files("linux", files)
 
-          platform[:name].must_equal("opensuse")
-          platform[:family].must_equal("suse")
-          platform[:release].must_equal("15.1")
+          _(platform[:name]).must_equal("opensuse")
+          _(platform[:family]).must_equal("suse")
+          _(platform[:release]).must_equal("15.1")
         end
       end
       describe "when /etc/os-release is not present" do
@@ -259,9 +259,9 @@ describe "os_detect" do
           }
           platform = scan_with_files("linux", files)
 
-          platform[:name].must_equal("suse")
-          platform[:family].must_equal("suse")
-          platform[:release].must_equal("11.2")
+          _(platform[:name]).must_equal("suse")
+          _(platform[:family]).must_equal("suse")
+          _(platform[:release]).must_equal("11.2")
         end
 
         it "sets the correct family/release for openSUSE" do
@@ -270,9 +270,9 @@ describe "os_detect" do
           }
           platform = scan_with_files("linux", files)
 
-          platform[:name].must_equal("opensuse")
-          platform[:family].must_equal("suse")
-          platform[:release].must_equal("10.2")
+          _(platform[:name]).must_equal("opensuse")
+          _(platform[:family]).must_equal("suse")
+          _(platform[:release]).must_equal("10.2")
         end
       end
     end
@@ -282,9 +282,9 @@ describe "os_detect" do
     it "sets the correct info for qnx platform" do
       platform = scan_with_files("qnx", {})
 
-      platform[:name].must_equal("qnx")
-      platform[:family].must_equal("qnx")
-      platform[:release].must_equal("test-release")
+      _(platform[:name]).must_equal("qnx")
+      _(platform[:family]).must_equal("qnx")
+      _(platform[:release]).must_equal("test-release")
     end
   end
 
@@ -294,9 +294,9 @@ describe "os_detect" do
       mock.mock_command("show version", "Cisco IOS Software, C3750E Software (C3750E-UNIVERSALK9-M), Version 12.2(58)SE")
       platform = Train::Platforms::Detect.scan(mock)
 
-      platform[:name].must_equal("cisco_ios")
-      platform[:family].must_equal("cisco")
-      platform[:release].must_equal("12.2")
+      _(platform[:name]).must_equal("cisco_ios")
+      _(platform[:family]).must_equal("cisco")
+      _(platform[:release]).must_equal("12.2")
     end
 
     it "recognizes Cisco IOS XE" do
@@ -304,9 +304,9 @@ describe "os_detect" do
       mock.mock_command("show version", "Cisco IOS Software, IOS-XE Software, Catalyst L3 Switch Software (CAT3K_CAA-UNIVERSALK9-M), Version 03.03.03SE RELEASE SOFTWARE (fc2)")
       platform = Train::Platforms::Detect.scan(mock)
 
-      platform[:name].must_equal("cisco_ios_xe")
-      platform[:family].must_equal("cisco")
-      platform[:release].must_equal("03.03.03SE")
+      _(platform[:name]).must_equal("cisco_ios_xe")
+      _(platform[:family]).must_equal("cisco")
+      _(platform[:release]).must_equal("03.03.03SE")
     end
 
     it "recognizes Cisco Nexus" do
@@ -314,9 +314,9 @@ describe "os_detect" do
       mock.mock_command("show version", "Cisco Nexus Operating System (NX-OS) Software\n  system:      version 5.2(1)N1(8b)\n")
       platform = Train::Platforms::Detect.scan(mock)
 
-      platform[:name].must_equal("cisco_nexus")
-      platform[:family].must_equal("cisco")
-      platform[:release].must_equal("5.2")
+      _(platform[:name]).must_equal("cisco_nexus")
+      _(platform[:family]).must_equal("cisco")
+      _(platform[:release]).must_equal("5.2")
     end
   end
 
@@ -326,9 +326,9 @@ describe "os_detect" do
       mock.mock_command("version", "Kernel:     2.6.14.2\nFabric OS:  v7.4.2a\nMade on:    Thu Jun 29 19:22:14 2017\nFlash:      Sat Sep 9 17:30:42 2017\nBootProm:   1.0.11")
       platform = Train::Platforms::Detect.scan(mock)
 
-      platform[:name].must_equal("brocade_fos")
-      platform[:family].must_equal("brocade")
-      platform[:release].must_equal("7.4.2a")
+      _(platform[:name]).must_equal("brocade_fos")
+      _(platform[:family]).must_equal("brocade")
+      _(platform[:release]).must_equal("7.4.2a")
     end
   end
 end

--- a/test/unit/platforms/platform_test.rb
+++ b/test/unit/platforms/platform_test.rb
@@ -29,377 +29,377 @@ describe "platform" do
 
   it "set platform title" do
     plat = mock_platform_family("mock")
-    plat.title.must_equal("Mock")
+    _(plat.title).must_equal("Mock")
     plat.title("The Best Mock")
-    plat.title.must_equal("The Best Mock")
+    _(plat.title).must_equal("The Best Mock")
   end
 
   it "clean init name" do
     plat = mock_platform_family("Mo ck")
-    plat.name.must_equal("mo_ck")
+    _(plat.name).must_equal("mo_ck")
   end
 
   it "set name and name override" do
     plat = mock_platform_family("mock")
-    plat.name.must_equal("mock")
-    plat[:name].must_equal("mock")
+    _(plat.name).must_equal("mock")
+    _(plat[:name]).must_equal("mock")
     plat.platform[:name] = "Mock 2020"
     plat.add_platform_methods
-    plat.name.must_equal("mock_2020")
-    plat[:name].must_equal("mock_2020")
+    _(plat.name).must_equal("mock_2020")
+    _(plat[:name]).must_equal("mock_2020")
   end
 
   it "check families" do
     plat = mock_platform_family("mock")
-    plat.families.keys[0].name.must_equal("mock")
+    _(plat.families.keys[0].name).must_equal("mock")
   end
 
   it "check families with condition" do
     Train::Platforms.list["mock"] = nil
     plat = Train::Platforms.name("mock", arch: "= x86_64").in_family("linux")
-    plat.families.keys[0].name.must_equal("linux")
-    plat.families.values[0].must_equal({ arch: "= x86_64" })
+    _(plat.families.keys[0].name).must_equal("linux")
+    _(plat.families.values[0]).must_equal({ arch: "= x86_64" })
   end
 
   it "finds family hierarchy" do
     plat = Train::Platforms.name("linux")
     plat.find_family_hierarchy
-    plat.family_hierarchy.must_equal %w{linux unix os}
+    _(plat.family_hierarchy).must_equal %w{linux unix os}
   end
 
   it "return direct families" do
     plat = mock_platform_family("mock")
     plat.in_family("mock2")
     plat.in_family("mock3")
-    plat.direct_families.must_equal(%w{mock mock2 mock3})
+    _(plat.direct_families).must_equal(%w{mock mock2 mock3})
   end
 
   it "return to_hash" do
     plat = mock_platform_family("mock")
-    plat.to_hash.must_equal({ family: "mock" })
+    _(plat.to_hash).must_equal({ family: "mock" })
   end
 
   it "return unknown release" do
     plat = mock_platform_family("mock")
-    plat[:release].must_equal("unknown")
+    _(plat[:release]).must_equal("unknown")
   end
 
   it "return name?" do
     plat = Train::Platforms.name("windows_rc1")
-    defined?(plat.windows_rc1?).must_be_nil
+    _(defined?(plat.windows_rc1?)).must_be_nil
     plat.add_platform_methods
-    plat.windows_rc1?.must_equal(true)
+    _(plat.windows_rc1?).must_equal(true)
   end
 
   it "add platform methods" do
     Train::Platforms.list["mock"] = nil
     plat = Train::Platforms.name("mock").in_family("linux")
-    defined?(plat.linux?).must_be_nil
+    _(defined?(plat.linux?)).must_be_nil
     plat.family_hierarchy = mock_os_hierarchy(plat).flatten
     plat.add_platform_methods
-    plat.linux?.must_equal(true)
+    _(plat.linux?).must_equal(true)
   end
 
   it "provides a method to access platform data" do
     family = "test-os"
     os = mock_platform_family(family)
-    os[:family].must_equal family
+    _(os[:family]).must_equal family
   end
 
   it "provides an accessor for the full hash" do
     x = "test-os"
     os = mock_platform_family(x)
-    os.to_hash.must_equal({ family: x })
+    _(os.to_hash).must_equal({ family: x })
   end
 
   describe "with platform set to redhat" do
     let(:os) { mock_platform("redhat") }
-    it { os.redhat?.must_equal(true) }
-    it { os.debian?.must_equal(false) }
-    it { os.suse?.must_equal(false) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.redhat?).must_equal(true) }
+    it { _(os.debian?).must_equal(false) }
+    it { _(os.suse?).must_equal(false) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to oracle" do
     let(:os) { mock_platform("oracle") }
-    it { os.redhat?.must_equal(true) }
-    it { os.debian?.must_equal(false) }
-    it { os.suse?.must_equal(false) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.redhat?).must_equal(true) }
+    it { _(os.debian?).must_equal(false) }
+    it { _(os.suse?).must_equal(false) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to centos" do
     let(:os) { mock_platform("centos") }
-    it { os.redhat?.must_equal(true) }
-    it { os.debian?.must_equal(false) }
-    it { os.suse?.must_equal(false) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.redhat?).must_equal(true) }
+    it { _(os.debian?).must_equal(false) }
+    it { _(os.suse?).must_equal(false) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to cloudlinux" do
     let(:os) { mock_platform("cloudlinux") }
-    it { os.redhat?.must_equal(true) }
-    it { os.debian?.must_equal(false) }
-    it { os.suse?.must_equal(false) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.redhat?).must_equal(true) }
+    it { _(os.debian?).must_equal(false) }
+    it { _(os.suse?).must_equal(false) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to fedora" do
     let(:os) { mock_platform("fedora") }
-    it { os.fedora?.must_equal(true) }
-    it { os.redhat?.must_equal(false) }
-    it { os.debian?.must_equal(false) }
-    it { os.suse?.must_equal(false) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.fedora?).must_equal(true) }
+    it { _(os.redhat?).must_equal(false) }
+    it { _(os.debian?).must_equal(false) }
+    it { _(os.suse?).must_equal(false) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to amazon" do
     let(:os) { mock_platform("amazon") }
-    it { os.fedora?.must_equal(false) }
-    it { os.redhat?.must_equal(true) }
-    it { os.debian?.must_equal(false) }
-    it { os.suse?.must_equal(false) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.fedora?).must_equal(false) }
+    it { _(os.redhat?).must_equal(true) }
+    it { _(os.debian?).must_equal(false) }
+    it { _(os.suse?).must_equal(false) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to debian" do
     let(:os) { mock_platform("debian") }
-    it { os.redhat?.must_equal(false) }
-    it { os.debian?.must_equal(true) }
-    it { os.suse?.must_equal(false) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.redhat?).must_equal(false) }
+    it { _(os.debian?).must_equal(true) }
+    it { _(os.suse?).must_equal(false) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to ubuntu" do
     let(:os) { mock_platform("ubuntu") }
-    it { os.redhat?.must_equal(false) }
-    it { os.debian?.must_equal(true) }
-    it { os.suse?.must_equal(false) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.redhat?).must_equal(false) }
+    it { _(os.debian?).must_equal(true) }
+    it { _(os.suse?).must_equal(false) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to linuxmint" do
     let(:os) { mock_platform("linuxmint") }
-    it { os.redhat?.must_equal(false) }
-    it { os.debian?.must_equal(true) }
-    it { os.suse?.must_equal(false) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.redhat?).must_equal(false) }
+    it { _(os.debian?).must_equal(true) }
+    it { _(os.suse?).must_equal(false) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to raspbian" do
     let(:os) { mock_platform("raspbian") }
-    it { os.redhat?.must_equal(false) }
-    it { os.debian?.must_equal(true) }
-    it { os.suse?.must_equal(false) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.redhat?).must_equal(false) }
+    it { _(os.debian?).must_equal(true) }
+    it { _(os.suse?).must_equal(false) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to suse" do
     let(:os) { mock_platform("suse") }
-    it { os.redhat?.must_equal(false) }
-    it { os.debian?.must_equal(false) }
-    it { os.suse?.must_equal(true) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.redhat?).must_equal(false) }
+    it { _(os.debian?).must_equal(false) }
+    it { _(os.suse?).must_equal(true) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to opensuse" do
     let(:os) { mock_platform("opensuse") }
-    it { os.redhat?.must_equal(false) }
-    it { os.debian?.must_equal(false) }
-    it { os.suse?.must_equal(true) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.redhat?).must_equal(false) }
+    it { _(os.debian?).must_equal(false) }
+    it { _(os.suse?).must_equal(true) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to alpine" do
     let(:os) { mock_platform("alpine") }
-    it { os.redhat?.must_equal(false) }
-    it { os.debian?.must_equal(false) }
-    it { os.suse?.must_equal(false) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.redhat?).must_equal(false) }
+    it { _(os.debian?).must_equal(false) }
+    it { _(os.suse?).must_equal(false) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to arch" do
     let(:os) { mock_platform("arch") }
-    it { os.redhat?.must_equal(false) }
-    it { os.debian?.must_equal(false) }
-    it { os.suse?.must_equal(false) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.redhat?).must_equal(false) }
+    it { _(os.debian?).must_equal(false) }
+    it { _(os.suse?).must_equal(false) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to coreos" do
     let(:os) { mock_platform("coreos") }
-    it { os.redhat?.must_equal(false) }
-    it { os.debian?.must_equal(false) }
-    it { os.suse?.must_equal(false) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.redhat?).must_equal(false) }
+    it { _(os.debian?).must_equal(false) }
+    it { _(os.suse?).must_equal(false) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to exherbo" do
     let(:os) { mock_platform("exherbo") }
-    it { os.redhat?.must_equal(false) }
-    it { os.debian?.must_equal(false) }
-    it { os.suse?.must_equal(false) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.redhat?).must_equal(false) }
+    it { _(os.debian?).must_equal(false) }
+    it { _(os.suse?).must_equal(false) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to gentoo" do
     let(:os) { mock_platform("gentoo") }
-    it { os.redhat?.must_equal(false) }
-    it { os.debian?.must_equal(false) }
-    it { os.suse?.must_equal(false) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.redhat?).must_equal(false) }
+    it { _(os.debian?).must_equal(false) }
+    it { _(os.suse?).must_equal(false) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to slackware" do
     let(:os) { mock_platform("slackware") }
-    it { os.redhat?.must_equal(false) }
-    it { os.debian?.must_equal(false) }
-    it { os.suse?.must_equal(false) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.redhat?).must_equal(false) }
+    it { _(os.debian?).must_equal(false) }
+    it { _(os.suse?).must_equal(false) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to wrlinux" do
     let(:os) { mock_platform("wrlinux") }
-    it { os.redhat?.must_equal(true) }
-    it { os.debian?.must_equal(false) }
-    it { os.suse?.must_equal(false) }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.redhat?).must_equal(true) }
+    it { _(os.debian?).must_equal(false) }
+    it { _(os.suse?).must_equal(false) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to linux" do
     let(:os) { mock_platform("linux") }
-    it { os.linux?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.linux?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to freebsd" do
     let(:os) { mock_platform("freebsd") }
-    it { os.bsd?.must_equal(true) }
-    it { os.linux?.must_equal(false) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.bsd?).must_equal(true) }
+    it { _(os.linux?).must_equal(false) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to netbsd" do
     let(:os) { mock_platform("netbsd") }
-    it { os.bsd?.must_equal(true) }
-    it { os.linux?.must_equal(false) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.bsd?).must_equal(true) }
+    it { _(os.linux?).must_equal(false) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to openbsd" do
     let(:os) { mock_platform("openbsd") }
-    it { os.bsd?.must_equal(true) }
-    it { os.linux?.must_equal(false) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.bsd?).must_equal(true) }
+    it { _(os.linux?).must_equal(false) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to darwin" do
     let(:os) { mock_platform("darwin") }
-    it { os.bsd?.must_equal(true) }
-    it { os.linux?.must_equal(false) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.bsd?).must_equal(true) }
+    it { _(os.linux?).must_equal(false) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to solaris" do
     let(:os) { mock_platform("solaris") }
-    it { os.solaris?.must_equal(true) }
-    it { os.linux?.must_equal(false) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.solaris?).must_equal(true) }
+    it { _(os.linux?).must_equal(false) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to smartos" do
     let(:os) { mock_platform("smartos") }
-    it { os.solaris?.must_equal(true) }
-    it { os.linux?.must_equal(false) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.solaris?).must_equal(true) }
+    it { _(os.linux?).must_equal(false) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to openindiana" do
     let(:os) { mock_platform("openindiana") }
-    it { os.solaris?.must_equal(true) }
-    it { os.linux?.must_equal(false) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.solaris?).must_equal(true) }
+    it { _(os.linux?).must_equal(false) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to opensolaris" do
     let(:os) { mock_platform("opensolaris") }
-    it { os.solaris?.must_equal(true) }
-    it { os.linux?.must_equal(false) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.solaris?).must_equal(true) }
+    it { _(os.linux?).must_equal(false) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to nexentacore" do
     let(:os) { mock_platform("nexentacore") }
-    it { os.solaris?.must_equal(true) }
-    it { os.linux?.must_equal(false) }
-    it { os.unix?.must_equal(true) }
+    it { _(os.solaris?).must_equal(true) }
+    it { _(os.linux?).must_equal(false) }
+    it { _(os.unix?).must_equal(true) }
   end
 
   describe "with platform set to windows" do
     let(:os) { mock_platform("windows") }
-    it { os.solaris?.must_equal(false) }
-    it { os.bsd?.must_equal(false) }
-    it { os.linux?.must_equal(false) }
-    it { os.unix?.must_equal(false) }
+    it { _(os.solaris?).must_equal(false) }
+    it { _(os.bsd?).must_equal(false) }
+    it { _(os.linux?).must_equal(false) }
+    it { _(os.unix?).must_equal(false) }
   end
 
   describe "with platform set to hpux" do
     let(:os) { mock_platform("hpux") }
-    it { os.solaris?.must_equal(false) }
-    it { os.linux?.must_equal(false) }
-    it { os.unix?.must_equal(true) }
-    it { os.hpux?.must_equal(true) }
+    it { _(os.solaris?).must_equal(false) }
+    it { _(os.linux?).must_equal(false) }
+    it { _(os.unix?).must_equal(true) }
+    it { _(os.hpux?).must_equal(true) }
   end
 
   describe "with platform set to esx" do
     let(:os) { mock_platform("vmkernel") }
-    it { os.solaris?.must_equal(false) }
-    it { os.linux?.must_equal(false) }
-    it { os[:family].must_equal("esx") }
-    it { os.unix?.must_equal(false) }
-    it { os.esx?.must_equal(true) }
+    it { _(os.solaris?).must_equal(false) }
+    it { _(os.linux?).must_equal(false) }
+    it { _(os[:family]).must_equal("esx") }
+    it { _(os.unix?).must_equal(false) }
+    it { _(os.esx?).must_equal(true) }
   end
 
   describe "with platform set to darwin" do
     let(:os) { mock_platform("darwin") }
-    it { os.solaris?.must_equal(false) }
-    it { os.linux?.must_equal(false) }
-    it { os[:family].must_equal("darwin") }
-    it { os.bsd?.must_equal(true) }
-    it { os.darwin?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
-    it { os.bsd?.must_equal(true) }
-    it { os.esx?.must_equal(false) }
+    it { _(os.solaris?).must_equal(false) }
+    it { _(os.linux?).must_equal(false) }
+    it { _(os[:family]).must_equal("darwin") }
+    it { _(os.bsd?).must_equal(true) }
+    it { _(os.darwin?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
+    it { _(os.bsd?).must_equal(true) }
+    it { _(os.esx?).must_equal(false) }
   end
 
   describe "with platform set to mac_os_x" do
     let(:os) { mock_platform("mac_os_x") }
-    it { os.solaris?.must_equal(false) }
-    it { os.linux?.must_equal(false) }
-    it { os[:family].must_equal("darwin") }
-    it { os.bsd?.must_equal(true) }
-    it { os.darwin?.must_equal(true) }
-    it { os.unix?.must_equal(true) }
-    it { os.bsd?.must_equal(true) }
-    it { os.esx?.must_equal(false) }
+    it { _(os.solaris?).must_equal(false) }
+    it { _(os.linux?).must_equal(false) }
+    it { _(os[:family]).must_equal("darwin") }
+    it { _(os.bsd?).must_equal(true) }
+    it { _(os.darwin?).must_equal(true) }
+    it { _(os.unix?).must_equal(true) }
+    it { _(os.bsd?).must_equal(true) }
+    it { _(os.esx?).must_equal(false) }
   end
 end

--- a/test/unit/platforms/platforms_test.rb
+++ b/test/unit/platforms/platforms_test.rb
@@ -9,9 +9,9 @@ describe "platforms" do
     plat = Train::Platforms.name("mock")
     Train::Platforms.name("mock").in_family("test")
     Train::Platforms.name("mock").detect { true }
-    plat.title.must_equal("Mock")
-    plat.detect.call.must_equal(true)
-    plat.families.keys[0].name.must_equal("test")
+    _(plat.title).must_equal("Mock")
+    _(plat.detect.call).must_equal(true)
+    _(plat.families.keys[0].name).must_equal("test")
   end
 
   it "create family" do
@@ -19,16 +19,16 @@ describe "platforms" do
     fam = Train::Platforms.family("mock")
     Train::Platforms.family("mock").in_family("test")
     Train::Platforms.family("mock").detect { true }
-    fam.title.must_equal("Mock Family")
-    fam.detect.call.must_equal(true)
-    fam.families.keys[0].name.must_equal("test")
+    _(fam.title).must_equal("Mock Family")
+    _(fam.detect.call).must_equal(true)
+    _(fam.families.keys[0].name).must_equal("test")
   end
 
   it "return top platforms empty" do
     Train::Platforms.stubs(:list).returns({})
     Train::Platforms.stubs(:families).returns({})
     top = Train::Platforms.top_platforms
-    top.count.must_equal(0)
+    _(top.count).must_equal(0)
   end
 
   it "return top platforms with data" do
@@ -37,14 +37,14 @@ describe "platforms" do
     Train::Platforms.stubs(:list).returns({ "linux" => plat })
     Train::Platforms.stubs(:families).returns({})
     top = Train::Platforms.top_platforms
-    top.count.must_equal(1)
+    _(top.count).must_equal(1)
   end
 
   it "return platforms export with data" do
     export = Train::Platforms.export
-    export.size.must_be :>, 10
-    export[0][:name].must_equal "aix"
+    _(export.size).must_be :>, 10
+    _(export[0][:name]).must_equal "aix"
     expected_families = %w{aix unix os}
-    export[0][:families].must_equal expected_families
+    _(export[0][:families]).must_equal expected_families
   end
 end

--- a/test/unit/plugins/connection_test.rb
+++ b/test/unit/plugins/connection_test.rb
@@ -11,27 +11,27 @@ describe "v1 Connection Plugin" do
     end
 
     it "raises an exception for run_command" do
-      proc { connection.run_command("") }.must_raise NotImplementedError
+      _ { connection.run_command("") }.must_raise NotImplementedError
     end
 
     it "raises an exception for run_command_via_connection" do
-      proc { connection.send(:run_command_via_connection, "") }.must_raise NotImplementedError
+      _ { connection.send(:run_command_via_connection, "") }.must_raise NotImplementedError
     end
 
     it "raises an exception for os method" do
-      proc { connection.os }.must_raise NotImplementedError
+      _ { connection.os }.must_raise NotImplementedError
     end
 
     it "raises an exception for file method" do
-      proc { connection.file("") }.must_raise NotImplementedError
+      _ { connection.file("") }.must_raise NotImplementedError
     end
 
     it "raises an exception for file_via_connection method" do
-      proc { connection.send(:file_via_connection, "") }.must_raise NotImplementedError
+      _ { connection.send(:file_via_connection, "") }.must_raise NotImplementedError
     end
 
     it "raises an exception for login command method" do
-      proc { connection.login_command }.must_raise NotImplementedError
+      _ { connection.login_command }.must_raise NotImplementedError
     end
 
     it "can wait until ready" do
@@ -39,24 +39,24 @@ describe "v1 Connection Plugin" do
     end
 
     it "provides a default logger" do
-      connection.method(:logger).call
+      _(connection.method(:logger).call)
         .must_be_instance_of(Logger)
     end
 
     it "provides direct platform" do
       plat = connection.force_platform!("mac_os_x")
-      plat.name.must_equal "mac_os_x"
-      plat.linux?.must_equal false
-      plat.cloud?.must_equal false
-      plat.unix?.must_equal true
-      plat.family.must_equal "darwin"
-      plat.family_hierarchy.must_equal %w{darwin bsd unix os}
+      _(plat.name).must_equal "mac_os_x"
+      _(plat.linux?).must_equal false
+      _(plat.cloud?).must_equal false
+      _(plat.unix?).must_equal true
+      _(plat.family).must_equal "darwin"
+      _(plat.family_hierarchy).must_equal %w{darwin bsd unix os}
     end
 
     it "must use the user-provided logger" do
       l = rand
-      cls.new({ logger: l })
-        .method(:logger).call.must_equal(l)
+      _(cls.new({ logger: l })
+        .method(:logger).call).must_equal(l)
     end
 
     describe "cached_client helper" do
@@ -84,7 +84,7 @@ describe "v1 Connection Plugin" do
         client1 = conn.demo_client
         client2 = conn.demo_client
 
-        client1.wont_be_same_as client2
+        _(client1).wont_be_same_as client2
       end
 
       it "returns a new connection when cache enabled and not hydrated" do
@@ -93,7 +93,7 @@ describe "v1 Connection Plugin" do
 
         client1 = conn.demo_client
 
-        client1.must_be_instance_of DemoConnection::DemoClient
+        _(client1).must_be_instance_of DemoConnection::DemoClient
       end
 
       it "returns a cached connection when cache enabled and hydrated" do
@@ -103,32 +103,32 @@ describe "v1 Connection Plugin" do
         client1 = conn.demo_client
         client2 = conn.demo_client
 
-        client1.must_be_same_as client2
+        _(client1).must_be_same_as client2
       end
     end
 
     describe "create cache connection" do
       it "default connection cache settings" do
-        connection.cache_enabled?(:file).must_equal true
-        connection.cache_enabled?(:command).must_equal false
-        connection.cache_enabled?(:api_call).must_equal false
+        _(connection.cache_enabled?(:file)).must_equal true
+        _(connection.cache_enabled?(:command)).must_equal false
+        _(connection.cache_enabled?(:api_call)).must_equal false
       end
     end
 
     describe "disable/enable caching" do
       it "disable file cache via connection" do
         connection.disable_cache(:file)
-        connection.cache_enabled?(:file).must_equal false
+        _(connection.cache_enabled?(:file)).must_equal false
       end
 
       it "enable command cache via cache_connection" do
         connection.enable_cache(:command)
-        connection.cache_enabled?(:command).must_equal true
+        _(connection.cache_enabled?(:command)).must_equal true
       end
 
       it "raises an exception for unknown cache type" do
-        proc { connection.enable_cache(:fake) }.must_raise Train::UnknownCacheType
-        proc { connection.disable_cache(:fake) }.must_raise Train::UnknownCacheType
+        _ { connection.enable_cache(:fake) }.must_raise Train::UnknownCacheType
+        _ { connection.disable_cache(:fake) }.must_raise Train::UnknownCacheType
       end
     end
 
@@ -136,13 +136,13 @@ describe "v1 Connection Plugin" do
       it "returns true when cache is enabled" do
         cache_enabled = connection.instance_variable_get(:@cache_enabled)
         cache_enabled[:test] = true
-        connection.cache_enabled?(:test).must_equal true
+        _(connection.cache_enabled?(:test)).must_equal true
       end
 
       it "returns false when cache is disabled" do
         cache_enabled = connection.instance_variable_get(:@cache_enabled)
         cache_enabled[:test] = false
-        connection.cache_enabled?(:test).must_equal false
+        _(connection.cache_enabled?(:test)).must_equal false
       end
     end
 
@@ -152,7 +152,7 @@ describe "v1 Connection Plugin" do
         cache[:file]["/tmp"] = "test"
         connection.send(:clear_cache, :file)
         cache = connection.instance_variable_get(:@cache)
-        cache[:file].must_equal({})
+        _(cache[:file]).must_equal({})
       end
     end
 
@@ -160,20 +160,20 @@ describe "v1 Connection Plugin" do
       it "with caching" do
         connection.enable_cache(:file)
         connection.expects(:file_via_connection).once.returns("test_file")
-        connection.file("/tmp/test").must_equal("test_file")
-        connection.file("/tmp/test").must_equal("test_file")
+        _(connection.file("/tmp/test")).must_equal("test_file")
+        _(connection.file("/tmp/test")).must_equal("test_file")
         assert = { "/tmp/test" => "test_file" }
         cache = connection.instance_variable_get(:@cache)
-        cache[:file].must_equal(assert)
+        _(cache[:file]).must_equal(assert)
       end
 
       it "without caching" do
         connection.disable_cache(:file)
         connection.expects(:file_via_connection).twice.returns("test_file")
-        connection.file("/tmp/test").must_equal("test_file")
-        connection.file("/tmp/test").must_equal("test_file")
+        _(connection.file("/tmp/test")).must_equal("test_file")
+        _(connection.file("/tmp/test")).must_equal("test_file")
         cache = connection.instance_variable_get(:@cache)
-        cache[:file].must_equal({})
+        _(cache[:file]).must_equal({})
       end
     end
 
@@ -181,20 +181,20 @@ describe "v1 Connection Plugin" do
       it "with caching" do
         connection.enable_cache(:command)
         connection.expects(:run_command_via_connection).once.returns("test_user")
-        connection.run_command("whoami").must_equal("test_user")
-        connection.run_command("whoami").must_equal("test_user")
+        _(connection.run_command("whoami")).must_equal("test_user")
+        _(connection.run_command("whoami")).must_equal("test_user")
         assert = { "whoami" => "test_user" }
         cache = connection.instance_variable_get(:@cache)
-        cache[:command].must_equal(assert)
+        _(cache[:command]).must_equal(assert)
       end
 
       it "without caching" do
         connection.disable_cache(:command)
         connection.expects(:run_command_via_connection).twice.returns("test_user")
-        connection.run_command("whoami").must_equal("test_user")
-        connection.run_command("whoami").must_equal("test_user")
+        _(connection.run_command("whoami")).must_equal("test_user")
+        _(connection.run_command("whoami")).must_equal("test_user")
         cache = connection.instance_variable_get(:@cache)
-        cache[:command].must_equal({})
+        _(cache[:command]).must_equal({})
       end
     end
   end

--- a/test/unit/plugins/transport_test.rb
+++ b/test/unit/plugins/transport_test.rb
@@ -5,35 +5,35 @@ describe "v1 Transport Plugin" do
     let(:plugin) { Class.new(Train.plugin(1)) }
 
     it "initializes an empty configuration" do
-      plugin.new.options.must_equal({})
+      _(plugin.new.options).must_equal({})
     end
 
     it "saves the provided configuration" do
       conf = { a: rand }
-      plugin.new(conf).options.must_equal(conf)
+      _(plugin.new(conf).options).must_equal(conf)
     end
 
     it "saves the provided configuration" do
       conf = { a: rand }
-      plugin.new(conf).options.must_equal(conf)
+      _(plugin.new(conf).options).must_equal(conf)
     end
 
     it "provides a default logger" do
       conf = { a: rand }
-      plugin.new(conf)
-        .method(:logger).call
+      _(plugin.new(conf)
+        .method(:logger).call)
         .must_be_instance_of(Logger)
     end
 
     it "can configure custom loggers" do
       l = rand
-      plugin.new({ logger: l })
-        .method(:logger).call
+      _(plugin.new({ logger: l })
+        .method(:logger).call)
         .must_equal(l)
     end
 
     it "provides a connection method" do
-      proc { plugin.new.connection }.must_raise Train::ClientError
+      _ { plugin.new.connection }.must_raise Train::ClientError
     end
   end
 
@@ -43,18 +43,18 @@ describe "v1 Transport Plugin" do
     end
 
     it "doesnt have any plugins in the registry if none were configured" do
-      Train::Plugins.registry.empty?.must_equal true
+      _(Train::Plugins.registry.empty?).must_equal true
     end
 
     it "is is added to the plugins registry" do
       plugin_name = rand
-      Train::Plugins.registry.wont_include(plugin_name)
+      _(Train::Plugins.registry).wont_include(plugin_name)
 
       plugin = Class.new(Train.plugin(1)) do
         name plugin_name
       end
 
-      Train::Plugins.registry[plugin_name].must_equal(plugin)
+      _(Train::Plugins.registry[plugin_name]).must_equal(plugin)
     end
   end
 
@@ -69,23 +69,23 @@ describe "v1 Transport Plugin" do
 
     it "exposes the parameters via api" do
       name, plugin = train_class
-      plugin.default_options.keys.must_equal [name]
+      _(plugin.default_options.keys).must_equal [name]
     end
 
     it "exposes the parameters via api" do
       default = rand.to_s
       name, plugin = train_class({ default: default })
-      plugin.default_options[name][:default].must_equal default
+      _(plugin.default_options[name][:default]).must_equal default
     end
 
     it "option must be required" do
       name, plugin = train_class(required: true)
-      plugin.default_options[name][:required].must_equal true
+      _(plugin.default_options[name][:required]).must_equal true
     end
 
     it "default option must not be required" do
       name, plugin = train_class
-      plugin.default_options[name][:required].must_be_nil
+      _(plugin.default_options[name][:required]).must_be_nil
     end
 
     it "can include options from another module" do
@@ -93,7 +93,7 @@ describe "v1 Transport Plugin" do
       b = Class.new(Train.plugin(1)) do
         include_options(plugin_a)
       end
-      b.default_options[name_a].wont_be_nil
+      _(b.default_options[name_a]).wont_be_nil
     end
 
     it "overwrites existing options when including" do
@@ -104,7 +104,7 @@ describe "v1 Transport Plugin" do
         option name_a, default: old
         include_options(plugin_a)
       end
-      b.default_options[name_a][:default].must_equal nu
+      _(b.default_options[name_a][:default]).must_equal nu
     end
   end
 end

--- a/test/unit/plugins_test.rb
+++ b/test/unit/plugins_test.rb
@@ -1,22 +1,24 @@
 # encoding: utf-8
 require "helper"
 
+# rubocop:disable Style/BlockDelimiters
+
 describe Train::Plugins do
   it "provides a method to create new v1 transport plugins" do
-    Train.plugin(1).must_equal Train::Plugins::Transport
+    _(Train.plugin(1)).must_equal Train::Plugins::Transport
   end
 
   it "fails when called with an unsupported plugin version" do
-    proc {
+    _ {
       Train.plugin(2)
     }.must_raise Train::ClientError
   end
 
   it "defaults to v1 plugins" do
-    Train.plugin.must_equal Train::Plugins::Transport
+    _(Train.plugin).must_equal Train::Plugins::Transport
   end
 
   it "provides a registry of plugins" do
-    Train::Plugins.registry.must_be_instance_of(Hash)
+    _(Train::Plugins.registry).must_be_instance_of(Hash)
   end
 end

--- a/test/unit/train_test.rb
+++ b/test/unit/train_test.rb
@@ -12,15 +12,15 @@ describe Train do
 
   describe "#create" do
     it "raises an error if the plugin isnt found" do
-      proc { Train.create("missing") }.must_raise Train::UserError
-      proc { Train.create("missing") }.must_raise Train::PluginLoadError
+      _ { Train.create("missing") }.must_raise Train::UserError
+      _ { Train.create("missing") }.must_raise Train::PluginLoadError
     end
 
     it "loads a core plugin if it isnt in the registry yet via symbol" do
       Kernel.stub :require, true do
         ex = Class.new(Train.plugin 1) { name "existing" }
         train = Train.create(:existing)
-        train.class.must_equal ex
+        _(train.class).must_equal ex
       end
     end
 
@@ -28,7 +28,7 @@ describe Train do
       Kernel.stub :require, true do
         ex = Class.new(Train.plugin 1) { name "existing" }
         train = Train.create("existing")
-        train.class.must_equal ex
+        _(train.class).must_equal ex
       end
     end
 
@@ -39,19 +39,19 @@ describe Train do
       transport = Train.create("test-fixture")
       # Normally one would call transport.class.name, but that's been overridden to be a write-only DSL method
       # So use to_s
-      transport.class.to_s.must_equal "TrainPlugins::TestFixture::Transport"
+      _(transport.class.to_s).must_equal "TrainPlugins::TestFixture::Transport"
     end
   end
 
   describe "#options" do
     it "raises exception if a given transport plugin isnt found" do
-      proc { Train.options("missing") }.must_raise Train::UserError
-      proc { Train.options("missing") }.must_raise Train::PluginLoadError
+      _ { Train.options("missing") }.must_raise Train::UserError
+      _ { Train.options("missing") }.must_raise Train::PluginLoadError
     end
 
     it "provides empty options of a transport plugin" do
       Class.new(Train.plugin 1) { name "none" }
-      Train.options("none").must_equal({})
+      _(Train.options("none")).must_equal({})
     end
 
     it "provides all options of a transport plugin" do
@@ -59,7 +59,7 @@ describe Train do
         name "one"
         option :one, required: true, default: 123
       end
-      Train.options("one").must_equal({
+      _(Train.options("one")).must_equal({
         one: {
           required: true,
           default: 123,
@@ -74,14 +74,14 @@ describe Train do
         target: "ssh://user:pass@host.com:123/path",
       }
       res = Train.target_config(org)
-      res[:backend].must_equal "ssh"
-      res[:host].must_equal "host.com"
-      res[:user].must_equal "user"
-      res[:password].must_equal "pass"
-      res[:port].must_equal 123
-      res[:target].must_equal org[:target]
-      res[:path].must_equal "/path"
-      org.keys.must_equal [:target]
+      _(res[:backend]).must_equal "ssh"
+      _(res[:host]).must_equal "host.com"
+      _(res[:user]).must_equal "user"
+      _(res[:password]).must_equal "pass"
+      _(res[:port]).must_equal 123
+      _(res[:target]).must_equal org[:target]
+      _(res[:path]).must_equal "/path"
+      _(org.keys).must_equal [:target]
     end
 
     it "resolves a target while keeping existing fields" do
@@ -95,7 +95,7 @@ describe Train do
         path: rand,
       }
       res = Train.target_config(org)
-      res.must_equal org
+      _(res).must_equal org
     end
 
     it "resolves a winrm target" do
@@ -109,7 +109,7 @@ describe Train do
         path: nil,
       }
       res = Train.target_config(org)
-      res.must_equal org
+      _(res).must_equal org
     end
 
     it "keeps the configuration when incorrect target is supplied" do
@@ -117,13 +117,13 @@ describe Train do
         target: "wrong",
       }
       res = Train.target_config(org)
-      res[:backend].must_be_nil
-      res[:host].must_be_nil
-      res[:user].must_be_nil
-      res[:password].must_be_nil
-      res[:port].must_be_nil
-      res[:path].must_be_nil
-      res[:target].must_equal org[:target]
+      _(res[:backend]).must_be_nil
+      _(res[:host]).must_be_nil
+      _(res[:user]).must_be_nil
+      _(res[:password]).must_be_nil
+      _(res[:port]).must_be_nil
+      _(res[:path]).must_be_nil
+      _(res[:target]).must_equal org[:target]
     end
 
     it "always transforms config fields into ruby symbols" do
@@ -140,55 +140,55 @@ describe Train do
         acc[x.to_sym] = y; acc
       end
       res = Train.target_config(org)
-      res.must_equal nu
+      _(res).must_equal nu
     end
 
     it "supports IPv4 URIs" do
       org = { target: "mock://1.2.3.4:123" }
       res = Train.target_config(org)
-      res[:backend].must_equal "mock"
-      res[:host].must_equal "1.2.3.4"
-      res[:user].must_be_nil
-      res[:password].must_be_nil
-      res[:port].must_equal 123
-      res[:path].must_be_nil
-      res[:target].must_equal org[:target]
+      _(res[:backend]).must_equal "mock"
+      _(res[:host]).must_equal "1.2.3.4"
+      _(res[:user]).must_be_nil
+      _(res[:password]).must_be_nil
+      _(res[:port]).must_equal 123
+      _(res[:path]).must_be_nil
+      _(res[:target]).must_equal org[:target]
     end
 
     it "supports IPv6 URIs" do
       org = { target: "mock://[abc::def]:123" }
       res = Train.target_config(org)
-      res[:backend].must_equal "mock"
-      res[:host].must_equal "abc::def"
-      res[:user].must_be_nil
-      res[:password].must_be_nil
-      res[:port].must_equal 123
-      res[:path].must_be_nil
-      res[:target].must_equal org[:target]
+      _(res[:backend]).must_equal "mock"
+      _(res[:host]).must_equal "abc::def"
+      _(res[:user]).must_be_nil
+      _(res[:password]).must_be_nil
+      _(res[:port]).must_equal 123
+      _(res[:path]).must_be_nil
+      _(res[:target]).must_equal org[:target]
     end
 
     it "supports empty URIs with schema://" do
       org = { target: "mock://" }
       res = Train.target_config(org)
-      res[:backend].must_equal "mock"
-      res[:host].must_be_nil
-      res[:user].must_be_nil
-      res[:password].must_be_nil
-      res[:port].must_be_nil
-      res[:path].must_be_nil
-      res[:target].must_equal org[:target]
+      _(res[:backend]).must_equal "mock"
+      _(res[:host]).must_be_nil
+      _(res[:user]).must_be_nil
+      _(res[:password]).must_be_nil
+      _(res[:port]).must_be_nil
+      _(res[:path]).must_be_nil
+      _(res[:target]).must_equal org[:target]
     end
 
     it "supports empty URIs with schema:" do
       org = { target: "mock:" }
       res = Train.target_config(org)
-      res[:backend].must_equal "mock"
-      res[:host].must_be_nil
-      res[:user].must_be_nil
-      res[:password].must_be_nil
-      res[:port].must_be_nil
-      res[:path].must_be_nil
-      res[:target].must_equal org[:target]
+      _(res[:backend]).must_equal "mock"
+      _(res[:host]).must_be_nil
+      _(res[:user]).must_be_nil
+      _(res[:password]).must_be_nil
+      _(res[:port]).must_be_nil
+      _(res[:path]).must_be_nil
+      _(res[:target]).must_equal org[:target]
     end
 
     it "supports www-form encoded passwords when the option is set" do
@@ -197,53 +197,53 @@ describe Train do
       orig = { target: "mock://username:#{encoded_password}@1.2.3.4:100",
                www_form_encoded_password: true }
       result = Train.target_config(orig)
-      result[:backend].must_equal "mock"
-      result[:host].must_equal "1.2.3.4"
-      result[:user].must_equal "username"
-      result[:password].must_equal raw_password
-      result[:port].must_equal 100
-      result[:target].must_equal orig[:target]
+      _(result[:backend]).must_equal "mock"
+      _(result[:host]).must_equal "1.2.3.4"
+      _(result[:user]).must_equal "username"
+      _(result[:password]).must_equal raw_password
+      _(result[:port]).must_equal 100
+      _(result[:target]).must_equal orig[:target]
     end
 
     it "ignores www-form-encoded password value when there is no password" do
       org = { target: "mock://username@1.2.3.4:100",
               www_form_encoded_password: true }
       res = Train.target_config(org)
-      res[:backend].must_equal "mock"
-      res[:host].must_equal "1.2.3.4"
-      res[:user].must_equal "username"
-      res[:password].must_be_nil
-      res[:port].must_equal 100
-      res[:target].must_equal org[:target]
+      _(res[:backend]).must_equal "mock"
+      _(res[:host]).must_equal "1.2.3.4"
+      _(res[:user]).must_equal "username"
+      _(res[:password]).must_be_nil
+      _(res[:port]).must_equal 100
+      _(res[:target]).must_equal org[:target]
     end
 
     it "it raises UserError on invalid URIs" do
       org = { target: "mock world" }
-      proc { Train.target_config(org) }.must_raise Train::UserError
+      _ { Train.target_config(org) }.must_raise Train::UserError
     end
   end
 
   describe "#validate_backend" do
     it "just returns the backend if it is provided" do
       x = rand
-      Train.validate_backend({ backend: x }).must_equal x
+      _(Train.validate_backend({ backend: x })).must_equal x
     end
 
     it "returns the local backend if nothing was provided" do
-      Train.validate_backend({}).must_equal "local"
+      _(Train.validate_backend({})).must_equal "local"
     end
 
     it "returns the default backend if nothing was provided" do
       x = rand
-      Train.validate_backend({}, x).must_equal x
+      _(Train.validate_backend({}, x)).must_equal x
     end
 
     it "fails if no backend was given but a target is provided" do
-      proc { Train.validate_backend({ target: rand }) }.must_raise Train::UserError
+      _ { Train.validate_backend({ target: rand }) }.must_raise Train::UserError
     end
 
     it "fails if no backend was given but a host is provided" do
-      proc { Train.validate_backend({ host: rand }) }.must_raise Train::UserError
+      _ { Train.validate_backend({ host: rand }) }.must_raise Train::UserError
     end
   end
 end

--- a/test/unit/transports/azure_test.rb
+++ b/test/unit/transports/azure_test.rb
@@ -25,34 +25,34 @@ describe "azure transport" do
 
   describe "options" do
     it "defaults to env options" do
-      options[:tenant_id].must_equal "test_tenant_id"
-      options[:client_id].must_equal "test_client_id"
-      options[:client_secret].must_equal "test_client_secret"
-      options[:subscription_id].must_equal "test_subscription_id"
+      _(options[:tenant_id]).must_equal "test_tenant_id"
+      _(options[:client_id]).must_equal "test_client_id"
+      _(options[:client_secret]).must_equal "test_client_secret"
+      _(options[:subscription_id]).must_equal "test_subscription_id"
     end
 
     it "allows for options override" do
       transport = transport(subscription_id: "102", client_id: "717")
       options = transport.connection.instance_variable_get(:@options)
-      options[:tenant_id].must_equal "test_tenant_id"
-      options[:client_id].must_equal "717"
-      options[:client_secret].must_equal "test_client_secret"
-      options[:subscription_id].must_equal "102"
+      _(options[:tenant_id]).must_equal "test_tenant_id"
+      _(options[:client_id]).must_equal "717"
+      _(options[:client_secret]).must_equal "test_client_secret"
+      _(options[:subscription_id]).must_equal "102"
     end
 
     it "allows uri parse override" do
       transport = transport(host: "999")
       options = transport.connection.instance_variable_get(:@options)
-      options[:tenant_id].must_equal "test_tenant_id"
-      options[:subscription_id].must_equal "999"
+      _(options[:tenant_id]).must_equal "test_tenant_id"
+      _(options[:subscription_id]).must_equal "999"
     end
   end
 
   describe "platform" do
     it "returns platform" do
       plat = connection.platform
-      plat.name.must_equal "azure"
-      plat.family_hierarchy.must_equal %w{cloud api}
+      _(plat.name).must_equal "azure"
+      _(plat.family_hierarchy).must_equal %w{cloud api}
     end
   end
 
@@ -67,34 +67,34 @@ describe "azure transport" do
     it "can use azure_client with caching" do
       connection.instance_variable_set(:@credentials, {})
       client = connection.azure_client(AzureResource)
-      client.is_a?(AzureResource).must_equal true
-      cache[:api_call].count.must_equal 1
+      _(client.is_a?(AzureResource)).must_equal true
+      _(cache[:api_call].count).must_equal 1
     end
 
     it "can use azure_client without caching" do
       connection.instance_variable_set(:@credentials, {})
       connection.disable_cache(:api_call)
       client = connection.azure_client(AzureResource)
-      client.is_a?(AzureResource).must_equal true
-      cache[:api_call].count.must_equal 0
+      _(client.is_a?(AzureResource)).must_equal true
+      _(cache[:api_call].count).must_equal 0
     end
 
     it "can use azure_client default client" do
       management_api_client = Azure::Resources::Profiles::Latest::Mgmt::Client
       client = connection.azure_client
-      client.class.must_equal management_api_client
+      _(client.class).must_equal management_api_client
     end
 
     it "can use azure_client graph client" do
       graph_api_client = Azure::GraphRbac::Profiles::Latest::Client
       client = connection.azure_client(graph_api_client)
-      client.class.must_equal graph_api_client
+      _(client.class).must_equal graph_api_client
     end
 
     it "can use azure_client vault client" do
       vault_api_client = ::Azure::KeyVault::Profiles::Latest::Mgmt::Client
       client = connection.azure_client(vault_api_client, vault_name: "Test Vault")
-      client.class.must_equal vault_api_client
+      _(client.class).must_equal vault_api_client
     end
 
     it "cannot instantiate azure_client vault client without a vault name" do
@@ -109,13 +109,13 @@ describe "azure transport" do
     it "validate credentials" do
       connection.connect
       token = credentials[:credentials].instance_variable_get(:@token_provider)
-      token.class.must_equal MsRestAzure::ApplicationTokenProvider
+      _(token.class).must_equal MsRestAzure::ApplicationTokenProvider
 
-      credentials[:credentials].class.must_equal MsRest::TokenCredentials
-      credentials[:tenant_id].must_equal "test_tenant_id"
-      credentials[:client_id].must_equal "test_client_id"
-      credentials[:client_secret].must_equal "test_client_secret"
-      credentials[:subscription_id].must_equal "test_subscription_id"
+      _(credentials[:credentials].class).must_equal MsRest::TokenCredentials
+      _(credentials[:tenant_id]).must_equal "test_tenant_id"
+      _(credentials[:client_id]).must_equal "test_client_id"
+      _(credentials[:client_secret]).must_equal "test_client_secret"
+      _(credentials[:subscription_id]).must_equal "test_subscription_id"
     end
 
     it "validate msi credentials" do
@@ -125,26 +125,26 @@ describe "azure transport" do
 
       connection.connect
       token = credentials[:credentials].instance_variable_get(:@token_provider)
-      token.class.must_equal MsRestAzure::MSITokenProvider
+      _(token.class).must_equal MsRestAzure::MSITokenProvider
 
-      credentials[:credentials].class.must_equal MsRest::TokenCredentials
-      credentials[:tenant_id].must_equal "test_tenant_id"
-      credentials[:subscription_id].must_equal "test_subscription_id"
-      credentials[:client_id].must_be_nil
-      credentials[:client_secret].must_be_nil
-      options[:msi_port].must_equal 50342
+      _(credentials[:credentials].class).must_equal MsRest::TokenCredentials
+      _(credentials[:tenant_id]).must_equal "test_tenant_id"
+      _(credentials[:subscription_id]).must_equal "test_subscription_id"
+      _(credentials[:client_id]).must_be_nil
+      _(credentials[:client_secret]).must_be_nil
+      _(options[:msi_port]).must_equal 50342
     end
   end
 
   describe "unique_identifier" do
     it "returns a subscription id" do
-      connection.unique_identifier.must_equal "test_subscription_id"
+      _(connection.unique_identifier).must_equal "test_subscription_id"
     end
 
     it "returns a tenant id" do
       options = connection.instance_variable_get(:@options)
       options[:subscription_id] = nil
-      connection.unique_identifier.must_equal "test_tenant_id"
+      _(connection.unique_identifier).must_equal "test_tenant_id"
     end
   end
 end

--- a/test/unit/transports/cisco_ios_connection_test.rb
+++ b/test/unit/transports/cisco_ios_connection_test.rb
@@ -29,7 +29,7 @@ describe "CiscoIOSConnection" do
 
   describe "#initialize" do
     it "provides a uri" do
-      connection.uri.must_equal "ssh://fakeuser@fakehost:22"
+      _(connection.uri).must_equal "ssh://fakeuser@fakehost:22"
     end
   end
 
@@ -40,7 +40,7 @@ describe "CiscoIOSConnection" do
         .expects(:run_command_via_connection)
         .with("show version | include Processor")
         .returns(OpenStruct.new(stdout: output))
-      connection.unique_identifier.must_equal("1111111111")
+      _(connection.unique_identifier).must_equal("1111111111")
     end
   end
 
@@ -80,14 +80,14 @@ describe "CiscoIOSConnection" do
       cmd = "show calendar"
       output = "show calendar\r\n10:35:50 UTC Fri Mar 23 2018\r\n7200_ios_12#\r\n7200_ios_12#"
       result = connection.send(:format_output, output, cmd)
-      result.must_equal "10:35:50 UTC Fri Mar 23 2018"
+      _(result).must_equal "10:35:50 UTC Fri Mar 23 2018"
     end
 
     it "returns the correct output when a pipe is used" do
       cmd = "show running-config | section line con 0"
       output = "show running-config | section line con 0\r\nline con 0\r\n exec-timeout 0 0\r\n privilege level 15\r\n logging synchronous\r\n stopbits 1\r\n7200_ios_12#\r\n7200_ios_12#"
       result = connection.send(:format_output, output, cmd)
-      result.must_equal "line con 0\r\n exec-timeout 0 0\r\n privilege level 15\r\n logging synchronous\r\n stopbits 1"
+      _(result).must_equal "line con 0\r\n exec-timeout 0 0\r\n privilege level 15\r\n logging synchronous\r\n stopbits 1"
     end
   end
 end

--- a/test/unit/transports/gcp_test.rb
+++ b/test/unit/transports/gcp_test.rb
@@ -50,172 +50,172 @@ describe "gcp transport" do
   describe "options" do
     it "defaults to env options" do
       options[:google_application_credentials] = credentials_file.path
-      options[:google_cloud_project].must_equal "test_project"
+      _(options[:google_cloud_project]).must_equal "test_project"
     end
   end
 
   it "allows for options override" do
     transport = transport(google_application_credentials: credentials_file_override.path, google_cloud_project: "override_project")
     options = transport.connection.instance_variable_get(:@options)
-    options[:google_application_credentials].must_equal credentials_file_override.path
-    options[:google_cloud_project].must_equal "override_project"
+    _(options[:google_application_credentials]).must_equal credentials_file_override.path
+    _(options[:google_cloud_project]).must_equal "override_project"
   end
 
   describe "platform" do
     it "returns platform" do
       platform = connection.platform
-      platform.name.must_equal "gcp"
-      platform.family_hierarchy.must_equal %w{cloud api}
+      _(platform.name).must_equal "gcp"
+      _(platform.family_hierarchy).must_equal %w{cloud api}
     end
   end
 
   describe "gcp_client" do
     it "test gcp_client with caching" do
       client = connection.gcp_client(Object)
-      client.is_a?(Object).must_equal true
-      cache[:api_call].count.must_equal 1
+      _(client.is_a?(Object)).must_equal true
+      _(cache[:api_call].count).must_equal 1
     end
 
     it "test gcp_client without caching" do
       connection.disable_cache(:api_call)
       client = connection.gcp_client(Object)
-      client.is_a?(Object).must_equal true
-      cache[:api_call].count.must_equal 0
+      _(client.is_a?(Object)).must_equal true
+      _(cache[:api_call].count).must_equal 0
     end
   end
 
   describe "gcp_compute_client" do
     it "test gcp_compute_client with caching" do
       client = connection.gcp_compute_client
-      client.is_a?(Google::Apis::ComputeV1::ComputeService).must_equal true
-      cache[:api_call].count.must_equal 1
+      _(client.is_a?(Google::Apis::ComputeV1::ComputeService)).must_equal true
+      _(cache[:api_call].count).must_equal 1
     end
 
     it "test gcp_client without caching" do
       connection.disable_cache(:api_call)
       client = connection.gcp_compute_client
-      client.is_a?(Google::Apis::ComputeV1::ComputeService).must_equal true
-      cache[:api_call].count.must_equal 0
+      _(client.is_a?(Google::Apis::ComputeV1::ComputeService)).must_equal true
+      _(cache[:api_call].count).must_equal 0
     end
 
     it "test gcp_compute_client application name" do
       client = connection.gcp_compute_client
-      client.is_a?(Google::Apis::ComputeV1::ComputeService).must_equal true
-      client.client_options.application_name.must_equal "chef-inspec-train"
+      _(client.is_a?(Google::Apis::ComputeV1::ComputeService)).must_equal true
+      _(client.client_options.application_name).must_equal "chef-inspec-train"
     end
 
     it "test gcp_compute_client application version" do
       client = connection.gcp_compute_client
-      client.is_a?(Google::Apis::ComputeV1::ComputeService).must_equal true
-      client.client_options.application_version.must_equal Train::VERSION
+      _(client.is_a?(Google::Apis::ComputeV1::ComputeService)).must_equal true
+      _(client.client_options.application_version).must_equal Train::VERSION
     end
   end
 
   describe "gcp_iam_client" do
     it "test gcp_iam_client with caching" do
       client = connection.gcp_iam_client
-      client.is_a?(Google::Apis::IamV1::IamService).must_equal true
-      cache[:api_call].count.must_equal 1
+      _(client.is_a?(Google::Apis::IamV1::IamService)).must_equal true
+      _(cache[:api_call].count).must_equal 1
     end
 
     it "test gcp_iam_client without caching" do
       connection.disable_cache(:api_call)
       client = connection.gcp_iam_client
-      client.is_a?(Google::Apis::IamV1::IamService).must_equal true
-      cache[:api_call].count.must_equal 0
+      _(client.is_a?(Google::Apis::IamV1::IamService)).must_equal true
+      _(cache[:api_call].count).must_equal 0
     end
 
     it "test gcp_iam_client application name" do
       client = connection.gcp_iam_client
-      client.is_a?(Google::Apis::IamV1::IamService).must_equal true
-      client.client_options.application_name.must_equal "chef-inspec-train"
+      _(client.is_a?(Google::Apis::IamV1::IamService)).must_equal true
+      _(client.client_options.application_name).must_equal "chef-inspec-train"
     end
 
     it "test gcp_iam_client application version" do
       client = connection.gcp_iam_client
-      client.is_a?(Google::Apis::IamV1::IamService).must_equal true
-      client.client_options.application_version.must_equal Train::VERSION
+      _(client.is_a?(Google::Apis::IamV1::IamService)).must_equal true
+      _(client.client_options.application_version).must_equal Train::VERSION
     end
   end
 
   describe "gcp_project_client" do
     it "test gcp_project_client with caching" do
       client = connection.gcp_project_client
-      client.is_a?(Google::Apis::CloudresourcemanagerV1::CloudResourceManagerService).must_equal true
-      cache[:api_call].count.must_equal 1
+      _(client.is_a?(Google::Apis::CloudresourcemanagerV1::CloudResourceManagerService)).must_equal true
+      _(cache[:api_call].count).must_equal 1
     end
 
     it "test gcp_project_client without caching" do
       connection.disable_cache(:api_call)
       client = connection.gcp_project_client
-      client.is_a?(Google::Apis::CloudresourcemanagerV1::CloudResourceManagerService).must_equal true
-      cache[:api_call].count.must_equal 0
+      _(client.is_a?(Google::Apis::CloudresourcemanagerV1::CloudResourceManagerService)).must_equal true
+      _(cache[:api_call].count).must_equal 0
     end
 
     it "test gcp_project_client application name" do
       client = connection.gcp_project_client
-      client.is_a?(Google::Apis::CloudresourcemanagerV1::CloudResourceManagerService).must_equal true
-      client.client_options.application_name.must_equal "chef-inspec-train"
+      _(client.is_a?(Google::Apis::CloudresourcemanagerV1::CloudResourceManagerService)).must_equal true
+      _(client.client_options.application_name).must_equal "chef-inspec-train"
     end
 
     it "test gcp_project_client application version" do
       client = connection.gcp_project_client
-      client.is_a?(Google::Apis::CloudresourcemanagerV1::CloudResourceManagerService).must_equal true
-      client.client_options.application_version.must_equal Train::VERSION
+      _(client.is_a?(Google::Apis::CloudresourcemanagerV1::CloudResourceManagerService)).must_equal true
+      _(client.client_options.application_version).must_equal Train::VERSION
     end
   end
 
   describe "gcp_storage_client" do
     it "test gcp_storage_client with caching" do
       client = connection.gcp_storage_client
-      client.is_a?(Google::Apis::StorageV1::StorageService).must_equal true
-      cache[:api_call].count.must_equal 1
+      _(client.is_a?(Google::Apis::StorageV1::StorageService)).must_equal true
+      _(cache[:api_call].count).must_equal 1
     end
 
     it "test gcp_storage_client without caching" do
       connection.disable_cache(:api_call)
       client = connection.gcp_storage_client
-      client.is_a?(Google::Apis::StorageV1::StorageService).must_equal true
-      cache[:api_call].count.must_equal 0
+      _(client.is_a?(Google::Apis::StorageV1::StorageService)).must_equal true
+      _(cache[:api_call].count).must_equal 0
     end
 
     it "test gcp_storage_client application name" do
       client = connection.gcp_storage_client
-      client.is_a?(Google::Apis::StorageV1::StorageService).must_equal true
-      client.client_options.application_name.must_equal "chef-inspec-train"
+      _(client.is_a?(Google::Apis::StorageV1::StorageService)).must_equal true
+      _(client.client_options.application_name).must_equal "chef-inspec-train"
     end
 
     it "test gcp_storage_client application version" do
       client = connection.gcp_storage_client
-      client.is_a?(Google::Apis::StorageV1::StorageService).must_equal true
-      client.client_options.application_version.must_equal Train::VERSION
+      _(client.is_a?(Google::Apis::StorageV1::StorageService)).must_equal true
+      _(client.client_options.application_version).must_equal Train::VERSION
     end
   end
 
   describe "gcp_admin_client" do
     it "test gcp_admin_client with caching" do
       client = connection.gcp_admin_client
-      client.is_a?(Google::Apis::AdminDirectoryV1::DirectoryService).must_equal true
-      cache[:api_call].count.must_equal 1
+      _(client.is_a?(Google::Apis::AdminDirectoryV1::DirectoryService)).must_equal true
+      _(cache[:api_call].count).must_equal 1
     end
 
     it "test gcp_admin_client without caching" do
       connection.disable_cache(:api_call)
       client = connection.gcp_admin_client
-      client.is_a?(Google::Apis::AdminDirectoryV1::DirectoryService).must_equal true
-      cache[:api_call].count.must_equal 0
+      _(client.is_a?(Google::Apis::AdminDirectoryV1::DirectoryService)).must_equal true
+      _(cache[:api_call].count).must_equal 0
     end
 
     it "test gcp_admin_client application name" do
       client = connection.gcp_admin_client
-      client.is_a?(Google::Apis::AdminDirectoryV1::DirectoryService).must_equal true
-      client.client_options.application_name.must_equal "chef-inspec-train"
+      _(client.is_a?(Google::Apis::AdminDirectoryV1::DirectoryService)).must_equal true
+      _(client.client_options.application_name).must_equal "chef-inspec-train"
     end
 
     it "test gcp_admin_client application version" do
       client = connection.gcp_admin_client
-      client.is_a?(Google::Apis::AdminDirectoryV1::DirectoryService).must_equal true
-      client.client_options.application_version.must_equal Train::VERSION
+      _(client.is_a?(Google::Apis::AdminDirectoryV1::DirectoryService)).must_equal true
+      _(client.client_options.application_version).must_equal Train::VERSION
     end
   end
 
@@ -239,26 +239,26 @@ describe "gcp transport" do
     it "validate gcp connection with credentials" do
       options[:google_application_credentials] = creds.path
       connection.connect
-      ENV["GOOGLE_APPLICATION_CREDENTIALS"].must_equal creds.path
+      _(ENV["GOOGLE_APPLICATION_CREDENTIALS"]).must_equal creds.path
     end
     it "validate gcp connection with project" do
       options[:google_cloud_project] = "project"
       connection.connect
-      ENV["GOOGLE_CLOUD_PROJECT"].must_equal "project"
+      _(ENV["GOOGLE_CLOUD_PROJECT"]).must_equal "project"
     end
   end
 
   describe "unique_identifier" do
     it "test connection unique identifier" do
       client = connection
-      client.unique_identifier.must_equal "asdfasf-asdfasdf.apps.googleusercontent.com"
+      _(client.unique_identifier).must_equal "asdfasf-asdfasdf.apps.googleusercontent.com"
     end
   end
 
   describe "uri" do
     it "test uri" do
       client = connection
-      client.uri.must_equal "gcp://asdfasf-asdfasdf.apps.googleusercontent.com"
+      _(client.uri).must_equal "gcp://asdfasf-asdfasdf.apps.googleusercontent.com"
     end
   end
 end

--- a/test/unit/transports/local_test.rb
+++ b/test/unit/transports/local_test.rb
@@ -21,41 +21,41 @@ describe "local transport" do
   let(:connection) { transport.connection }
 
   it "can be instantiated" do
-    transport.wont_be_nil
+    _(transport).wont_be_nil
   end
 
   it "gets the connection" do
-    connection.must_be_kind_of Train::Transports::Local::Connection
+    _(connection).must_be_kind_of Train::Transports::Local::Connection
   end
 
   it "provides a uri" do
-    connection.uri.must_equal "local://"
+    _(connection.uri).must_equal "local://"
   end
 
   it "doesnt wait to be read" do
-    connection.wait_until_ready.must_be_nil
+    _(connection.wait_until_ready).must_be_nil
   end
 
   it "inspects with readable output" do
-    connection.inspect.must_match(/Train::Transports::Local::Connection\[\w+\]/)
+    _(connection.inspect).must_match(/Train::Transports::Local::Connection\[\w+\]/)
   end
 
   it "can be closed" do
-    connection.close.must_be_nil
+    _(connection.close).must_be_nil
   end
 
   it "has no login command" do
-    connection.login_command.must_be_nil
+    _(connection.login_command).must_be_nil
   end
 
   it "provides a run_command_via_connection method" do
     methods = connection.class.private_instance_methods(false)
-    methods.include?(:run_command_via_connection).must_equal true
+    _(methods.include?(:run_command_via_connection)).must_equal true
   end
 
   it "provides a file_via_connection method" do
     methods = connection.class.private_instance_methods(false)
-    methods.include?(:file_via_connection).must_equal true
+    _(methods.include?(:file_via_connection)).must_equal true
   end
 
   describe "when overriding runner selection" do
@@ -105,7 +105,7 @@ describe "local transport" do
     end
 
     it "throws a RuntimeError when an invalid runner type is passed" do
-      proc { Train::Transports::Local::Connection.new(command_runner: :nope ) }
+      _ { Train::Transports::Local::Connection.new(command_runner: :nope ) }
         .must_raise(RuntimeError, "Runner type `:nope` not supported")
     end
   end
@@ -126,7 +126,7 @@ describe "local transport" do
         cmd_runner.expect :stdout, x
         cmd_runner.expect :stderr, nil
         cmd_runner.expect :exitstatus, nil
-        connection.run_command(rand).stdout.must_equal x
+        _(connection.run_command(rand).stdout).must_equal x
       end
     end
 
@@ -136,7 +136,7 @@ describe "local transport" do
         cmd_runner.expect :stdout, nil
         cmd_runner.expect :stderr, x
         cmd_runner.expect :exitstatus, nil
-        connection.run_command(rand).stderr.must_equal x
+        _(connection.run_command(rand).stderr).must_equal x
       end
     end
 
@@ -146,7 +146,7 @@ describe "local transport" do
         cmd_runner.expect :stdout, nil
         cmd_runner.expect :stderr, nil
         cmd_runner.expect :exitstatus, x
-        connection.run_command(rand).exit_status.must_equal x
+        _(connection.run_command(rand).exit_status).must_equal x
       end
     end
   end

--- a/test/unit/transports/mock_test.rb
+++ b/test/unit/transports/mock_test.rb
@@ -8,25 +8,25 @@ describe "mock transport" do
   let(:connection) { transport.connection }
 
   it "can be instantiated" do
-    transport.wont_be_nil
+    _(transport).wont_be_nil
   end
 
   it "can create a connection" do
-    connection.wont_be_nil
+    _(connection).wont_be_nil
   end
 
   it "provides a uri" do
-    connection.uri.must_equal "mock://"
+    _(connection.uri).must_equal "mock://"
   end
 
   it "provides a run_command_via_connection method" do
     methods = connection.class.private_instance_methods(false)
-    methods.include?(:run_command_via_connection).must_equal true
+    _(methods.include?(:run_command_via_connection)).must_equal true
   end
 
   it "provides a file_via_connection method" do
     methods = connection.class.private_instance_methods(false)
-    methods.include?(:file_via_connection).must_equal true
+    _(methods.include?(:file_via_connection)).must_equal true
   end
 
   describe "when running a mocked command" do
@@ -36,12 +36,12 @@ describe "mock transport" do
       out = rand
       cls = Train::Transports::Mock::Connection::Command
       res = cls.new(out, "", 0)
-      connection.mock_command("test", out).must_equal res
+      _(connection.mock_command("test", out)).must_equal res
     end
 
     it "handles nil commands" do
       assert_output "", /Command not mocked/ do
-        connection.run_command(nil).stdout.must_equal("")
+        _(connection.run_command(nil).stdout).must_equal("")
       end
     end
 
@@ -49,28 +49,28 @@ describe "mock transport" do
       out = rand
       connection.mock_command("", rand) # don't pull this result! always mock the input
       connection.mock_command(nil, out) # pull this result
-      connection.run_command(nil).stdout.must_equal(out)
+      _(connection.run_command(nil).stdout).must_equal(out)
     end
 
     it "gets results for stdout" do
       out = rand
       cmd = rand
       connection.mock_command(cmd, out)
-      connection.run_command(cmd).stdout.must_equal(out)
+      _(connection.run_command(cmd).stdout).must_equal(out)
     end
 
     it "gets results for stderr" do
       err = rand
       cmd = rand
       connection.mock_command(cmd, nil, err)
-      connection.run_command(cmd).stderr.must_equal(err)
+      _(connection.run_command(cmd).stderr).must_equal(err)
     end
 
     it "gets results for exit_status" do
       code = rand
       cmd = rand
       connection.mock_command(cmd, nil, nil, code)
-      connection.run_command(cmd).exit_status.must_equal(code)
+      _(connection.run_command(cmd).exit_status).must_equal(code)
     end
 
     it "can mock a command via its SHA2 sum" do
@@ -78,55 +78,55 @@ describe "mock transport" do
       cmd = rand.to_s
       shacmd = Digest::SHA256.hexdigest cmd
       connection.mock_command(shacmd, out)
-      connection.run_command(cmd).stdout.must_equal(out)
+      _(connection.run_command(cmd).stdout).must_equal(out)
     end
   end
 
   describe "when accessing a mocked os" do
     it "has the default mock os faily set to mock" do
-      connection.os[:name].must_equal "mock"
-      connection.platform[:name].must_equal "mock"
+      _(connection.os[:name]).must_equal "mock"
+      _(connection.platform[:name]).must_equal "mock"
     end
 
     it "sets the OS to the mocked value" do
       connection.mock_os({ name: "centos", family: "redhat" })
-      connection.os.linux?.must_equal true
-      connection.os.redhat?.must_equal true
-      connection.os[:family].must_equal "redhat"
+      _(connection.os.linux?).must_equal true
+      _(connection.os.redhat?).must_equal true
+      _(connection.os[:family]).must_equal "redhat"
     end
 
     it "allows the setting of the name" do
       connection.mock_os({ name: "foo" })
-      connection.os[:name].must_equal "foo"
+      _(connection.os[:name]).must_equal "foo"
     end
 
     it "allows setting of the family" do
       connection.mock_os({ family: "foo" })
-      connection.os[:family].must_equal "foo"
+      _(connection.os[:family]).must_equal "foo"
     end
 
     it "allows setting of the release" do
       connection.mock_os({ release: "1.2.3" })
-      connection.os[:release].must_equal "1.2.3"
+      _(connection.os[:release]).must_equal "1.2.3"
     end
 
     it "allows setting of the arch" do
       connection.mock_os({ arch: "amd123" })
-      connection.os[:arch].must_equal "amd123"
+      _(connection.os[:arch]).must_equal "amd123"
     end
 
     it "allow setting of multiple values" do
       connection.mock_os({ name: "foo", family: "bar" })
-      connection.os[:name].must_equal "foo"
-      connection.os[:family].must_equal "bar"
-      connection.os[:arch].must_equal "unknown"
-      connection.os[:release].must_equal "unknown"
+      _(connection.os[:name]).must_equal "foo"
+      _(connection.os[:family]).must_equal "bar"
+      _(connection.os[:arch]).must_equal "unknown"
+      _(connection.os[:release]).must_equal "unknown"
     end
 
     it "properly handles a nil value" do
       connection.mock_os(nil)
-      connection.os[:name].must_equal "mock"
-      connection.os[:family].must_equal "mock"
+      _(connection.os[:name]).must_equal "mock"
+      _(connection.os[:family]).must_equal "mock"
     end
   end
 
@@ -135,9 +135,9 @@ describe "mock transport" do
       x = rand.to_s
       assert_output "", /File not mocked/ do
         f = connection.file(x)
-        f.must_be_kind_of Train::Transports::Mock::Connection::File
-        f.exist?.must_equal false
-        f.path.must_equal x
+        _(f).must_be_kind_of Train::Transports::Mock::Connection::File
+        _(f.exist?).must_equal false
+        _(f.path).must_equal x
       end
     end
 
@@ -150,9 +150,9 @@ describe "mock transport" do
         r = RES.send(f)
         d = JSON_DATA[f]
         if d
-          r.must_equal d
+          _(r).must_equal d
         else
-          r.must_be_nil # I think just group on windows
+          _(r).must_be_nil # I think just group on windows
         end
       end
     end

--- a/test/unit/transports/ssh_connection_test.rb
+++ b/test/unit/transports/ssh_connection_test.rb
@@ -69,9 +69,9 @@ describe "ssh connection" do
       # run_command b/c run_command_via_connection is private.
       ssh.run_command("test") do |data|
         called = true
-        data.must_equal inbound_data
+        _(data).must_equal inbound_data
       end
-      called.must_equal true
+      _(called).must_equal true
 
     end
   end

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -26,23 +26,23 @@ describe "ssh transport" do
     let(:ssh) { cls.new({ host: "dummy" }) }
 
     it "can be instantiated (with valid config)" do
-      ssh.wont_be_nil
+      _(ssh).wont_be_nil
     end
 
     it "configures the host" do
-      ssh.options[:host].must_equal "dummy"
+      _(ssh.options[:host]).must_equal "dummy"
     end
 
     it "has default port" do
-      ssh.options[:port].must_equal 22
+      _(ssh.options[:port]).must_equal 22
     end
 
     it "has default user" do
-      ssh.options[:user].must_equal "root"
+      _(ssh.options[:user]).must_equal "root"
     end
 
     it "by default does not request a pty" do
-      ssh.options[:pty].must_equal false
+      _(ssh.options[:pty]).must_equal false
     end
   end
 
@@ -52,7 +52,7 @@ describe "ssh transport" do
     let(:connection_options) { ssh.send(:connection_options, opts) }
 
     it "does not set a paranoid option - deprecated in net-ssh 4.2" do
-      connection_options.key?(:paranoid).must_equal false
+      _(connection_options.key?(:paranoid)).must_equal false
     end
 
     describe "various values are mapped appropriately for verify_host_key" do
@@ -69,11 +69,11 @@ describe "ssh transport" do
           }.each do |given, expected|
             opts = { verify_host_key: given }
             seen_opts = ssh.send(:connection_options, opts)
-            seen_opts[:verify_host_key].must_equal expected
+            _(seen_opts[:verify_host_key]).must_equal expected
           end
         end
         it "defaults verify_host_key option to false" do
-          connection_options[:verify_host_key].must_equal false
+          _(connection_options[:verify_host_key]).must_equal false
         end
       else
         it "maps correctly when net-ssh > 5.0" do
@@ -88,12 +88,12 @@ describe "ssh transport" do
           }.each do |given, expected|
             opts = { verify_host_key: given }
             seen_opts = ssh.send(:connection_options, opts)
-            seen_opts[:verify_host_key].must_equal expected
+            _(seen_opts[:verify_host_key]).must_equal expected
           end
         end
 
         it "defaults verify_host_key option to :never" do
-          connection_options[:verify_host_key].must_equal :never
+          _(connection_options[:verify_host_key]).must_equal :never
         end
       end
     end
@@ -104,10 +104,10 @@ describe "ssh transport" do
     let(:connection) { ssh.connection }
     it "includes BatchMode when :non_interactive is set" do
       conf[:non_interactive] = true
-      connection.ssh_opts.include?("BatchMode=yes").must_equal true
+      _(connection.ssh_opts.include?("BatchMode=yes")).must_equal true
     end
     it "excludes BatchMode when :non_interactive is not set" do
-      connection.ssh_opts.include?("BatchMode=yes").must_equal false
+      _(connection.ssh_opts.include?("BatchMode=yes")).must_equal false
     end
   end
 
@@ -117,36 +117,36 @@ describe "ssh transport" do
 
     it "provides a run_command_via_connection method" do
       methods = connection.class.private_instance_methods(false)
-      methods.include?(:run_command_via_connection).must_equal true
+      _(methods.include?(:run_command_via_connection)).must_equal true
     end
 
     it "provides a file_via_connection method" do
       methods = connection.class.private_instance_methods(false)
-      methods.include?(:file_via_connection).must_equal true
+      _(methods.include?(:file_via_connection)).must_equal true
     end
 
     it "gets the connection" do
-      connection.must_be_kind_of Train::Transports::SSH::Connection
+      _(connection).must_be_kind_of Train::Transports::SSH::Connection
     end
 
     it "provides a uri" do
-      connection.uri.must_equal "ssh://root@#{conf[:host]}:22"
+      _(connection.uri).must_equal "ssh://root@#{conf[:host]}:22"
     end
 
     it "must respond to wait_until_ready" do
-      connection.must_respond_to :wait_until_ready
+      _(connection).must_respond_to :wait_until_ready
     end
 
     it "can be closed" do
-      connection.close.must_be_nil
+      _(connection.close).must_be_nil
     end
 
     it "has a login command == ssh" do
-      connection.login_command.command.must_equal "ssh"
+      _(connection.login_command.command).must_equal "ssh"
     end
 
     it "has login command arguments" do
-      connection.login_command.arguments.must_equal([
+      _(connection.login_command.arguments).must_equal([
         "-o", "UserKnownHostsFile=/dev/null",
         "-o", "StrictHostKeyChecking=no",
         "-o", "IdentitiesOnly=yes",
@@ -161,17 +161,17 @@ describe "ssh transport" do
 
     it "sets the right auth_methods when password is specified" do
       conf[:key_files] = nil
-      cls.new(conf).connection.method(:options).call[:auth_methods].must_equal %w{none password keyboard-interactive}
+      _(cls.new(conf).connection.method(:options).call[:auth_methods]).must_equal %w{none password keyboard-interactive}
     end
 
     it "sets the right auth_methods when keys are specified" do
       conf[:password] = nil
-      cls.new(conf).connection.method(:options).call[:auth_methods].must_equal %w{none publickey}
+      _(cls.new(conf).connection.method(:options).call[:auth_methods]).must_equal %w{none publickey}
     end
 
     it "sets the right auth_methods for agent auth" do
       cls_agent.stubs(:ssh_known_identities).returns({ some: "rsa_key" })
-      cls_agent.connection.method(:options).call[:auth_methods].must_equal %w{none publickey}
+      _(cls_agent.connection.method(:options).call[:auth_methods]).must_equal %w{none publickey}
     end
 
     it "works with ssh agent auth" do
@@ -209,7 +209,7 @@ describe "ssh transport" do
 
     it "does not like host == nil" do
       conf.delete(:host)
-      proc { cls.new(conf).connection }.must_raise Train::ClientError
+      _ { cls.new(conf).connection }.must_raise Train::ClientError
     end
 
     it "reverts to root on user == nil" do
@@ -219,7 +219,7 @@ describe "ssh transport" do
 
     it "does not like key and password == nil" do
       cls_agent.stubs(:ssh_known_identities).returns({})
-      proc { cls_agent.connection }.must_raise Train::ClientError
+      _ { cls_agent.connection }.must_raise Train::ClientError
     end
 
     it "wont connect if it is not possible" do
@@ -229,7 +229,7 @@ describe "ssh transport" do
       conf[:port] = 1
       conf.delete :proxy_command
       conn = cls.new(conf).connection
-      proc { conn.run_command("uname") }.must_raise Train::Transports::SSHFailed
+      _ { conn.run_command("uname") }.must_raise Train::Transports::SSHFailed
     end
   end
 end
@@ -257,15 +257,15 @@ describe "ssh transport with bastion" do
       let(:ssh) { cls.new({ bastion_host: "bastion_dummy" }) }
 
       it "configures the host" do
-        ssh.options[:bastion_host].must_equal "bastion_dummy"
+        _(ssh.options[:bastion_host]).must_equal "bastion_dummy"
       end
 
       it "has default port" do
-        ssh.options[:bastion_port].must_equal 22
+        _(ssh.options[:bastion_port]).must_equal 22
       end
 
       it "has default user" do
-        ssh.options[:bastion_user].must_equal "root"
+        _(ssh.options[:bastion_user]).must_equal "root"
       end
     end
 
@@ -275,38 +275,38 @@ describe "ssh transport with bastion" do
 
       it "provides a run_command_via_connection method" do
         methods = connection.class.private_instance_methods(false)
-        methods.include?(:run_command_via_connection).must_equal true
+        _(methods.include?(:run_command_via_connection)).must_equal true
       end
 
       it "provides a file_via_connection method" do
         methods = connection.class.private_instance_methods(false)
-        methods.include?(:file_via_connection).must_equal true
+        _(methods.include?(:file_via_connection)).must_equal true
       end
 
       it "gets the connection" do
-        connection.must_be_kind_of Train::Transports::SSH::Connection
+        _(connection).must_be_kind_of Train::Transports::SSH::Connection
       end
 
       it "provides a uri" do
-        connection.uri.must_equal "ssh://root@#{conf[:host]}:22"
+        _(connection.uri).must_equal "ssh://root@#{conf[:host]}:22"
       end
 
       it "must respond to wait_until_ready" do
-        connection.must_respond_to :wait_until_ready
+        _(connection).must_respond_to :wait_until_ready
       end
 
       it "can be closed" do
-        connection.close.must_be_nil
+        _(connection.close).must_be_nil
       end
 
       it "has a login command == ssh" do
-        connection.login_command.command.must_equal "ssh"
+        _(connection.login_command.command).must_equal "ssh"
       end
 
       make_my_diffs_pretty!
 
       it "has login command arguments" do
-        connection.login_command.arguments.must_equal([
+        _(connection.login_command.arguments).must_equal([
           "-o", "UserKnownHostsFile=/dev/null",
           "-o", "StrictHostKeyChecking=no",
           "-o", "IdentitiesOnly=yes",
@@ -321,17 +321,17 @@ describe "ssh transport with bastion" do
 
       it "sets the right auth_methods when password is specified" do
         conf[:key_files] = nil
-        cls.new(conf).connection.method(:options).call[:auth_methods].must_equal %w{none password keyboard-interactive}
+        _(cls.new(conf).connection.method(:options).call[:auth_methods]).must_equal %w{none password keyboard-interactive}
       end
 
       it "sets the right auth_methods when keys are specified" do
         conf[:password] = nil
-        cls.new(conf).connection.method(:options).call[:auth_methods].must_equal %w{none publickey}
+        _(cls.new(conf).connection.method(:options).call[:auth_methods]).must_equal %w{none publickey}
       end
 
       it "sets the right auth_methods for agent auth" do
         cls_agent.stubs(:ssh_known_identities).returns({ some: "rsa_key" })
-        cls_agent.connection.method(:options).call[:auth_methods].must_equal %w{none publickey}
+        _(cls_agent.connection.method(:options).call[:auth_methods]).must_equal %w{none publickey}
       end
 
       it "works with ssh agent auth" do
@@ -376,7 +376,7 @@ describe "ssh transport with bastion and proxy" do
 
   describe "bastion and proxy" do
     it "will throw an exception when both proxy_command and bastion_host is specified" do
-      proc { cls.new(conf).connection }.must_raise Train::ClientError
+      _ { cls.new(conf).connection }.must_raise Train::ClientError
     end
   end
 end

--- a/test/unit/transports/vmware_test.rb
+++ b/test/unit/transports/vmware_test.rb
@@ -38,10 +38,10 @@ describe "Train::Transports::VMware::Connection" do
   describe "#initialize" do
     it "defaults to ENV options" do
       options = create_transport.connection.instance_variable_get(:@options)
-      options[:viserver].must_equal "10.0.0.10"
-      options[:username].must_equal "testuser"
-      options[:password].must_equal "supersecurepassword"
-      options[:insecure].must_equal false
+      _(options[:viserver]).must_equal "10.0.0.10"
+      _(options[:username]).must_equal "testuser"
+      _(options[:password]).must_equal "supersecurepassword"
+      _(options[:insecure]).must_equal false
     end
 
     it "allows for overriding options" do
@@ -54,10 +54,10 @@ describe "Train::Transports::VMware::Connection" do
         }
       )
       options = transport.connection.instance_variable_get(:@options)
-      options[:viserver].must_equal "10.1.1.1"
-      options[:username].must_equal "anotheruser"
-      options[:password].must_equal "notsecurepassword"
-      options[:insecure].must_equal false
+      _(options[:viserver]).must_equal "10.1.1.1"
+      _(options[:username]).must_equal "anotheruser"
+      _(options[:password]).must_equal "notsecurepassword"
+      _(options[:insecure]).must_equal false
     end
 
     it "ignores certificate validation if --insecure is used" do
@@ -67,7 +67,7 @@ describe "Train::Transports::VMware::Connection" do
         .returns(nil)
       transport = create_transport(transport_options: { insecure: true })
       options = transport.connection.instance_variable_get(:@options)
-      options[:insecure].must_equal true
+      _(options[:insecure]).must_equal true
     end
 
     it "uses the Local connection when Windows PowerShell is found" do
@@ -81,13 +81,15 @@ describe "Train::Transports::VMware::Connection" do
     end
   end
 
+  # rubocop:disable Style/BlockDelimiters
+
   describe "#connect" do
     def mock_connect_result(stderr, exit_status)
       OpenStruct.new(stderr: stderr, exit_status: exit_status)
     end
 
     it "raises certificate error when stderr matches regular expression" do
-      e = proc {
+      e = _ {
         create_transport(
           stub_options: {
             mock_connect_result: mock_connect_result(
@@ -96,11 +98,11 @@ describe "Train::Transports::VMware::Connection" do
           }
         ).connection
       }.must_raise(RuntimeError)
-      e.message.must_match(/Unable to connect.*Please use `--insecure`/)
+      _(e.message).must_match(/Unable to connect.*Please use `--insecure`/)
     end
 
     it "raises auth error when stderr matches regular expression" do
-      e = proc {
+      e = _ {
         create_transport(
           stub_options: {
             mock_connect_result: mock_connect_result(
@@ -109,11 +111,11 @@ describe "Train::Transports::VMware::Connection" do
           }
         ).connection
       }.must_raise(RuntimeError)
-      e.message.must_match(/Unable to connect.*Incorrect username/)
+      _(e.message).must_match(/Unable to connect.*Incorrect username/)
     end
 
     it "redacts the password when an unspecified error is raised" do
-      e = proc {
+      e = _ {
         create_transport(
           stub_options: {
             mock_connect_result: mock_connect_result(
@@ -122,17 +124,17 @@ describe "Train::Transports::VMware::Connection" do
           }
         ).connection
       }.must_raise(RuntimeError)
-      e.message.must_match(/-Password REDACTED/)
+      _(e.message).must_match(/-Password REDACTED/)
     end
   end
 
   describe "#platform" do
     it "returns correct platform details" do
       platform = create_transport.connection.platform
-      platform.clean_name.must_equal "vmware"
-      platform.family_hierarchy.must_equal %w{cloud api}
-      platform.platform.must_equal(release: "vmware-powercli-10.1.1.8827525")
-      platform.vmware?.must_equal true
+      _(platform.clean_name).must_equal "vmware"
+      _(platform.family_hierarchy).must_equal %w{cloud api}
+      _(platform.platform).must_equal(release: "vmware-powercli-10.1.1.8827525")
+      _(platform.vmware?).must_equal true
     end
   end
 
@@ -146,13 +148,13 @@ describe "Train::Transports::VMware::Connection" do
         stub_options: { mock_uuid_result: mock_uuid_result }
       ).connection
 
-      connection.unique_identifier.must_equal(uuid)
+      _(connection.unique_identifier).must_equal(uuid)
     end
   end
 
   describe "#uri" do
     it "returns the correct URI" do
-      create_transport.connection.uri.must_equal "vmware://testuser@10.0.0.10"
+      _(create_transport.connection.uri).must_equal "vmware://testuser@10.0.0.10"
     end
   end
 end

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -3,6 +3,6 @@ require "helper"
 
 describe Train do
   it "defines a version" do
-    Train::VERSION.must_be_instance_of String
+    _(Train::VERSION).must_be_instance_of String
   end
 end

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -23,16 +23,16 @@ describe "windows local command" do
 
   it "verify os" do
     os = conn.os
-    os[:name].must_match(/windows_server.*/)
-    os[:family].must_equal "windows"
-    os[:release].must_match(/\d+(\.\d+)+/)
-    os[:arch].must_equal "x86_64"
+    _(os[:name]).must_match(/windows_server.*/)
+    _(os[:family]).must_equal "windows"
+    _(os[:release]).must_match(/\d+(\.\d+)+/)
+    _(os[:arch]).must_equal "x86_64"
   end
 
   it "run echo test" do
     cmd = conn.run_command('Write-Output "test"')
-    cmd.stdout.must_equal "test\r\n"
-    cmd.stderr.must_equal ""
+    _(cmd.stdout).must_equal "test\r\n"
+    _(cmd.stderr).must_equal ""
   end
 
   describe "force 64 bit powershell command" do
@@ -58,7 +58,7 @@ describe "windows local command" do
         .returns("acquired")
 
       override_platform("x64-mingw32")
-      powershell.must_equal "powershell"
+      _(powershell).must_equal "powershell"
     end
 
     it "use 64bit powershell with PipeRunner" do
@@ -68,7 +68,7 @@ describe "windows local command" do
         .returns("acquired")
 
       override_platform("i386-mingw32")
-      powershell.must_equal "#{ENV["SystemRoot"]}\\sysnative\\WindowsPowerShell\\v1.0\\powershell.exe"
+      _(powershell).must_equal "#{ENV["SystemRoot"]}\\sysnative\\WindowsPowerShell\\v1.0\\powershell.exe"
     end
 
     it "use normal powershell with ShellRunner" do
@@ -78,8 +78,8 @@ describe "windows local command" do
         .returns(nil)
 
       override_platform("x64-mingw32")
-      runner.class.must_equal Train::Transports::Local::Connection::WindowsShellRunner
-      powershell.must_equal "powershell"
+      _(runner.class).must_equal Train::Transports::Local::Connection::WindowsShellRunner
+      _(powershell).must_equal "powershell"
     end
 
     it "use 64bit powershell with ShellRunner" do
@@ -89,15 +89,15 @@ describe "windows local command" do
         .returns(nil)
 
       override_platform("i386-mingw32")
-      runner.class.must_equal Train::Transports::Local::Connection::WindowsShellRunner
-      powershell.must_equal "#{ENV["SystemRoot"]}\\sysnative\\WindowsPowerShell\\v1.0\\powershell.exe"
+      _(runner.class).must_equal Train::Transports::Local::Connection::WindowsShellRunner
+      _(powershell).must_equal "#{ENV["SystemRoot"]}\\sysnative\\WindowsPowerShell\\v1.0\\powershell.exe"
     end
   end
 
   it "use powershell piping" do
     cmd = conn.run_command("New-Object -Type PSObject | Add-Member -MemberType NoteProperty -Name A -Value (Write-Output 'PropertyA') -PassThru | Add-Member -MemberType NoteProperty -Name B -Value (Write-Output 'PropertyB') -PassThru | ConvertTo-Json")
-    cmd.stdout.must_equal "{\r\n    \"A\":  \"PropertyA\",\r\n    \"B\":  \"PropertyB\"\r\n}\r\n"
-    cmd.stderr.must_equal ""
+    _(cmd.stdout).must_equal "{\r\n    \"A\":  \"PropertyA\",\r\n    \"B\":  \"PropertyB\"\r\n}\r\n"
+    _(cmd.stderr).must_equal ""
   end
 
   it "can execute a command using a named pipe" do
@@ -109,9 +109,9 @@ describe "windows local command" do
       .never
 
     cmd = conn.run_command('Write-Output "Create pipe"')
-    File.exist?("//./pipe/inspec_via_pipe").must_equal true
-    cmd.stdout.must_equal "Create pipe\r\n"
-    cmd.stderr.must_equal ""
+    _(File.exist?("//./pipe/inspec_via_pipe")).must_equal true
+    _(cmd.stdout).must_equal "Create pipe\r\n"
+    _(cmd.stderr).must_equal ""
   end
 
   it "can execute a command via ShellRunner if pipe creation fails" do
@@ -128,8 +128,8 @@ describe "windows local command" do
       .must_raise(Train::Transports::Local::PipeError)
 
     cmd = conn.run_command('Write-Output "test"')
-    cmd.stdout.must_equal "test\r\n"
-    cmd.stderr.must_equal ""
+    _(cmd.stdout).must_equal "test\r\n"
+    _(cmd.stderr).must_equal ""
   end
 
   describe "file" do
@@ -142,75 +142,75 @@ describe "windows local command" do
     let(:file) { conn.file(@temp.path) }
 
     it "exists" do
-      file.exist?.must_equal(true)
+      _(file.exist?).must_equal(true)
     end
 
     it "is a file" do
-      file.file?.must_equal(true)
+      _(file.file?).must_equal(true)
     end
 
     it "has type :file" do
-      file.type.must_equal(:file)
+      _(file.type).must_equal(:file)
     end
 
     it "has content" do
-      file.content.must_equal("hello world")
+      _(file.content).must_equal("hello world")
     end
 
     it "returns basename of file" do
       file_name = ::File.basename(@temp)
-      file.basename.must_equal(file_name)
+      _(file.basename).must_equal(file_name)
     end
 
     it "has owner name" do
-      file.owner.wont_be_nil
+      _(file.owner).wont_be_nil
     end
 
     it "has no group name" do
-      file.group.must_be_nil
+      _(file.group).must_be_nil
     end
 
     it "has no mode" do
-      file.mode.wont_be_nil
+      _(file.mode).wont_be_nil
     end
 
     it "has an md5sum" do
-      file.md5sum.wont_be_nil
+      _(file.md5sum).wont_be_nil
     end
 
     it "has an sha256sum" do
-      file.sha256sum.wont_be_nil
+      _(file.sha256sum).wont_be_nil
     end
 
     it "has no modified time" do
-      file.mtime.wont_be_nil
+      _(file.mtime).wont_be_nil
     end
 
     it "has no size" do
-      file.size.wont_be_nil
+      _(file.size).wont_be_nil
     end
 
     it "has size 11" do
       size = ::File.size(@temp)
-      file.size.must_equal size
+      _(file.size).must_equal size
     end
 
     it "has no selinux_label handling" do
-      file.selinux_label.must_be_nil
+      _(file.selinux_label).must_be_nil
     end
 
     it "has product_version" do
-      file.product_version.wont_be_nil
+      _(file.product_version).wont_be_nil
     end
 
     it "has file_version" do
-      file.file_version.wont_be_nil
+      _(file.file_version).wont_be_nil
     end
 
     it "provides a json representation" do
       j = file.to_json
-      j.must_be_kind_of Hash
-      j["type"].must_equal :file
+      _(j).must_be_kind_of Hash
+      _(j["type"]).must_equal :file
     end
 
     after do
@@ -228,7 +228,7 @@ describe "windows local command" do
     let(:file) { conn.file(@temp.path) }
 
     it 'provides the full path with whitespace for path #{@temp.path}' do
-      file.path.must_equal @temp.path
+      _(file.path).must_equal @temp.path
     end
 
     after do


### PR DESCRIPTION
Fixes new deprecations from minitest 5.12+ and cleans the test output
back to plain dots.

Signed-off-by: Ryan Davis <zenspider@chef.io>