### PR TITLE
Pin ffi to < 1.13

### DIFF
--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "addressable", "~> 2.5"
+  spec.add_dependency "ffi", "< 1.13"
   spec.add_dependency "json", ">= 1.8", "< 3.0"
   spec.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
   spec.add_dependency "net-scp", ">= 1.2", "< 4.0"


### PR DESCRIPTION
Our tests are failing on Windows:

https://buildkite.com/chef-oss/inspec-train-master-verify/builds/395#18f8c2af-6501-4258-bdbf-0f8af87ce9e7

```
rake aborted!
SignalException: SIGSEGV
```

See https://github.com/ffi/ffi/issues/784 - ffi 1.13 introduces segmentation faults. These are not ffi's fault directly, other gems that are not using ffi 100% correctly get away with it in ffi 1.12 but now crash with 1.13.

Signed-off-by: James Stocks <jstocks@chef.io>
