### PR TITLE
Return exit code for local Windows command

### DIFF
--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -200,6 +200,10 @@ module Train::Transports
               try {
                 $stdout = & $scriptBlock | Out-String
                 $exit_code = $LastExitCode
+                if ($exit_code -eq $null)
+                {
+                  $exit_code = 0
+                }
                 $result = @{ 'stdout' = $stdout ; 'stderr' = ''; 'exitstatus' = $exit_code }
               } catch {
                 $stderr = $_ | Out-String

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -199,10 +199,12 @@ module Train::Transports
               $scriptBlock = $ExecutionContext.InvokeCommand.NewScriptBlock($command)
               try {
                 $stdout = & $scriptBlock | Out-String
-                $result = @{ 'stdout' = $stdout ; 'stderr' = ''; 'exitstatus' = 0 }
+                $exit_code = $LastExitCode
+                $result = @{ 'stdout' = $stdout ; 'stderr' = ''; 'exitstatus' = $exit_code }
               } catch {
                 $stderr = $_ | Out-String
-                $result = @{ 'stdout' = ''; 'stderr' = $stderr; 'exitstatus' = 1 }
+                $exit_code = $LastExitCode
+                $result = @{ 'stdout' = ''; 'stderr' = $stderr; 'exitstatus' = $exit_code }
               }
               $resultJSON = $result | ConvertTo-JSON
 

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -146,6 +146,12 @@ module Train::Transports
           raise PipeError if @pipe.nil?
         end
 
+        # @param  cmd The command to execute
+        # @return Local::ComandResult with stdout, stderr and exitstatus
+        #         Note that exitstatus ($?) in PowerShell is boolean, but we use a numeric exit code.
+        #         A command that succeeds without setting an exit code will have exitstatus 0
+        #         A command that exits with an exit code will have that value as exitstatus
+        #         A command that fails (e.g. throws exception) before setting an exit code will have exitstatus 1
         def run_command(cmd)
           script = "$ProgressPreference='SilentlyContinue';" + cmd
           encoded_script = Base64.strict_encode64(script)

--- a/test/fixtures/PowerShell/exit_fortytwo.ps1
+++ b/test/fixtures/PowerShell/exit_fortytwo.ps1
@@ -1,0 +1,2 @@
+echo 'Goodbye'
+exit 42

--- a/test/fixtures/PowerShell/exit_zero.ps1
+++ b/test/fixtures/PowerShell/exit_zero.ps1
@@ -1,0 +1,1 @@
+echo 'Hello'

--- a/test/fixtures/PowerShell/throws.ps1
+++ b/test/fixtures/PowerShell/throws.ps1
@@ -1,0 +1,2 @@
+echo 'Next line throws'
+Throw 'Oh dear.'

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -35,6 +35,20 @@ describe "windows local command" do
     _(cmd.stderr).must_equal ""
   end
 
+  it "run script without exit code" do
+    cmd = conn.run_command("powershell -file test/fixtures/PowerShell/exit_zero.ps1")
+    _(cmd.stdout).must_equal "Hello\r\n"
+    _(cmd.stderr).must_equal ""
+    _(cmd.exit_status).must_equal 0
+  end
+
+  it "run script without exit code" do
+    cmd = conn.run_command("powershell -file test/fixtures/PowerShell/exit_fortytwo.ps1")
+    _(cmd.stdout).must_equal "Goodbye\r\n"
+    _(cmd.stderr).must_equal ""
+    _(cmd.exit_status).must_equal 42
+  end
+
   describe "force 64 bit powershell command" do
     let(:runner) { conn.instance_variable_get(:@runner) }
     let(:powershell) { runner.instance_variable_get(:@powershell_cmd) }

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -33,6 +33,7 @@ describe "windows local command" do
     cmd = conn.run_command('Write-Output "test"')
     _(cmd.stdout).must_equal "test\r\n"
     _(cmd.stderr).must_equal ""
+    _(cmd.exit_status).must_equal 0
   end
 
   it "run script without exit code" do

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -50,6 +50,13 @@ describe "windows local command" do
     _(cmd.exit_status).must_equal 42
   end
 
+  it "returns exit code 1 for a script that throws" do
+    cmd = conn.run_command("powershell -file test/fixtures/PowerShell/throws.ps1")
+    _(cmd.stdout).must_match(/Next line throws/)
+    _(cmd.stderr).must_equal ""
+    _(cmd.exit_status).must_equal 1
+  end
+
   describe "force 64 bit powershell command" do
     let(:runner) { conn.instance_variable_get(:@runner) }
     let(:powershell) { runner.instance_variable_get(:@powershell_cmd) }


### PR DESCRIPTION


Signed-off-by: James Stocks <jstocks@chef.io>

## Description
The exit code might not be 0 for a script that does not `throw` a PowerShell exception. We should get the actual exit code and return it.
Note that PowerShell has a `$?` which is boolean _as well as_ a numeric last exit code. The variable name train is using `exitstatus` is ambiguous on which it represents, maybe.

## Related Issue
Partly addresses #288 but that issue also requires the stderr to be provided.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [X ] Breaking change (a content change which would break existing functionality or processes)

If anyone is currently depending on the inaccurate 0 and 1 exit codes then they will get different behaviour when train starts returning the real exit code.

## Checklist:
- [X ] I have read the **CONTRIBUTING** document.
