### PR TITLE
Correctly verify ssh w/ sudo

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -25,6 +25,14 @@ steps:
       docker:
         image: ruby:2.6-stretch
 
+- label: run-tests-ruby-2.7
+  command:
+    - /workdir/.expeditor/buildkite/verify.sh
+  expeditor:
+    executor:
+      docker:
+        image: ruby:2.7-rc
+
 - label: run-tests-ruby-2.6-windows
   command:
     - /workdir/.expeditor/buildkite/verify.ps1

--- a/lib/train/extras/command_wrapper.rb
+++ b/lib/train/extras/command_wrapper.rb
@@ -28,27 +28,29 @@ module Train::Extras
   class LinuxCommand < CommandWrapperBase
     Train::Options.attach(self)
 
-    option :shell, default: false
+    option :shell,         default: false
     option :shell_options, default: nil
     option :shell_command, default: nil
-    option :sudo, default: false
-    option :sudo_options, default: nil
+    option :sudo,          default: false
+    option :sudo_options,  default: nil
     option :sudo_password, default: nil
-    option :sudo_command, default: nil
+    option :sudo_command,  default: nil
     option :user
+
+    attr_reader :backend
 
     def initialize(backend, options)
       @backend = backend
       validate_options(options)
 
-      @shell = options[:shell]
+      @shell         = options[:shell]
       @shell_options = options[:shell_options] # e.g. '--login'
       @shell_command = options[:shell_command] # e.g. '/bin/sh'
-      @sudo = options[:sudo]
-      @sudo_options = options[:sudo_options]
+      @sudo          = options[:sudo]
+      @sudo_options  = options[:sudo_options]
       @sudo_password = options[:sudo_password]
-      @sudo_command = options[:sudo_command]
-      @user = options[:user]
+      @sudo_command  = options[:sudo_command]
+      @user          = options[:user]
     end
 
     # (see CommandWrapperBase::verify)
@@ -96,9 +98,12 @@ module Train::Extras
 
       res = (@sudo_command || "sudo") + " "
 
-      res = "#{safe_string(@sudo_password + "\n")} | #{res}-S " unless @sudo_password.nil?
+      if @sudo_password
+        str = safe_string(@sudo_password + "\n")
+        res = "#{str} | #{res}-S "
+      end
 
-      res << @sudo_options.to_s + " " unless @sudo_options.nil?
+      res << "#{@sudo_options} " if @sudo_options
 
       res + cmd
     end
@@ -109,7 +114,7 @@ module Train::Extras
       return cmd unless @shell
 
       shell = @shell_command || "$SHELL"
-      options = " " + @shell_options.to_s unless @shell_options.nil?
+      options = " #{@shell_options}" if @shell_options
 
       "#{safe_string(cmd)} | #{shell}#{options}"
     end

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -158,6 +158,12 @@ class Train::Transports::SSH
       @session.forward.remote(port, host, remote_port, remote_host)
     end
 
+    def obscured_options
+      options_to_print = @options.clone
+      options_to_print[:password] = "<hidden>" if options_to_print.key?(:password)
+      options_to_print
+    end
+
     private
 
     PING_COMMAND = "echo '[SSH] Established'".freeze
@@ -182,6 +188,7 @@ class Train::Transports::SSH
     # @api private
     def establish_connection(opts)
       logger.debug("[SSH] opening connection to #{self}")
+      logger.debug("[SSH] using options %p" % [obscured_options])
       if check_proxy
         require "net/ssh/proxy/command"
         @options[:proxy] = Net::SSH::Proxy::Command.new(generate_proxy_command)
@@ -270,9 +277,7 @@ class Train::Transports::SSH
     #
     # @api private
     def to_s
-      options_to_print = @options.clone
-      options_to_print[:password] = "<hidden>" if options_to_print.key?(:password)
-      "#{@username}@#{@hostname}<#{options_to_print.inspect}>"
+      "#{@username}@#{@hostname}"
     end
 
     # Given a channel and a command string, it will execute the command on the channel

--- a/test/unit/transports/helpers/azure/file_credentials_test.rb
+++ b/test/unit/transports/helpers/azure/file_credentials_test.rb
@@ -41,13 +41,13 @@ describe "parse_credentials_file" do
   it "handles a nil file" do
     options[:credentials_file] = nil
 
