### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/train.rb
+++ b/lib/train.rb
@@ -2,11 +2,11 @@
 #
 # Author:: Dominik Richter (<dominik.richter@gmail.com>)
 
-require "train/version"
-require "train/options"
-require "train/plugins"
-require "train/errors"
-require "train/platforms"
+require_relative "train/version"
+require_relative "train/options"
+require_relative "train/plugins"
+require_relative "train/errors"
+require_relative "train/platforms"
 require "uri"
 
 module Train

--- a/lib/train/extras.rb
+++ b/lib/train/extras.rb
@@ -3,8 +3,8 @@
 # Author:: Dominik Richter (<dominik.richter@gmail.com>)
 
 module Train::Extras
-  require "train/extras/command_wrapper"
-  require "train/extras/stat"
+  require_relative "extras/command_wrapper"
+  require_relative "extras/stat"
 
   CommandResult = Struct.new(:stdout, :stderr, :exit_status)
   LoginCommand = Struct.new(:command, :arguments)

--- a/lib/train/extras/command_wrapper.rb
+++ b/lib/train/extras/command_wrapper.rb
@@ -3,7 +3,7 @@
 # author: Christoph Hartmann
 
 require "base64"
-require "train/errors"
+require_relative "../errors"
 
 module Train::Extras
   # Define the interface of all command wrappers.

--- a/lib/train/file.rb
+++ b/lib/train/file.rb
@@ -3,9 +3,9 @@
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require "train/file/local"
-require "train/file/remote"
-require "train/extras/stat"
+require_relative "file/local"
+require_relative "file/remote"
+require_relative "extras/stat"
 
 module Train
   class File # rubocop:disable Metrics/ClassLength

--- a/lib/train/file/local.rb
+++ b/lib/train/file/local.rb
@@ -78,5 +78,5 @@ end
 
 # subclass requires are loaded after Train::File::Local is defined
 # to avoid superclass mismatch errors
-require "train/file/local/unix"
-require "train/file/local/windows"
+require_relative "local/unix"
+require_relative "local/windows"

--- a/lib/train/file/local/unix.rb
+++ b/lib/train/file/local/unix.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 require "shellwords"
-require "train/extras/stat"
+require_relative "../../extras/stat"
 
 module Train
   class File

--- a/lib/train/file/remote.rb
+++ b/lib/train/file/remote.rb
@@ -33,8 +33,8 @@ end
 
 # subclass requires are loaded after Train::File::Remote is defined
 # to avoid superclass mismatch errors
-require "train/file/remote/aix"
-require "train/file/remote/linux"
-require "train/file/remote/qnx"
-require "train/file/remote/unix"
-require "train/file/remote/windows"
+require_relative "remote/aix"
+require_relative "remote/linux"
+require_relative "remote/qnx"
+require_relative "remote/unix"
+require_relative "remote/windows"

--- a/lib/train/file/remote/aix.rb
+++ b/lib/train/file/remote/aix.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require "train/file/remote/unix"
+require_relative "unix"
 
 module Train
   class File

--- a/lib/train/file/remote/linux.rb
+++ b/lib/train/file/remote/linux.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require "train/file/remote/unix"
+require_relative "unix"
 
 module Train
   class File

--- a/lib/train/file/remote/qnx.rb
+++ b/lib/train/file/remote/qnx.rb
@@ -3,7 +3,7 @@
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require "train/file/remote/unix"
+require_relative "unix"
 
 module Train
   class File

--- a/lib/train/platforms.rb
+++ b/lib/train/platforms.rb
@@ -1,13 +1,13 @@
 # encoding: utf-8
 
-require "train/platforms/common"
-require "train/platforms/detect"
-require "train/platforms/detect/scanner"
-require "train/platforms/detect/specifications/os"
-require "train/platforms/detect/specifications/api"
-require "train/platforms/detect/uuid"
-require "train/platforms/family"
-require "train/platforms/platform"
+require_relative "platforms/common"
+require_relative "platforms/detect"
+require_relative "platforms/detect/scanner"
+require_relative "platforms/detect/specifications/os"
+require_relative "platforms/detect/specifications/api"
+require_relative "platforms/detect/uuid"
+require_relative "platforms/family"
+require_relative "platforms/platform"
 
 module Train::Platforms
   # Retrieve the current platform list

--- a/lib/train/platforms/detect/helpers/os_common.rb
+++ b/lib/train/platforms/detect/helpers/os_common.rb
@@ -1,5 +1,5 @@
-require "train/platforms/detect/helpers/os_linux"
-require "train/platforms/detect/helpers/os_windows"
+require_relative "os_linux"
+require_relative "os_windows"
 require "rbconfig"
 
 module Train::Platforms::Detect::Helpers

--- a/lib/train/platforms/detect/scanner.rb
+++ b/lib/train/platforms/detect/scanner.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require "train/platforms/detect/helpers/os_common"
+require_relative "helpers/os_common"
 
 module Train::Platforms::Detect
   class Scanner

--- a/lib/train/plugin_test_helper.rb
+++ b/lib/train/plugin_test_helper.rb
@@ -3,7 +3,7 @@
 
 # Load Train.  We certainly need the plugin system, and also several other parts
 # that are tightly coupled.  Train itself is fairly light, and non-invasive.
