### PR TITLE
Remove azure and GCP from rejected gemspec.files

### DIFF
--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.4"
 
   spec.files = Dir.glob("{LICENSE,lib/**/*}")
-    .grep_v(%r{transports/(clients|docker|helpers|vmware)})
+    .grep_v(%r{transports/(azure|clients|docker|gcp|helpers|vmware)})
     .reject { |f| File.directory?(f) }
 
   spec.require_paths = ["lib"]

--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.4"
 
   spec.files = Dir.glob("{LICENSE,lib/**/*}")
-    .grep_v(%r{transports/(azure|clients|docker|gcp|helpers|vmware)})
+    .grep_v(%r{transports/(clients|docker|helpers|vmware)})
     .reject { |f| File.directory?(f) }
 
   spec.require_paths = ["lib"]

--- a/train.gemspec
+++ b/train.gemspec
@@ -21,9 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4"
 
-  spec.files = Dir.glob("{LICENSE,lib/**/*}")
-    .grep(%r{transports/(clients|docker|helpers|vmware)})
-    .reject { |f| File.directory?(f) }
+  spec.files = %w{LICENSE} + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
 
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/train.gemspec
+++ b/train.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.4"
 
   spec.files = Dir.glob("{LICENSE,lib/**/*}")
-    .grep(%r{transports/(azure|clients|docker|gcp|helpers|vmware)})
+    .grep(%r{transports/(clients|docker|helpers|vmware)})
     .reject { |f| File.directory?(f) }
 
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Signed-off-by: Ross Moles <rmoles@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This should hopefully fix the error seen in the most recent version of inspec `Can't find train plugin azure. Please install it first`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/inspec/inspec-azure/issues/234

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
