### PR TITLE
Revert to regular require to fix transport loading across gem boundary

### DIFF
--- a/lib/train/transports/azure.rb
+++ b/lib/train/transports/azure.rb
@@ -1,15 +1,15 @@
 # encoding: utf-8
 
-require_relative "../plugins"
+require "train/plugins"
 require "ms_rest_azure"
 require "azure_mgmt_resources"
 require "azure_graph_rbac"
 require "azure_mgmt_key_vault"
 require "socket"
 require "timeout"
-require_relative "helpers/azure/file_credentials"
-require_relative "clients/azure/graph_rbac"
-require_relative "clients/azure/vault"
+require "train/transports/helpers/azure/file_credentials"
+require "train/transports/clients/azure/graph_rbac"
+require "train/transports/clients/azure/vault"
 
 module Train::Transports
   class Azure < Train.plugin(1)

--- a/lib/train/transports/gcp.rb
+++ b/lib/train/transports/gcp.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require_relative "../plugins"
+require "train/plugins"
 require "google/apis"
 require "google/apis/cloudresourcemanager_v1"
 require "google/apis/compute_v1"

--- a/lib/train/transports/vmware.rb
+++ b/lib/train/transports/vmware.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require_relative "../plugins"
+require "train/plugins"
 require "open3"
 require "ostruct"
 require "json"


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

Fixes https://github.com/inspec/inspec-azure/issues/234 . 

You can't require_relative a file when it is contained in a separate gem. So, our train-core / train split means we need to `require` these bundled files.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
