### PR TITLE
Bump Chefstyle and ready for dependabot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :test do
   gem "coveralls", require: false
   gem "minitest", "~> 5.8"
   gem "rake", ["~> 12.3", ">= 12.3.3"]
-  gem "chefstyle", "0.13.2"
+  gem "chefstyle", "1.0.2"
   gem "simplecov", "~> 0.10"
   gem "concurrent-ruby", "~> 1.0"
   gem "pry-byebug"
@@ -32,6 +32,3 @@ group :tools do
   gem "rb-readline"
   gem "license_finder"
 end
-
-# add these additional dependencies into Gemfile.local
-eval_gemfile(__FILE__ + ".local") if File.exist?(__FILE__ + ".local")

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -54,7 +54,7 @@ class Train::Transports::SSH
       @bastion_user           = @options.delete(:bastion_user)
       @bastion_port           = @options.delete(:bastion_port)
 
-      @cmd_wrapper            = CommandWrapper.load(self, @transport_options)
+      @cmd_wrapper = CommandWrapper.load(self, @transport_options)
     end
 
     # (see Base::Connection#close)


### PR DESCRIPTION
Remove the gemfile.local sourcing which dependabot can't work with. This
way we'll get nice PRs to bump deps including CVEs complete with
changelogs showing us what's changed.

Signed-off-by: Tim Smith <tsmith@chef.io>