### PR TITLE
Run Chefstyle on the oldest ruby we support

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,13 +1,14 @@
 ---
 steps:
 
-  - label: lint-ruby-2.6
+  # make sure lint runs on the oldest Ruby we support so we catch any new Ruby-isms here
+  - label: lint-ruby-2.4
     command:
       - RAKE_TASK=lint /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       executor:
         docker:
-          image: ruby:2.6
+          image: ruby:2.4
 
   - label: run-tests-ruby-2.4
     command:


### PR DESCRIPTION
This has been super helpful in Chef to make sure we don't accidentally
sneak in new ruby-isms.

Signed-off-by: Tim Smith <tsmith@chef.io>