### PR TITLE
Move dependency on inifile from train-core to train

### DIFF
--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "addressable", "~> 2.5"
-  spec.add_dependency "inifile", "~> 3.0"
   spec.add_dependency "json", ">= 1.8", "< 3.0"
   spec.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
   spec.add_dependency "net-scp", ">= 1.2", "< 3.0"

--- a/train.gemspec
+++ b/train.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
 
   # azure, docker, gcp dependencies
   spec.add_dependency "activesupport", "~> 5.2.3"
+  spec.add_dependency "inifile", "~> 3.0"
   spec.add_dependency "azure_graph_rbac", "~> 0.16"
   spec.add_dependency "azure_mgmt_key_vault", "~> 0.17"
   spec.add_dependency "azure_mgmt_resources", "~> 0.15"


### PR DESCRIPTION
inifile is only used by the azure transport, which is in train and not
in train-core.