### PR TITLE
Remove the redundant encoding comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-# encoding: utf-8
 source "https://rubygems.org"
 gemspec name: "train"
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,4 @@
 #!/usr/bin/env rake
-# encoding: utf-8
-
 require "bundler"
 require "bundler/gem_helper"
 require "rake/testtask"

--- a/contrib/fixup_requiretty.rb
+++ b/contrib/fixup_requiretty.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Stephan Renatus
 #
 # chef-apply script to fix sudoers configuration

--- a/examples/plugins/train-local-rot13/Gemfile
+++ b/examples/plugins/train-local-rot13/Gemfile
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 source "https://rubygems.org"
 
 # This is Gemfile, which is used by bundler

--- a/lib/train.rb
+++ b/lib/train.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Author:: Dominik Richter (<dominik.richter@gmail.com>)
 

--- a/lib/train/errors.rb
+++ b/lib/train/errors.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 # Author:: Dominik Richter (<dominik.richter@gmail.com>)

--- a/lib/train/extras.rb
+++ b/lib/train/extras.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Author:: Dominik Richter (<dominik.richter@gmail.com>)
 

--- a/lib/train/extras/command_wrapper.rb
+++ b/lib/train/extras/command_wrapper.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/lib/train/extras/stat.rb
+++ b/lib/train/extras/stat.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 module Train::Extras

--- a/lib/train/file.rb
+++ b/lib/train/file.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # author: Christoph Hartmann
 # author: Dominik Richter

--- a/lib/train/file/local.rb
+++ b/lib/train/file/local.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Train
   class File
     class Local < Train::File

--- a/lib/train/file/local/unix.rb
+++ b/lib/train/file/local/unix.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "shellwords"
 require_relative "../../extras/stat"
 

--- a/lib/train/file/local/windows.rb
+++ b/lib/train/file/local/windows.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Train
   class File
     class Local

--- a/lib/train/file/remote.rb
+++ b/lib/train/file/remote.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Train
   class File
     class Remote < Train::File

--- a/lib/train/file/remote/aix.rb
+++ b/lib/train/file/remote/aix.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require_relative "unix"
 
 module Train

--- a/lib/train/file/remote/linux.rb
+++ b/lib/train/file/remote/linux.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require_relative "unix"
 
 module Train

--- a/lib/train/file/remote/qnx.rb
+++ b/lib/train/file/remote/qnx.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # author: Christoph Hartmann
 # author: Dominik Richter

--- a/lib/train/file/remote/windows.rb
+++ b/lib/train/file/remote/windows.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Train
   class File
     class Remote

--- a/lib/train/options.rb
+++ b/lib/train/options.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Author:: Dominik Richter (<dominik.richter@gmail.com>)
 # Author:: Christoph Hartmann (<chris@lollyrock.com>)

--- a/lib/train/platforms.rb
+++ b/lib/train/platforms.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require_relative "platforms/common"
 require_relative "platforms/detect"
 require_relative "platforms/detect/scanner"

--- a/lib/train/platforms/common.rb
+++ b/lib/train/platforms/common.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Train::Platforms
   module Common
     # Add a family connection. This will create a family

--- a/lib/train/platforms/detect.rb
+++ b/lib/train/platforms/detect.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Train::Platforms
   module Detect
     # Main detect method to scan all platforms for a match

--- a/lib/train/platforms/detect/helpers/os_linux.rb
+++ b/lib/train/platforms/detect/helpers/os_linux.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Train::Platforms::Detect::Helpers
   module Linux
     def redhatish_platform(conf)

--- a/lib/train/platforms/detect/scanner.rb
+++ b/lib/train/platforms/detect/scanner.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require_relative "helpers/os_common"
 
 module Train::Platforms::Detect

--- a/lib/train/platforms/detect/specifications/api.rb
+++ b/lib/train/platforms/detect/specifications/api.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Train::Platforms::Detect::Specifications
   class Api
     def self.load

--- a/lib/train/platforms/family.rb
+++ b/lib/train/platforms/family.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Train::Platforms
   class Family
     include Train::Platforms::Common

--- a/lib/train/platforms/platform.rb
+++ b/lib/train/platforms/platform.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Train::Platforms
   class Platform
     include Train::Platforms::Common

--- a/lib/train/plugins.rb
+++ b/lib/train/plugins.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Author:: Dominik Richter (<dominik.richter@gmail.com>)
 # Author:: Christoph Hartmann (<chris@lollyrock.com>)

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require_relative "../errors"
 require_relative "../extras"
 require_relative "../file"

