### PR TITLE
Added create_github_release action to stable promotion.

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -53,6 +53,7 @@ promote:
   actions:
     - built_in:rollover_changelog
     - built_in:publish_rubygems
+    - built_in:create_github_release
 
 subscriptions:
  - workload: pull_request_opened:{{agent_id}}:*


### PR DESCRIPTION
It hasn't been done since 2017. :(

Signed-off-by: Ryan Davis <zenspider@chef.io>