### PR TITLE
Unified gemspec and fixed dependencies across train and train-core.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :test do
   # but it's close enough to show the gempath handler can find a plugin
   # See test/unit/
   gem "train-test-fixture", path: "test/fixtures/plugins/train-test-fixture"
+  gem "mocha", "~> 1.1"
 end
 
 group :integration do

--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -3,21 +3,11 @@ lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "train/version"
 
-CORE_TRANSPORTS = [
-  "lib/train/transports/local.rb",
-  "lib/train/transports/mock.rb",
-  "lib/train/transports/ssh.rb",
-  "lib/train/transports/ssh_connection.rb",
-  "lib/train/transports/cisco_ios_connection.rb",
-  "lib/train/transports/winrm.rb",
-  "lib/train/transports/winrm_connection.rb",
-].freeze
-
 Gem::Specification.new do |spec|
   spec.name          = "train-core"
   spec.version       = Train::VERSION
-  spec.authors       = ["Dominik Richter"]
-  spec.email         = ["drichter@chef.io"]
+  spec.authors       = ["Chef InSpec Team"]
+  spec.email         = ["inspec@chef.io"]
   spec.summary       = "Transport interface to talk to a selected set of backends."
   spec.description   = "A minimal Train with a backends for ssh and winrm."
   spec.license       = "Apache-2.0"
@@ -31,16 +21,15 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4"
 
-  spec.files = %w{LICENSE} + Dir
-    .glob("lib/**/*", File::FNM_DOTMATCH)
-    .reject { |f| f =~ %r{lib/train/transports} unless CORE_TRANSPORTS.include?(f) }
+  spec.files = Dir.glob("{LICENSE,lib/**/*}")
+    .grep_v(%r{transports/(azure|clients|docker|gcp|helpers|vmware)})
     .reject { |f| File.directory?(f) }
 
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "inifile", "~> 3.0"
   spec.add_dependency "json", ">= 1.8", "< 3.0"
   spec.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
-  spec.add_dependency "net-ssh", ">= 2.9", "< 6.0"
   spec.add_dependency "net-scp", ">= 1.2", "< 3.0"
+  spec.add_dependency "net-ssh", ">= 2.9", "< 6.0"
 end

--- a/train.gemspec
+++ b/train.gemspec
@@ -1,4 +1,4 @@
-# coding: utf-8
+# encoding: utf-8
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "train/version"
@@ -6,8 +6,8 @@ require "train/version"
 Gem::Specification.new do |spec|
   spec.name          = "train"
   spec.version       = Train::VERSION
-  spec.authors       = ["Dominik Richter"]
-  spec.email         = ["drichter@chef.io"]
+  spec.authors       = ["Chef InSpec Team"]
+  spec.email         = ["inspec@chef.io"]
   spec.summary       = "Transport interface to talk to different backends."
   spec.description   = "Transport interface to talk to different backends."
   spec.license       = "Apache-2.0"
@@ -19,28 +19,26 @@ Gem::Specification.new do |spec|
     "bug_tracker_uri" => "https://github.com/inspec/train/issues",
   }
 
-  spec.files = %w{LICENSE} + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
-
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
-
   spec.required_ruby_version = ">= 2.4"
 
-  spec.add_dependency "json", ">= 1.8", "< 3.0"
-  spec.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
-  spec.add_dependency "net-ssh", ">= 2.9", "< 6.0"
-  spec.add_dependency "net-scp", ">= 1.2", "< 3.0"
-  spec.add_dependency "docker-api", "~> 1.26"
-  spec.add_dependency "azure_mgmt_resources", "~> 0.15"
+  spec.files = Dir.glob("{LICENSE,lib/**/*}")
+    .grep(%r{transports/(azure|clients|docker|gcp|helpers|vmware)})
+    .reject { |f| File.directory?(f) }
+
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "train-core", "= #{Train::VERSION}"
+  spec.add_dependency "train-winrm", "~> 0.2"
+
+  # azure, docker, gcp dependencies
+  spec.add_dependency "activesupport", "~> 5.2.3"
   spec.add_dependency "azure_graph_rbac", "~> 0.16"
   spec.add_dependency "azure_mgmt_key_vault", "~> 0.17"
+  spec.add_dependency "azure_mgmt_resources", "~> 0.15"
   spec.add_dependency "azure_mgmt_security", "~> 0.18"
   spec.add_dependency "azure_mgmt_storage", "~> 0.18"
-  spec.add_dependency "activesupport", "~> 5.2.3"
+  spec.add_dependency "docker-api", "~> 1.26"
   spec.add_dependency "google-api-client", ">= 0.23.9", "< 0.35.0"
   spec.add_dependency "googleauth", ">= 0.6.6", "< 0.11.0"
-  spec.add_dependency "inifile"
-
-  spec.add_development_dependency "mocha", "~> 1.1"
 end


### PR DESCRIPTION
+ train-core has all the real dependencies for train (the project).
+ train keeps all azure/gcp/docker dependencies.
+ train depends on train-core.
+ Removed test_files entirely.
+ Removed FNM_DOTMATCH on our globs... don't cargo cult.
+ Added some code to print out the gemspec and files to make it easier
  to debug by executing the gemspec directly.
+ Sorted all deps... so hard to find things.

Signed-off-by: Ryan Davis <zenspider@chef.io>