### PR TITLE
Fix contributor url pointing to 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Train is heavily based on the work of:
 
 * [test-kitchen](https://github.com/test-kitchen/test-kitchen)
 
-    by [Fletcher Nichol](fnichol@nichol.ca)
+    by [Fletcher Nichol](mailto:fnichol@nichol.ca)
     and [a great community of contributors](https://github.com/test-kitchen/test-kitchen/graphs/contributors)
 
 * [ohai](https://github.com/chef/ohai)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Link ` [Fletcher Nichol](fnichol@nichol.ca)` of README content converted into `https://github.com/inspec/train/blob/master/fnichol@nichol.ca` which seems taking related to repo URL. 

So appended mailto ie. ` [Fletcher Nichol](mailto:fnichol@nichol.ca)`

Ref: https://github.com/fnichol

```
* [test-kitchen](https://github.com/test-kitchen/test-kitchen)

    by [Fletcher Nichol](fnichol@nichol.ca)
    and [a great community of contributors](https://github.com/test-kitchen/test-kitchen/graphs/contributors)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>
