### PR TITLE
Silence deprecation warning under ruby 2.7

### DIFF
--- a/lib/train/transports/azure.rb
+++ b/lib/train/transports/azure.rb
@@ -45,7 +45,7 @@ module Train::Transports
 
         if @options[:client_secret].nil? && @options[:client_id].nil?
           options[:credentials_file] = DEFAULT_FILE if options[:credentials_file].nil?
-          @options.merge!(Helpers::Azure::FileCredentials.parse(@options))
+          @options.merge!(Helpers::Azure::FileCredentials.parse(**@options))
         end
 
         @options[:msi_port] = @options[:msi_port].to_i unless @options[:msi_port].nil?


### PR DESCRIPTION
Just adds a hashsplat. Needed for a failing [inspec test](https://buildkite.com/chef-oss/inspec-inspec-master-verify/builds/1673#033dec83-62ed-4c9a-a1e4-89ad6d82dd8d/670-690).

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
