### PR TITLE
Fix Release detection on macOS

### DIFF
--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -464,7 +464,7 @@ module Train::Platforms::Detect::Specifications
       plat.family("darwin").in_family("bsd")
         .detect do
           if unix_uname_s =~ /darwin/i
-            cmd = unix_file_contents("/usr/bin/sw_vers")
+            cmd = command_output("/usr/bin/sw_vers")
             unless cmd.nil?
               m = cmd.match(/^ProductVersion:\s+(.+)$/)
               @platform[:release] = m.nil? ? nil : m[1]
@@ -478,7 +478,7 @@ module Train::Platforms::Detect::Specifications
         end
       plat.name("mac_os_x").title("macOS X").in_family("darwin")
         .detect do
-          cmd = unix_file_contents("/System/Library/CoreServices/SystemVersion.plist")
+          cmd = command_output("/usr/bin/sw_vers")
           @platform[:uuid_command] = "system_profiler SPHardwareDataType | awk '/UUID/ { print $3; }'"
           true if cmd =~ /Mac OS X/i
         end

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -86,22 +86,24 @@ describe "os_detect" do
   describe "darwin" do
     describe "mac_os_x" do
       it "sets the correct family, name, and release on os_x" do
-        files = {
-          "/System/Library/CoreServices/SystemVersion.plist" => "<string>Mac OS X</string>",
-        }
-        platform = scan_with_files("darwin", files)
+        mock = Train::Transports::Mock::Connection.new
+        mock.mock_command("uname -s", "darwin")
+        mock.mock_command("/usr/bin/sw_vers", "ProductName:	Mac OS X\nProductVersion:	10.14.6\nBuildVersion:	18G2022")
+        platform = Train::Platforms::Detect.scan(mock)
+
         _(platform[:name]).must_equal("mac_os_x")
         _(platform[:family]).must_equal("darwin")
-        _(platform[:release]).must_equal("test-release")
+        _(platform[:release]).must_equal("10.14.6")
       end
     end
 
     describe "generic darwin" do
       it "sets the correct family, name, and release on darwin" do
-        files = {
-          "/usr/bin/sw_vers" => "ProductVersion: 17.0.1\nBuildVersion: alpha.x1",
-        }
-        platform = scan_with_files("darwin", files)
+        mock = Train::Transports::Mock::Connection.new
+        mock.mock_command("uname -s", "darwin")
+        mock.mock_command("/usr/bin/sw_vers", "ProductVersion: 17.0.1\nBuildVersion: alpha.x1")
+        platform = Train::Platforms::Detect.scan(mock)
+
         _(platform[:name]).must_equal("darwin")
         _(platform[:family]).must_equal("darwin")
         _(platform[:release]).must_equal("17.0.1")


### PR DESCRIPTION
This was returning '18.7.0' for the 10.14.6 Mojave release and it came
down to this was the version of the Darwin kernel instead of the macOS
release. The content of '/usr/bin/sw_vers' was being checked instead
of the output of the command, which was the source of the failure.

Signed-off-by: Matt Ray <github@mattray.dev>