### PR TITLE
Bump minor version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Train supports:
 * AWS as an API
 * Azure as an API
 * VMware via PowerCLI
+* Habitat
 
 # Examples
 


### PR DESCRIPTION
#541 was supposed to bump the minor version, but the expeditor config was wrong; this PR bumps it.