-    result = Train::Transports::Helpers::Azure::FileCredentials.parse(options)
+    result = Train::Transports::Helpers::Azure::FileCredentials.parse(**options)
 
     assert_empty(result)
   end
 
   it "returns empty hash when no credentials file detected" do
-    result = Train::Transports::Helpers::Azure::FileCredentials.parse({})
+    result = Train::Transports::Helpers::Azure::FileCredentials.parse(**{})
 
     assert_empty(result)
   end
@@ -55,7 +55,7 @@ describe "parse_credentials_file" do
   it "loads only entry from file when no subscription id given" do
     options[:credentials_file] = cred_file_single_entry.path
 
-    result = Train::Transports::Helpers::Azure::FileCredentials.parse(options)
+    result = Train::Transports::Helpers::Azure::FileCredentials.parse(**options)
 
     assert_equal("my_tenant_id",       result[:tenant_id])
     assert_equal("my_client_id",       result[:client_id])
@@ -65,7 +65,7 @@ describe "parse_credentials_file" do
 
   it "raises an error when no subscription id given and multiple entries" do
     error = assert_raises RuntimeError do
-      Train::Transports::Helpers::Azure::FileCredentials.parse(options)
+      Train::Transports::Helpers::Azure::FileCredentials.parse(**options)
     end
 
     assert_equal("Credentials file must have one entry. Check your credentials file. If you have more than one entry set AZURE_SUBSCRIPTION_ID environment variable.", error.message)
@@ -74,7 +74,7 @@ describe "parse_credentials_file" do
   it "loads entry when subscription id is given" do
     options[:subscription_id] = "my_subscription_id"
 
-    result = Train::Transports::Helpers::Azure::FileCredentials.parse(options)
+    result = Train::Transports::Helpers::Azure::FileCredentials.parse(**options)
 
     assert_equal("my_tenant_id",       result[:tenant_id])
     assert_equal("my_client_id",       result[:client_id])
@@ -86,7 +86,7 @@ describe "parse_credentials_file" do
     options[:subscription_id] = "missing_subscription_id"
 
     error = assert_raises RuntimeError do
-      Train::Transports::Helpers::Azure::FileCredentials.parse(options)
+      Train::Transports::Helpers::Azure::FileCredentials.parse(**options)
     end
 
     assert_equal("No credentials found for subscription number missing_subscription_id", error.message)
@@ -95,7 +95,7 @@ describe "parse_credentials_file" do
   it "loads entry based on index" do
     ENV["AZURE_SUBSCRIPTION_NUMBER"] = "2"
 
-    result = Train::Transports::Helpers::Azure::FileCredentials.parse(options)
+    result = Train::Transports::Helpers::Azure::FileCredentials.parse(**options)
 
     ENV.delete("AZURE_SUBSCRIPTION_NUMBER")
 
@@ -109,7 +109,7 @@ describe "parse_credentials_file" do
     ENV["AZURE_SUBSCRIPTION_NUMBER"] = "3"
 
     error = assert_raises RuntimeError do
-      Train::Transports::Helpers::Azure::FileCredentials.parse(options)
+      Train::Transports::Helpers::Azure::FileCredentials.parse(**options)
     end
     ENV.delete("AZURE_SUBSCRIPTION_NUMBER")
 
@@ -120,7 +120,7 @@ describe "parse_credentials_file" do
     ENV["AZURE_SUBSCRIPTION_NUMBER"] = "0"
 
     error = assert_raises RuntimeError do
-      Train::Transports::Helpers::Azure::FileCredentials.parse(options)
+      Train::Transports::Helpers::Azure::FileCredentials.parse(**options)
     end
     ENV.delete("AZURE_SUBSCRIPTION_NUMBER")
 

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -193,12 +193,11 @@ describe "ssh transport" do
     end
   end
 
-  describe "converting connection to string for logging" do
+  describe "obscured_options" do
     it "masks passwords" do
-      assert_output(/.*:password=>"<hidden>".*/) do
-        connection = cls.new(conf).connection
-        puts "#{connection}"
-      end
+      connection = cls.new(conf).connection
+
+      assert_equal "<hidden>", connection.obscured_options[:password]
     end
   end
 


### PR DESCRIPTION
Does 2 things:

+ Forces pty if we're verifying w/ @sudo (but only during verify).
+ Wraps up the sudo verify command closing stdin while using `sudo -Sv`.

Quite a bit of cleanup in the ssh files as well, you might want to review the last commit first.