### PR TITLE
Get the old integration tests closer to running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ terraform.tfstate.backup
 .bundle
 .gems
 coverage/
+Berksfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ end
 
 group :integration do
   gem "berkshelf", "~> 6.3.0"
-  gem "test-kitchen", ">= 1.2.4"
+  gem "test-kitchen", ">= 2"
   gem "kitchen-vagrant"
 end
 

--- a/test/integration/.kitchen.yml
+++ b/test/integration/.kitchen.yml
@@ -7,37 +7,24 @@ provisioner:
   data_path: ../../.
 
 platforms:
-  - name: centos-7.1
-  - name: centos-6.7
-  - name: centos-6.7-i386
-  - name: centos-5.11
-  - name: centos-5.11-i386
-  - name: debian-6.0.10
-  - name: debian-6.0.10-i386
-  - name: debian-7.8
-  - name: debian-7.8-i386
-  - name: debian-8.1
-  - name: debian-8.1-i386
-  - name: fedora-21
-  - name: fedora-21-i386
-  - name: fedora-22
-  - name: freebsd-9.3
-  - name: freebsd-10.2
-  - name: opensuse-13.2-x86_64
-  - name: opensuse-13.2-i386
-  - name: ubuntu-14.04
-  - name: ubuntu-14.04-i386
-  - name: ubuntu-12.04
-  - name: ubuntu-12.04-i386
-  - name: ubuntu-10.04
-  - name: ubuntu-10.04-i386
+  - name: centos-8
+  - name: centos-7
+  - name: centos-6
+  - name: centos-6-i386
+  - name: debian-10
+  - name: debian-10-i386
+  - name: debian-9
+  - name: debian-9-i386
+  - name: fedora-latest
+  - name: freebsd-11
+  - name: freebsd-12
+  - name: opensuse-leap-15
+  - name: ubuntu-20.04
+  - name: ubuntu-18.04
+  - name: ubuntu-16.04
+  - name: ubuntu-16.04-i386
 
 suites:
   - name: default
     run_list:
-      - recipe[sudo]
       - recipe[test]
-    attributes:
-      authorization:
-        sudo:
-          include_sudoers_d: true

--- a/test/integration/Berksfile
+++ b/test/integration/Berksfile
@@ -1,3 +1,3 @@
 source "https://supermarket.chef.io"
-cookbook "sudo", "~> 2.7.2"
+
 cookbook "test", path: "cookbooks/test"

--- a/test/integration/cookbooks/test/metadata.rb
+++ b/test/integration/cookbooks/test/metadata.rb
@@ -1,1 +1,3 @@
 name "test"
+
+depends "sudo", ">= 5.0"

--- a/test/integration/cookbooks/test/recipes/default.rb
+++ b/test/integration/cookbooks/test/recipes/default.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 #
 # Helper recipe to create create a few files in the operating
@@ -9,7 +8,8 @@
 # Finally (for now), it actually executes the all tests with
 # the local execution backend
 
-include_recipe("test::prep_files")
+include_recipe "sudo"
+include_recipe "::prep_files"
 
 # prepare ssh for backend
 execute "create ssh key" do
@@ -58,6 +58,8 @@ sudo "customcommand" do
   nopasswd true
   defaults ["!requiretty"]
 end
+
+build_essential
 
 # execute tests
 execute "bundle install" do

--- a/test/integration/cookbooks/test/recipes/prep_files.rb
+++ b/test/integration/cookbooks/test/recipes/prep_files.rb
@@ -5,7 +5,7 @@
 # Helper recipe to create create a few files in the operating
 # systems, which the runner will test against.
 
-gid = node["platform_family"] == "aix" ? "system" : node["root_group"]
+gid = platform_family?("aix") ? "system" : node["root_group"]
 
 file "/tmp/file" do
   mode "0765"


### PR DESCRIPTION
I think the idea here is probably right. We just need to get them running in Buildkite again. This is step 1 of many.

Signed-off-by: Tim Smith <tsmith@chef.io>