### PR TITLE
Make stat command use '-c' for Yocto OS

### DIFF
--- a/lib/train/extras/stat.rb
+++ b/lib/train/extras/stat.rb
@@ -35,7 +35,7 @@ module Train::Extras
 
     def self.linux_stat(shell_escaped_path, backend, follow_symlink)
       lstat = follow_symlink ? " -L" : ""
-      format = (backend.os.esx? || backend.os[:name] == "alpine") ? "-c" : "--printf"
+      format = (backend.os.esx? || backend.os[:name] == "alpine" || backend.os[:name] == "yocto") ? "-c" : "--printf"
       res = backend.run_command("stat#{lstat} #{shell_escaped_path} 2>/dev/null #{format} '%s\n%f\n%U\n%u\n%G\n%g\n%X\n%Y\n%C'")
       # ignore the exit_code: it is != 0 if selinux labels are not supported
       # on the system.

--- a/test/unit/extras/stat_test.rb
+++ b/test/unit/extras/stat_test.rb
@@ -131,6 +131,36 @@ describe "stat" do
     end
   end
 
+  describe "yocto stat" do
+    let(:backend) do
+      mock = Train::Transports::Mock.new(verbose: true).connection
+      mock.mock_os({ name: "yocto", family: "yocto", release: nil })
+      mock.commands = {
+          "stat /path 2>/dev/null -c '%s\n%f\n%U\n%u\n%G\n%g\n%X\n%Y\n%C'" => mock.mock_command("", "", "", 0),
+          "stat /path-stat 2>/dev/null -c '%s\n%f\n%U\n%u\n%G\n%g\n%X\n%Y\n%C'" => mock.mock_command("", "360\n43ff\nroot\n0\nrootz\n1\n1444520846\n1444522445\n?", "", 0),
+      }
+      mock
+    end
+
+    it "ignores wrong stat results" do
+      _(cls.linux_stat("/path", backend, false)).must_equal({})
+    end
+
+    it "reads correct stat results" do
+      _(cls.linux_stat("/path-stat", backend, false)).must_equal({
+                                                                     type: :directory,
+                                                                     mode: 01777,
+                                                                     owner: "root",
+                                                                     uid: 0,
+                                                                     group: "rootz",
+                                                                     gid: 1,
+                                                                     mtime: 1444522445,
+                                                                     size: 360,
+                                                                     selinux_label: nil,
+                                                                 })
+    end
+  end
+
   describe "bsd stat" do
     let(:backend) { Minitest::Mock.new }
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
When running inspec on a target with Yocto linux, the stat command used the `--printf` option instead of the `-c` switch. This causes e.g. the checking of file owners to break due to yocto using a different implementation of stat.

## Related Issue

https://github.com/inspec/train/pull/558

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