--- a/lib/train/plugins/transport.rb
+++ b/lib/train/plugins/transport.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Author:: Dominik Richter (<dominik.richter@gmail.com>)
 # Author:: Christoph Hartmann (<chris@lollyrock.com>)

--- a/lib/train/transports/azure.rb
+++ b/lib/train/transports/azure.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "train/plugins"
 require "ms_rest_azure"
 require "azure_mgmt_resources"

--- a/lib/train/transports/cisco_ios_connection.rb
+++ b/lib/train/transports/cisco_ios_connection.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Train::Transports::SSH
   class CiscoIOSConnection < BaseConnection
     class BadEnablePassword < Train::TransportError; end

--- a/lib/train/transports/clients/azure/graph_rbac.rb
+++ b/lib/train/transports/clients/azure/graph_rbac.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "azure_graph_rbac"
 
 # Wrapper class for ::Azure::GraphRbac::Profiles::Latest::Client allowing custom configuration,

--- a/lib/train/transports/clients/azure/vault.rb
+++ b/lib/train/transports/clients/azure/vault.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "azure_mgmt_key_vault"
 
 # Wrapper class for ::Azure::KeyVault::Profiles::Latest::Mgmt::Client allowing custom configuration,

--- a/lib/train/transports/gcp.rb
+++ b/lib/train/transports/gcp.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "train/plugins"
 require "google/apis"
 require "google/apis/cloudresourcemanager_v1"

--- a/lib/train/transports/helpers/azure/file_credentials.rb
+++ b/lib/train/transports/helpers/azure/file_credentials.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "inifile"
 require_relative "file_parser"
 require_relative "subscription_number_file_parser"

--- a/lib/train/transports/helpers/azure/file_parser.rb
+++ b/lib/train/transports/helpers/azure/file_parser.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Train::Transports
   module Helpers
     module Azure

--- a/lib/train/transports/helpers/azure/subscription_id_file_parser.rb
+++ b/lib/train/transports/helpers/azure/subscription_id_file_parser.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Train::Transports
   module Helpers
     module Azure

--- a/lib/train/transports/helpers/azure/subscription_number_file_parser.rb
+++ b/lib/train/transports/helpers/azure/subscription_number_file_parser.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Train::Transports
   module Helpers
     module Azure

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # author: Dominik Richter
 # author: Christoph Hartmann

--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 # Author:: Dominik Richter (<dominik.richter@gmail.com>)

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 # Author:: Dominik Richter (<dominik.richter@gmail.com>)

--- a/lib/train/transports/vmware.rb
+++ b/lib/train/transports/vmware.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "train/plugins"
 require "open3"
 require "ostruct"

--- a/lib/train/version.rb
+++ b/lib/train/version.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Author:: Dominik Richter (<dominik.richter@gmail.com>)
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 if ENV["CI_ENABLE_COVERAGE"]
   require "simplecov"
   require "coveralls"

--- a/test/integration/cookbooks/test/recipes/prep_files.rb
+++ b/test/integration/cookbooks/test/recipes/prep_files.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 #

--- a/test/integration/docker_test.rb
+++ b/test/integration/docker_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require_relative "docker_run"
 tests = ARGV
 

--- a/test/integration/docker_test_container.rb
+++ b/test/integration/docker_test_container.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 
 require "train"

--- a/test/integration/helper.rb
+++ b/test/integration/helper.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "coveralls"
 Coveralls.wear!
 

--- a/test/integration/sudo/customcommand.rb
+++ b/test/integration/sudo/customcommand.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Jeremy Miller
 
 require_relative "run_as"

--- a/test/integration/sudo/run_as.rb
+++ b/test/integration/sudo/run_as.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/test/integration/test_local.rb
+++ b/test/integration/test_local.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 
 require_relative "helper"

--- a/test/integration/test_ssh.rb
+++ b/test/integration/test_ssh.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 
 require_relative "helper"

--- a/test/integration/tests/path_block_device_test.rb
+++ b/test/integration/tests/path_block_device_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe "file interface" do
   let(:backend) { get_backend.call }
 

--- a/test/integration/tests/path_character_device_test.rb
+++ b/test/integration/tests/path_character_device_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe "file interface" do
   let(:backend) { get_backend.call }
 

--- a/test/integration/tests/path_file_test.rb
+++ b/test/integration/tests/path_file_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe "file interface" do
   let(:backend) { get_backend.call }
 

--- a/test/integration/tests/path_folder_test.rb
+++ b/test/integration/tests/path_folder_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe "file interface" do
   let(:backend) { get_backend.call }
 

