### PR TITLE
Update to net-ssh 6 and allow older algorithms

### DIFF
--- a/lib/train/transports/cisco_ios_connection.rb
+++ b/lib/train/transports/cisco_ios_connection.rb
@@ -16,6 +16,9 @@ class Train::Transports::SSH
       # Use all options left that are not `nil` for `Net::SSH.start` later
       @ssh_options = options.reject { |_key, value| value.nil? }
 
+      # Allow older algorithms
+      @ssh_options[:append_all_supported_algorithms] = true
+
       @prompt = /^\S+[>#]\r\n.*$/
     end
 

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -202,6 +202,8 @@ class Train::Transports::SSH
         require "net/ssh/proxy/command"
         @options[:proxy] = Net::SSH::Proxy::Command.new(generate_proxy_command)
       end
+      # Allow older algorithms
+      @options[:append_all_supported_algorithms] = true
       Net::SSH.start(@hostname, @username, @options.clone.delete_if { |_key, value| value.nil? })
     rescue *RESCUE_EXCEPTIONS_ON_ESTABLISH => e
       if (opts[:retries] -= 1) <= 0

--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "json", ">= 1.8", "< 3.0"
   spec.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
   spec.add_dependency "net-scp", ">= 1.2", "< 4.0"
-  spec.add_dependency "net-ssh", ">= 2.9", "< 6.0"
+  spec.add_dependency "net-ssh", ">= 2.9", "< 7.0"
 end


### PR DESCRIPTION
Dependabot wanted to increase the net-ssh dependency to '< 7.0' but it was noted that this version drops support for weaker algorithms:
https://github.com/net-ssh/net-ssh/pull/709/files#diff-04c6e90faac2675aa89e2176d2eec7d8R31

This commit adds the `:append_all_supported_algorithms` option to Net::SSH connections to keep these algorithms supported.

Signed-off-by: James Stocks <jstocks@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
