### PR TITLE
Yocto Project Linux platform detection support

### DIFF
--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -318,6 +318,16 @@ module Train::Platforms::Detect::Specifications
           end
         end
 
+      # yocto family if they haven't modified the base Poky project
+      plat.name("yocto").title("Yocto Project Linux").in_family("linux")
+        .detect do
+          if unix_file_contents("/etc/issue").match?("Poky")
+            # assuming the Poky version is preferred over the /etc/version build
+            @platform[:release] = unix_file_contents("/etc/issue").match('\d+(\.\d+)+')[0]
+            true
+          end
+        end
+
       # brocade family detected here if device responds to 'uname' command,
       # happens when logging in as root
       plat.family("brocade").title("Brocade Family").in_family("linux")
@@ -457,7 +467,7 @@ module Train::Platforms::Detect::Specifications
       # bsd family
       plat.family("bsd").in_family("unix")
         .detect do
-            # we need a better way to determin this family
+            # we need a better way to determine this family
             # for now we are going to just try each platform
           true
         end

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -278,6 +278,18 @@ describe "os_detect" do
     end
   end
 
+  describe "yocto" do
+    it "sets the correct family, name, and release on yocto" do
+      files = {
+        "/etc/issue" => "Poky (Yocto Project Reference Distro) 2.7 \\n \\l",
+      }
+      platform = scan_with_files("linux", files)
+      _(platform[:name]).must_equal("yocto")
+      _(platform[:family]).must_equal("linux")
+      _(platform[:release]).must_equal("2.7")
+    end
+  end
+
   describe "qnx" do
     it "sets the correct info for qnx platform" do
       platform = scan_with_files("qnx", {})


### PR DESCRIPTION
Signed-off-by: Matt Ray <matthewhray@gmail.com>

Add support for [Yocto Project Linux](https://www.yoctoproject.org/)

## Description
This is an embedded Linux that doesn't appear to use the LSB stuff by default.