### PR TITLE
Adds activesupport gem to allow XML>JSON parsing from Azure APIs

### DIFF
--- a/train.gemspec
+++ b/train.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "azure_mgmt_resources", "~> 0.15"
   spec.add_dependency "azure_graph_rbac", "~> 0.16"
   spec.add_dependency "azure_mgmt_key_vault", "~> 0.17"
+  spec.add_dependency "activesupport", "~> 5.2.3"
   spec.add_dependency "google-api-client", "~> 0.23.9"
   spec.add_dependency "googleauth", "~> 0.6.6"
   spec.add_dependency "inifile"


### PR DESCRIPTION
Signed-off-by: Ruairi Fennell <rfennell@chef.io>

## Description
Adds activesupport gem to allow XML>JSON parsing from Azure APIs.
Had originally added this as a direct dependency to inspec-azure but users have been running into problems as resource-pack dependencies don't appear to be installed/bundled. 

## Related Issue
https://github.com/inspec/inspec-azure/issues/216

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

