### PR TITLE
Ensure file --> exist works with Solaris10

### DIFF
--- a/lib/train/file/remote/unix.rb
+++ b/lib/train/file/remote/unix.rb
@@ -22,8 +22,14 @@ module Train
         def exist?
           @exist ||= begin
             f = @follow_symlink ? "" : " || test -L #{@spath}"
-            @backend.run_command("test -e #{@spath}" + f)
-              .exit_status == 0
+            if @backend.platform.solaris?
+              # Solaris does not support `-e` flag in default `test`,
+              # so we specify by running /usr/bin/test:
+              # https://github.com/inspec/train/issues/587
+              @backend.run_command("/usr/bin/test -e #{@spath}" + f)
+            else
+              @backend.run_command("test -e #{@spath}" + f)
+            end.exit_status == 0
           end
         end
 


### PR DESCRIPTION
# Description

See below issue for full context here. The short summary is that
Solaris10 does not support `test -e` flag in `sh`. This is a large
issue because 1. we support Solaris10 and 2. this is a silent failure.

The goal of this PR is to recognize a Solaris instance at the breaking
point, and then run the command with the provided `/usr/bin/test`
utility.

# Related Issues

Fixes #587

# Run on my machine

@lhasadreams provided fantastic guidance on the referenced issue for
replicating on your machine. In vagrant run the above control with
the vagrant box `tnarik/solaris10-minimal`:

```ruby
control "find_file_test_sol10-1" do
  impact 1.0
  describe command('test -e /etc/passwd') do
     its('exit_status') { should eq 0 }
  end
  describe file('/etc/passwd') do
    it{ should exist }
  end
end
```

(Note: make sure `sh` is your default shell in the `etc/passwd`)

On master both should fail. On my change second should pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
