### PR TITLE
Properly detect macOS Big Sur as being platform mac_os_x

### DIFF
--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -357,7 +357,7 @@ module Train::Platforms::Detect::Specifications
       declare_instance("mac_os_x", "macOS X", "darwin") do
         cmd = unix_file_contents("/System/Library/CoreServices/SystemVersion.plist")
         @platform[:uuid_command] = "system_profiler SPHardwareDataType | awk '/UUID/ { print $3; }'"
-        cmd =~ /Mac OS X/i
+        cmd =~ /Mac OS X|macOS/i
       end
 
       declare_instance("darwin", "Darwin", "darwin") do

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -89,9 +89,19 @@ describe "os_detect" do
 
   describe "darwin" do
     describe "mac_os_x" do
-      it "sets the correct family, name, and release on os_x" do
+      it "sets the correct family, name, and release on macOS < 11" do
         files = {
           "/System/Library/CoreServices/SystemVersion.plist" => "<string>Mac OS X</string>",
+        }
+        platform = scan_with_files("darwin", files)
+        _(platform[:name]).must_equal("mac_os_x")
+        _(platform[:family]).must_equal("darwin")
+        _(platform[:release]).must_equal("test-release")
+      end
+
+      it "sets the correct family, name, and release on macOS >= 11" do
+        files = {
+          "/System/Library/CoreServices/SystemVersion.plist" => "<string>macOS</string>",
         }
         platform = scan_with_files("darwin", files)
         _(platform[:name]).must_equal("mac_os_x")


### PR DESCRIPTION
I've confirmed that this string has changed only.

Signed-off-by: Tim Smith <tsmith@chef.io>