### PR TITLE
Check stdout even when exit_status is 0, and handle JSON.parse exception

### DIFF
--- a/lib/train/platforms/detect/helpers/os_windows.rb
+++ b/lib/train/platforms/detect/helpers/os_windows.rb
@@ -37,7 +37,6 @@ module Train::Platforms::Detect::Helpers
 
       begin
         payload = JSON.parse(command.stdout)
-        
         @platform[:family] = "windows"
         @platform[:release] = payload["Version"]
         @platform[:name] = payload["Caption"]
@@ -45,7 +44,7 @@ module Train::Platforms::Detect::Helpers
         read_wmic
         true
       rescue
-        return false
+        false
       end
     end
 

--- a/lib/train/platforms/detect/helpers/os_windows.rb
+++ b/lib/train/platforms/detect/helpers/os_windows.rb
@@ -33,7 +33,8 @@ module Train::Platforms::Detect::Helpers
       command = @backend.run_command(
         "Get-WmiObject Win32_OperatingSystem | Select Caption,Version | ConvertTo-Json"
       )
-      return false if (command.exit_status != 0) || command.stdout.empty? || !(command.stdout.downcase =~ /window/)
+      # some targets (e.g. Cisco) may return 0 and print an error to stdout
+      return false if (command.exit_status != 0) || command.stdout.downcase !~ /window/
 
       begin
         payload = JSON.parse(command.stdout)

--- a/lib/train/platforms/detect/helpers/os_windows.rb
+++ b/lib/train/platforms/detect/helpers/os_windows.rb
@@ -33,15 +33,20 @@ module Train::Platforms::Detect::Helpers
       command = @backend.run_command(
         "Get-WmiObject Win32_OperatingSystem | Select Caption,Version | ConvertTo-Json"
       )
-      return false if (command.exit_status != 0) || command.stdout.empty?
+      return false if (command.exit_status != 0) || command.stdout.empty? || !(command.stdout.downcase =~ /window/)
 
-      payload = JSON.parse(command.stdout)
-      @platform[:family] = "windows"
-      @platform[:release] = payload["Version"]
-      @platform[:name] = payload["Caption"]
+      begin
+        payload = JSON.parse(command.stdout)
+        
+        @platform[:family] = "windows"
+        @platform[:release] = payload["Version"]
+        @platform[:name] = payload["Caption"]
 
-      read_wmic
-      true
+        read_wmic
+        true
+      rescue
+        return false
+      end
     end
 
     def local_windows?


### PR DESCRIPTION
## Description
When the target is a cisco_ios device, the exit_status is 0 but the error is described in the stdout, so the if condition doesn't work and the JSON.parse raises an exception.

Also, the JSON.parse should always be in rescue block.

## Related Issue
https://github.com/inspec/train/issues/599

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
