### PR TITLE
[chef#9635] Add reason for sudo root password

### DIFF
--- a/lib/train/extras/command_wrapper.rb
+++ b/lib/train/extras/command_wrapper.rb
@@ -82,6 +82,8 @@ module Train::Extras
       when "sudo: sorry, you must have a tty to run sudo"
         ["Sudo requires a TTY. Please see the README on how to configure "\
           "sudo to allow for non-interactive usage.", :sudo_no_tty]
+      when /\[sudo\] password for root: Sorry, try again./
+        ["[sudo] password for root: Sorry, try again", :sudo_root_password_required]
       else
         [rawerr, nil]
       end

--- a/lib/train/extras/command_wrapper.rb
+++ b/lib/train/extras/command_wrapper.rb
@@ -72,18 +72,16 @@ module Train::Extras
       rawerr = "#{res.stdout} #{res.stderr}".strip
 
       case rawerr
-      when "Sorry, try again"
+      when /Sorry, try again/
         ["Wrong sudo password.", :bad_sudo_password]
-      when "sudo: no tty present and no askpass program specified"
+      when /sudo: no tty present and no askpass program specified/
         ["Sudo requires a password, please configure it.", :sudo_password_required]
-      when "sudo: command not found"
+      when /sudo: command not found/
         ["Can't find sudo command. Please either install and "\
           "configure it on the target or deactivate sudo.", :sudo_command_not_found]
-      when "sudo: sorry, you must have a tty to run sudo"
+      when /sudo: sorry, you must have a tty to run sudo/
         ["Sudo requires a TTY. Please see the README on how to configure "\
           "sudo to allow for non-interactive usage.", :sudo_no_tty]
-      when /\[sudo\] password for root: Sorry, try again./
-        ["[sudo] password for root: Sorry, try again", :sudo_root_password_required]
       else
         [rawerr, nil]
       end


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
If the user has configured with sudo required root access
```
Defaults rootpw
user ALL=(ALL) PASSWD: ALL
```

It raises an error
```
"[sudo] password for root: Sorry, try again.\n[sudo] password for root: \nsudo: 1 incorrect password attempt"

``` 
Above need to catch and add `Train::UserError` sudo error.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
PR- https://github.com/chef/chef/pull/9635
Issues https://github.com/chef/chef/issues/9404, https://github.com/chef/chef/issues/2887

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>
