### PR TITLE
Yocto Project family and Yocto Linux and balenaOS platform detection

### DIFF
--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -318,6 +318,16 @@ module Train::Platforms::Detect::Specifications
           end
         end
 
+      # yocto family if they haven't modified the base Poky project
+      plat.name("yocto").title("Yocto Project Linux").in_family("linux")
+        .detect do
+          if unix_file_contents("/etc/issue").match?("Poky")
+            # assuming the Poky version is preferred over the /etc/version build
+            @platform[:release] = unix_file_contents("/etc/issue").match('\d+(\.\d+)+')[0]
+            true
+          end
+        end
+
       # brocade family detected here if device responds to 'uname' command,
       # happens when logging in as root
       plat.family("brocade").title("Brocade Family").in_family("linux")
@@ -457,7 +467,7 @@ module Train::Platforms::Detect::Specifications
       # bsd family
       plat.family("bsd").in_family("unix")
         .detect do
-            # we need a better way to determin this family
+            # we need a better way to determine this family
             # for now we are going to just try each platform
           true
         end

--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -17,7 +17,7 @@ module Train::Platforms::Detect::Specifications
 
       plat.family("windows").in_family("os")
         .detect do
-            # Can't return from a `proc` thus the `is_windows` shenanigans
+          # Can't return from a `proc` thus the `is_windows` shenanigans
           is_windows = false
           is_windows = true if winrm?
 
@@ -25,7 +25,7 @@ module Train::Platforms::Detect::Specifications
             is_windows = true if ruby_host_os(/mswin|mingw32|windows/)
           end
 
-            # Try to detect windows even for ssh transport
+          # Try to detect windows even for ssh transport
           if !is_windows && detect_windows == true
             is_windows = true
           end
@@ -41,8 +41,8 @@ module Train::Platforms::Detect::Specifications
       # unix master family
       plat.family("unix").in_family("os")
         .detect do
-            # we want to catch a special case here where cisco commands
-            # don't return an exit status and still print to stdout
+          # we want to catch a special case here where cisco commands
+          # don't return an exit status and still print to stdout
           if unix_uname_s =~ /./ && !unix_uname_s.start_with?("Line has invalid autocommand ") && !unix_uname_s.start_with?("The command you have entered")
             @platform[:arch] = unix_uname_m
             true
@@ -92,7 +92,7 @@ module Train::Platforms::Detect::Specifications
             true
           end
 
-            # if we get this far we have to be some type of debian
+          # if we get this far we have to be some type of debian
           @platform[:release] = unix_file_contents("/etc/debian_version").chomp
           true
         end
@@ -136,9 +136,9 @@ module Train::Platforms::Detect::Specifications
       # redhat family
       plat.family("redhat").in_family("linux")
         .detect do
-            # I am not sure this returns true for all redhats in this family
-            # for now we are going to just try each platform
-            # return true unless unix_file_contents('/etc/redhat-release').nil?
+          # I am not sure this returns true for all redhats in this family
+          # for now we are going to just try each platform
+          # return true unless unix_file_contents('/etc/redhat-release').nil?
 
           true
         end
@@ -318,12 +318,31 @@ module Train::Platforms::Detect::Specifications
           end
         end
 
-      # yocto family if they haven't modified the base Poky project
-      plat.name("yocto").title("Yocto Project Linux").in_family("linux")
+      # yocto family
+      plat.family("yocto").in_family("linux")
+        .detect do
+          # /etc/issue isn't specific to yocto, but it's the only way to detect
+          # the platform because there are no other identifying files
+          if unix_file_contents("/etc/issue") &&
+              (unix_file_contents("/etc/issue").match?("Poky") ||
+               unix_file_contents("/etc/issue").match?("balenaOS"))
+            true
+          end
+        end
+      plat.name("yocto").title("Yocto Project Linux").in_family("yocto")
         .detect do
           if unix_file_contents("/etc/issue").match?("Poky")
             # assuming the Poky version is preferred over the /etc/version build
             @platform[:release] = unix_file_contents("/etc/issue").match('\d+(\.\d+)+')[0]
