### PR TITLE
Add extended metadata

### DIFF
--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -20,8 +20,14 @@ Gem::Specification.new do |spec|
   spec.email         = ["drichter@chef.io"]
   spec.summary       = "Transport interface to talk to a selected set of backends."
   spec.description   = "A minimal Train with a backends for ssh and winrm."
-  spec.homepage      = "https://github.com/inspec/train/"
   spec.license       = "Apache-2.0"
+
+  spec.metadata = {
+    "homepage_uri" => "https://github.com/inspec/train",
+    "changelog_uri" => "https://github.com/inspec/train/blob/master/CHANGELOG.md",
+    "source_code_uri" => "https://github.com/inspec/train",
+    "bug_tracker_uri" => "https://github.com/inspec/train/issues",
+  }
 
   spec.required_ruby_version = ">= 2.4"
 

--- a/train.gemspec
+++ b/train.gemspec
@@ -10,8 +10,14 @@ Gem::Specification.new do |spec|
   spec.email         = ["drichter@chef.io"]
   spec.summary       = "Transport interface to talk to different backends."
   spec.description   = "Transport interface to talk to different backends."
-  spec.homepage      = "https://github.com/inspec/train/"
   spec.license       = "Apache-2.0"
+
+  spec.metadata = {
+    "homepage_uri" => "https://github.com/inspec/train",
+    "changelog_uri" => "https://github.com/inspec/train/blob/master/CHANGELOG.md",
+    "source_code_uri" => "https://github.com/inspec/train",
+    "bug_tracker_uri" => "https://github.com/inspec/train/issues",
+  }
 
   spec.files = %w{LICENSE} + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
 


### PR DESCRIPTION
This gives us links to the issue tracker and the changelog right on rubygems.

Signed-off-by: Tim Smith <tsmith@chef.io>