### PR TITLE
Add DragonflyBSD detection

### DIFF
--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -369,6 +369,7 @@ module Train::Platforms::Detect::Specifications
       declare_bsd("freebsd", "Freebsd", "bsd", /freebsd/i)
       declare_bsd("openbsd", "Openbsd", "bsd", /openbsd/i)
       declare_bsd("netbsd", "Netbsd", "bsd", /netbsd/i)
+      declare_bsd("dragonflybsd", "Dragonflybsd", "bsd", /dragonfly/i)
     end
 
     def self.load_other


### PR DESCRIPTION
## Description
This brings platform detection up to par with Ohai, as DragonFly is the only BSD missing in Train.

## Related Issue
As it's a one-liner without side effects, I suppose an own issue is overkill?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