+            true
+          end
+        end
+      plat.name("balenaos").title("balenaOS Linux").in_family("yocto")
+        .detect do
+          # balenaOS does have the /etc/os-release file
+          if unix_file_contents("/etc/issue").match?("balenaOS") &&
+              linux_os_release["NAME"] =~ /balenaos/i
+            @platform[:release] = linux_os_release["META_BALENA_VERSION"]
             true
           end
         end
@@ -335,9 +354,9 @@ module Train::Platforms::Detect::Specifications
           !brocade_version.nil?
         end
 
-      # genaric linux
+      # generic linux
       # this should always be last in the linux family list
-      plat.name("linux").title("Genaric Linux").in_family("linux")
+      plat.name("linux").title("Generic Linux").in_family("linux")
         .detect do
           true
         end
@@ -436,7 +455,7 @@ module Train::Platforms::Detect::Specifications
             true
           end
 
-            # must be some unknown solaris
+          # must be some unknown solaris
           true
         end
 
@@ -467,8 +486,8 @@ module Train::Platforms::Detect::Specifications
       # bsd family
       plat.family("bsd").in_family("unix")
         .detect do
-            # we need a better way to determine this family
-            # for now we are going to just try each platform
+          # we need a better way to determine this family
+          # for now we are going to just try each platform
           true
         end
       plat.family("darwin").in_family("bsd")
@@ -494,7 +513,7 @@ module Train::Platforms::Detect::Specifications
         end
       plat.name("darwin").title("Darwin").in_family("darwin")
         .detect do
-            # must be some other type of darwin
+          # must be some other type of darwin
           @platform[:name] = unix_uname_s.lines[0].chomp
           true
         end

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -278,6 +278,18 @@ describe "os_detect" do
     end
   end
 
+  describe "yocto" do
+    it "sets the correct family, name, and release on yocto" do
+      files = {
+        "/etc/issue" => "Poky (Yocto Project Reference Distro) 2.7 \\n \\l",
+      }
+      platform = scan_with_files("linux", files)
+      _(platform[:name]).must_equal("yocto")
+      _(platform[:family]).must_equal("linux")
+      _(platform[:release]).must_equal("2.7")
+    end
+  end
+
   describe "qnx" do
     it "sets the correct info for qnx platform" do
       platform = scan_with_files("qnx", {})

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -202,7 +202,7 @@ describe "os_detect" do
 
   describe "/etc/os-release" do
     describe "when not on a wrlinux build" do
-      it "fail back to genaric linux" do
+      it "fail back to generic linux" do
         os_release = "ID_LIKE=cisco-unkwown\nVERSION=unknown"
         files = {
           "/etc/os-release" => os_release,
@@ -285,8 +285,21 @@ describe "os_detect" do
       }
       platform = scan_with_files("linux", files)
       _(platform[:name]).must_equal("yocto")
-      _(platform[:family]).must_equal("linux")
+      _(platform[:family]).must_equal("yocto")
       _(platform[:release]).must_equal("2.7")
+    end
+  end
+
+  describe "balenaos" do
+    it "sets the correct family, name, and release on balenaos" do
+      files = {
+        "/etc/issue" => "balenaOS 2.46.1 \n \l",
+        "/etc/os-release" => "ID=\"balena-os\"\nNAME=\"balenaOS\"\nVERSION=\"2.46.1+rev1\"\nVERSION_ID=\"2.46.1+rev1\"\nPRETTY_NAME=\"balenaOS 2.46.1+rev1\"\nMACHINE=\"raspberrypi3\"\nVARIANT=\"Development\"\nVARIANT_ID=\"dev\"\nMETA_BALENA_VERSION=\"2.46.1\"\nRESIN_BOARD_REV=\"e194600\"\nMETA_RESIN_REV=\"f2295d2\"\nSLUG=\"raspberrypi3\"\n",
+      }
+      platform = scan_with_files("linux", files)
+      _(platform[:name]).must_equal("balenaos")
+      _(platform[:family]).must_equal("yocto")
+      _(platform[:release]).must_equal("2.46.1")
     end
   end
 


### PR DESCRIPTION
Add support for [Yocto Project Linux](https://www.yoctoproject.org/) family of Linuxes. Yocto is an embedded Linux and [balenaOS](https://www.balena.io/os) is a Yocto-derived platform.