--- a/test/integration/tests/path_missing_test.rb
+++ b/test/integration/tests/path_missing_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe "file interface" do
   let(:backend) { get_backend.call }
 

--- a/test/integration/tests/path_pipe_test.rb
+++ b/test/integration/tests/path_pipe_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe "file interface" do
   let(:backend) { get_backend.call }
 

--- a/test/integration/tests/path_symlink_test.rb
+++ b/test/integration/tests/path_symlink_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe "file interface" do
   let(:backend) { get_backend.call }
 

--- a/test/integration/tests/run_command_test.rb
+++ b/test/integration/tests/run_command_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe "run_command" do
   let(:backend) { get_backend.call }
 

--- a/test/unit/extras/command_wrapper_test.rb
+++ b/test/unit/extras/command_wrapper_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/test/unit/file/local/windows_test.rb
+++ b/test/unit/file/local/windows_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "helper"
 require "train/transports/mock"
 require "train/file/local/windows"

--- a/test/unit/platforms/detect/os_common_test.rb
+++ b/test/unit/platforms/detect/os_common_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "helper"
 
 class OsDetectLinuxTester

--- a/test/unit/platforms/detect/os_linux_test.rb
+++ b/test/unit/platforms/detect/os_linux_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "helper"
 require "train/transports/mock"
 

--- a/test/unit/platforms/detect/os_windows_test.rb
+++ b/test/unit/platforms/detect/os_windows_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "helper"
 require "train/transports/mock"
 

--- a/test/unit/platforms/detect/scanner_test.rb
+++ b/test/unit/platforms/detect/scanner_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "helper"
 require "train/platforms/detect/scanner"
 require "train/transports/mock"

--- a/test/unit/platforms/detect/uuid_test.rb
+++ b/test/unit/platforms/detect/uuid_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "helper"
 require "train/transports/mock"
 require "securerandom"

--- a/test/unit/platforms/family_test.rb
+++ b/test/unit/platforms/family_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "helper"
 
 describe "platform family" do

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "helper"
 require "train/transports/mock"
 

--- a/test/unit/platforms/platform_test.rb
+++ b/test/unit/platforms/platform_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "helper"
 
 describe "platform" do

--- a/test/unit/platforms/platforms_test.rb
+++ b/test/unit/platforms/platforms_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "helper"
 
 describe "platforms" do

--- a/test/unit/plugins/connection_test.rb
+++ b/test/unit/plugins/connection_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "helper"
 
 describe "v1 Connection Plugin" do

--- a/test/unit/plugins_test.rb
+++ b/test/unit/plugins_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "helper"
 
 # rubocop:disable Style/BlockDelimiters

--- a/test/unit/train_test.rb
+++ b/test/unit/train_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Author:: Dominik Richter (<dominik.richter@gmail.com>)
 require "helper"

--- a/test/unit/transports/azure_test.rb
+++ b/test/unit/transports/azure_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "helper"
 
 # Required because this test file acesses classes under Azure::

--- a/test/unit/transports/cisco_ios_connection_test.rb
+++ b/test/unit/transports/cisco_ios_connection_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "helper"
 require "train/transports/ssh"
 

--- a/test/unit/transports/gcp_test.rb
+++ b/test/unit/transports/gcp_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "helper"
 require "train/transports/gcp"
 

--- a/test/unit/transports/helpers/azure/file_credentials_test.rb
+++ b/test/unit/transports/helpers/azure/file_credentials_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "helper"
 require "tempfile"
 require "train/transports/helpers/azure/file_credentials"

--- a/test/unit/transports/local_test.rb
+++ b/test/unit/transports/local_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "helper"
 require "train/transports/local"
 

--- a/test/unit/transports/mock_test.rb
+++ b/test/unit/transports/mock_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "helper"
 require "train/transports/mock"
 require "digest/sha2"

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "helper"
 require "train/transports/ssh"
 

--- a/test/unit/transports/vmware_test.rb
+++ b/test/unit/transports/vmware_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "helper"
 require "train/transports/vmware"
 

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "helper"
 
 describe Train do

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 

--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -1,4 +1,3 @@
-# encoding: utf-8
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "train/version"

--- a/train.gemspec
+++ b/train.gemspec
@@ -1,4 +1,3 @@
-# encoding: utf-8
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "train/version"


### PR DESCRIPTION
In Ruby 2.0 utf-8 became the default so there's no need to set this.

Signed-off-by: Tim Smith <tsmith@chef.io>