### PR TITLE
Update rake dep for security issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec name: "train"
 group :test do
   gem "coveralls", require: false
   gem "minitest", "~> 5.8"
-  gem "rake", "~> 10"
+  gem "rake", ["~> 12.3", ">= 12.3.3"]
   gem "chefstyle", "0.13.2"
   gem "simplecov", "~> 0.10"
   gem "concurrent-ruby", "~> 1.0"


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

CVE-2020-8130 is a security issue in Rake 12.3.2 and previous. This updates the Gemfile dep to be 12.3.3 and later.

