### PR TITLE
Fix incorrect error message when password is expired

### DIFF
--- a/lib/train/platforms/detect/helpers/os_common.rb
+++ b/lib/train/platforms/detect/helpers/os_common.rb
@@ -36,7 +36,7 @@ module Train::Platforms::Detect::Helpers
     def command_output(cmd)
       res = @backend.run_command(cmd)
       output = res.stdout
-      output = res.stderr if output == ""  && res.exit_status != 0
+      output = res.stderr if output == "" && res.exit_status != 0
       # When you try to execute command using ssh connction as root user and you have provided ssh user identity file
       # it gives standard output to login as authorised user other than root. To show this standard ouput as an error
       # to user we are matching the string of stdout and raising the error here so that user gets exact information.

--- a/lib/train/platforms/detect/helpers/os_common.rb
+++ b/lib/train/platforms/detect/helpers/os_common.rb
@@ -34,16 +34,18 @@ module Train::Platforms::Detect::Helpers
     end
 
     def command_output(cmd)
-      res = @backend.run_command(cmd).stdout
+      res = @backend.run_command(cmd)
+      output = res.stdout
+      output = res.stderr if output == ""  && res.exit_status != 0
       # When you try to execute command using ssh connction as root user and you have provided ssh user identity file
       # it gives standard output to login as authorised user other than root. To show this standard ouput as an error
       # to user we are matching the string of stdout and raising the error here so that user gets exact information.
-      if @backend.class.to_s == "Train::Transports::SSH::Connection" && res =~ /Please login as the user/
-        raise Train::UserError, "SSH failed: #{res}"
+      if @backend.class.to_s == "Train::Transports::SSH::Connection" && (output =~ /Please login as the user/ || output =~ /WARNING: Your password has expired.\nPassword change required but no TTY available.\n/)
+        raise Train::UserError, "SSH failed: #{output}"
       end
 
-      res.strip! unless res.nil?
-      res
+      output.strip! unless output.nil?
+      output
     end
 
     def unix_uname_s

--- a/test/unit/platforms/detect/os_common_test.rb
+++ b/test/unit/platforms/detect/os_common_test.rb
@@ -57,7 +57,7 @@ describe "os_common" do
   describe "#detect_linux_arch" do
     it "uname m call" do
       be = mock("Backend")
-      be.stubs(:run_command).with("uname -m").returns(mock("Output", stdout: "x86_64\n"))
+      be.stubs(:run_command).with("uname -m").returns(mock("Output", stdout: "x86_64\n", stderr: ""))
       detector.instance_variable_set(:@backend, be)
       detector.instance_variable_set(:@uname, {})
       _(detector.unix_uname_m).must_equal("x86_64")
@@ -65,7 +65,7 @@ describe "os_common" do
 
     it "uname s call" do
       be = mock("Backend")
-      be.stubs(:run_command).with("uname -s").returns(mock("Output", stdout: "linux"))
+      be.stubs(:run_command).with("uname -s").returns(mock("Output", stdout: "linux", stderr: ""))
       detector.instance_variable_set(:@backend, be)
       detector.instance_variable_set(:@uname, {})
       _(detector.unix_uname_s).must_equal("linux")
@@ -73,7 +73,7 @@ describe "os_common" do
 
     it "uname r call" do
       be = mock("Backend")
-      be.stubs(:run_command).with("uname -r").returns(mock("Output", stdout: "17.0.0\n"))
+      be.stubs(:run_command).with("uname -r").returns(mock("Output", stdout: "17.0.0\n", stderr: ""))
       detector.instance_variable_set(:@backend, be)
       detector.instance_variable_set(:@uname, {})
       _(detector.unix_uname_r).must_equal("17.0.0")


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
I have come across a scenario where the AIX system password got expired due to this getting platform detention error which is wrong. Fixes provide an exact error message to the user so that, action should be taken accordingly.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes: https://github.com/inspec/train/issues/615

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>