### PR TITLE
allow overriding follow_symlink on Train::File

### DIFF
--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -213,17 +213,17 @@ class Train::Transports::SSH
       retry
     end
 
-    def file_via_connection(path)
+    def file_via_connection(path, *args)
       if os.aix?
-        Train::File::Remote::Aix.new(self, path)
+        Train::File::Remote::Aix.new(self, path, *args)
       elsif os.solaris?
-        Train::File::Remote::Unix.new(self, path)
+        Train::File::Remote::Unix.new(self, path, *args)
       elsif os[:name] == "qnx"
-        Train::File::Remote::Qnx.new(self, path)
+        Train::File::Remote::Qnx.new(self, path, *args)
       elsif os.windows?
-        Train::File::Remote::Windows.new(self, path)
+        Train::File::Remote::Windows.new(self, path, *args)
       else
-        Train::File::Remote::Linux.new(self, path)
+        Train::File::Remote::Linux.new(self, path, *args)
       end
     end
 


### PR DESCRIPTION
The File resource in InSpec the symlink related options isn't working right because follow_symlink is always true.

Consider..

```
module Train
  class File
    def initialize(backend, path, follow_symlink = true)
    end
  end
end
```

The remote file resources in train were not allowing this to be set.

Related https://github.com/inspec/inspec/issues/3876