-require "train"
+require_relative "../train"
 
 # You can select from a number of test harnesses.  Since Train is closely related
 # to InSpec, and InSpec uses Spec-style controls in profile code, you will

--- a/lib/train/plugins.rb
+++ b/lib/train/plugins.rb
@@ -3,11 +3,11 @@
 # Author:: Dominik Richter (<dominik.richter@gmail.com>)
 # Author:: Christoph Hartmann (<chris@lollyrock.com>)
 
-require "train/errors"
+require_relative "errors"
 
 module Train
   class Plugins
-    require "train/plugins/transport"
+    require_relative "plugins/transport"
 
     class << self
       # Retrieve the current plugin registry, containing all plugin names

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -1,8 +1,8 @@
 # encoding: utf-8
 
-require "train/errors"
-require "train/extras"
-require "train/file"
+require_relative "../errors"
+require_relative "../extras"
+require_relative "../file"
 require "logger"
 
 class Train::Plugins::Transport
@@ -88,7 +88,7 @@ class Train::Plugins::Transport
     end
 
     def load_json(j)
-      require "train/transports/mock"
+      require_relative "../transports/mock"
       j["files"].each do |path, jf|
         @cache[:file][path] = Train::Transports::Mock::Connection::File.from_json(jf)
       end

--- a/lib/train/plugins/transport.rb
+++ b/lib/train/plugins/transport.rb
@@ -4,16 +4,16 @@
 # Author:: Christoph Hartmann (<chris@lollyrock.com>)
 
 require "logger"
-require "train/errors"
-require "train/extras"
-require "train/options"
+require_relative "../errors"
+require_relative "../extras"
+require_relative "../options"
 
 class Train::Plugins
   class Transport
     include Train::Extras
     Train::Options.attach(self)
 
-    require "train/plugins/base_connection"
+    require_relative "base_connection"
 
     # Initialize a new Transport object
     #

--- a/lib/train/transports/azure.rb
+++ b/lib/train/transports/azure.rb
@@ -1,15 +1,15 @@
 # encoding: utf-8
 
-require "train/plugins"
+require_relative "../plugins"
 require "ms_rest_azure"
 require "azure_mgmt_resources"
 require "azure_graph_rbac"
 require "azure_mgmt_key_vault"
 require "socket"
 require "timeout"
-require "train/transports/helpers/azure/file_credentials"
-require "train/transports/clients/azure/graph_rbac"
-require "train/transports/clients/azure/vault"
+require_relative "helpers/azure/file_credentials"
+require_relative "clients/azure/graph_rbac"
+require_relative "clients/azure/vault"
 
 module Train::Transports
   class Azure < Train.plugin(1)

--- a/lib/train/transports/gcp.rb
+++ b/lib/train/transports/gcp.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require "train/plugins"
+require_relative "../plugins"
 require "google/apis"
 require "google/apis/cloudresourcemanager_v1"
 require "google/apis/compute_v1"

--- a/lib/train/transports/helpers/azure/file_credentials.rb
+++ b/lib/train/transports/helpers/azure/file_credentials.rb
@@ -1,9 +1,9 @@
 # encoding: utf-8
 
 require "inifile"
-require "train/transports/helpers/azure/file_parser"
-require "train/transports/helpers/azure/subscription_number_file_parser"
-require "train/transports/helpers/azure/subscription_id_file_parser"
+require_relative "file_parser"
+require_relative "subscription_number_file_parser"
+require_relative "subscription_id_file_parser"
 
 module Train::Transports
   module Helpers

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -3,8 +3,8 @@
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require "train/plugins"
-require "train/errors"
+require_relative "../plugins"
+require_relative "../errors"
 require "mixlib/shellout"
 
 module Train::Transports

--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -1,4 +1,4 @@
-require "train/plugins"
+require_relative "../plugins"
 require "digest"
 
 module Train::Transports

--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -20,7 +20,7 @@
 
 require "net/ssh"
 require "net/scp"
-require "train/errors"
+require_relative "../errors"
 
 module Train::Transports
   # Wrapped exception for any internally raised SSH-related errors.
@@ -36,8 +36,8 @@ module Train::Transports
   class SSH < Train.plugin(1) # rubocop:disable Metrics/ClassLength
     name "ssh"
 
-    require "train/transports/ssh_connection"
-    require "train/transports/cisco_ios_connection"
+    require_relative "ssh_connection"
+    require_relative "cisco_ios_connection"
 
     # add options for submodules
     include_options Train::Extras::CommandWrapper

--- a/lib/train/transports/vmware.rb
+++ b/lib/train/transports/vmware.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require "train/plugins"
+require_relative "../plugins"
 require "open3"
 require "ostruct"
 require "json"
@@ -35,7 +35,7 @@ module Train::Transports
         @powershell_binary = detect_powershell_binary
 
         if @powershell_binary == :powershell
-          require "train/transports/local"
+          require_relative "local"
           @powershell = Train::Transports::Local::Connection.new(options)
         end
 


### PR DESCRIPTION
require_relative is significantly faster and should be used when available. See @lamont-granquist for the full story.

Signed-off-by: Tim Smith <tsmith@chef.io>