### PR TITLE
Kali Linux platform detection support

### DIFF
--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -76,6 +76,13 @@ module Train::Platforms::Detect::Specifications
             true
           end
         end
+      plat.name("kali").title("Kali Linux").in_family("debian")
+        .detect do
+          if linux_os_release && linux_os_release["ID"].eql?("kali")
+            @platform[:release] = linux_os_release["VERSION"]
+            true
+          end
+        end
       plat.name("raspbian").title("Raspbian Linux").in_family("debian")
         .detect do
           if (linux_os_release && linux_os_release["NAME"] =~ /raspbian/i) || \

--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -78,8 +78,9 @@ module Train::Platforms::Detect::Specifications
         end
       plat.name("kali").title("Kali Linux").in_family("debian")
         .detect do
-          if linux_os_release && linux_os_release["ID"].eql?("kali")
-            @platform[:release] = linux_os_release["VERSION"]
+          l_o_r = linux_os_release
+          if l_o_r && l_o_r["ID"] == "kali"
+            @platform[:release] = l_o_r["VERSION"]
             true
           end
         end

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -140,6 +140,20 @@ describe "os_detect" do
       end
     end
 
+    describe "kali" do
+      it "sets the correct family/release for kali" do
+        os_release = "PRETTY_NAME=\"Kali GNU/Linux Rolling\"\nNAME=\"Kali GNU/Linux\"\nID=kali\nVERSION=\"2019.4\"\nVERSION_ID=\"2019.4\"\nVERSION_CODENAME=\"kali-rolling\"\nID_LIKE=debian\nANSI_COLOR=\"1;31\"\nHOME_URL=\"https://www.kali.org/\"\nSUPPORT_URL=\"https://forums.kali.org/\"\nBUG_REPORT_URL=\"https://bugs.kali.org/\"\n"
+        files = {
+          "/etc/os-release" => os_release,
+          "/etc/debian_version" => "kali-rolling",
+        }
+        platform = scan_with_files("linux", files)
+        _(platform[:name]).must_equal("kali")
+        _(platform[:family]).must_equal("debian")
+        _(platform[:release]).must_equal("2019.4")
+      end
+    end
+
     describe "raspbian" do
       it "sets the correct family/release for raspbian " do
         files = {


### PR DESCRIPTION
Add support for detecting [Kali Linux](https://www.kali.org)

Signed-off-by: Matt Ray <github@mattray.dev>
