### PR TITLE
Allow timeout option per ssh command

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -104,13 +104,14 @@ def initialize(options)
 end
 ```
 
-#### run_command_via_connection
+#### file_via_connection
 
 If your transport is OS based and has the option to read a file you can set this method. It is expected to return a `Train::File::Remote::*` class here to be used upstream in InSpec. Currently the file resource is restricted to Unix and Windows platforms. Caching is enabled by default for this method.
 
-#### file_via_connection
+#### run_command_via_connection
 
-If your transport is OS based and has the option to run a command you can set this method. It is expected to return a `CommandResult` class here to be used upstream in InSpec. Currently the command resource is restricted to Unix and Windows platforms. Caching is enabled by default for this method.
+If your transport is OS based and has the option to run a command you can set this method. It is expected to return a `CommandResult` class here to be used upstream in InSpec. Currently the command resource is restricted to Unix and Windows platforms. Caching is enabled by default for this method.  
+You can optionally receive an options hash as well as the command string. This is intended for options that apply only to the current instance of running a command. For example, applying a timeout to this command execution.
 
 #### API Access Methods
 

--- a/lib/train/errors.rb
+++ b/lib/train/errors.rb
@@ -40,4 +40,7 @@ module Train
 
   # Exception for when a invalid cache type is passed.
   class UnknownCacheType < Error; end
+
+  # Exception for when a command reaches configured timeout
+  class CommandTimeoutReached < Error; end
 end

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -127,13 +127,17 @@ class Train::Plugins::Transport
     # This is the main command call for all connections. This will call the private
     # run_command_via_connection on the connection with optional caching
     #
+    # Supported options for the opts hash:
+    # :timeout    Number of seconds to allow before a timeout. Implemented in the
+    #             derived connection class (currently ssh_connection)
+    #
     # This command accepts an optional data handler block. When provided,
     # inbound data will be published vi `data_handler.call(data)`. This can allow
     # callers to receive and render updates from remote command execution.
-    def run_command(cmd, &data_handler)
-      return run_command_via_connection(cmd, &data_handler) unless cache_enabled?(:command)
+    def run_command(cmd, opts = {}, &data_handler)
+      return run_command_via_connection(cmd, opts, &data_handler) unless cache_enabled?(:command)
 
-      @cache[:command][cmd] ||= run_command_via_connection(cmd, &data_handler)
+      @cache[:command][cmd] ||= run_command_via_connection(cmd, opts, &data_handler)
     end
 
     # This is the main file call for all connections. This will call the private

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -235,7 +235,7 @@ class Train::Transports::SSH
       end
     end
 
-    def run_command_via_connection(cmd, opts, &data_handler)
+    def run_command_via_connection(cmd, opts = {}, &data_handler)
       cmd.dup.force_encoding("binary") if cmd.respond_to?(:force_encoding)
 
       reset_session if session.closed?

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -235,12 +235,12 @@ class Train::Transports::SSH
       end
     end
 
-    def run_command_via_connection(cmd, &data_handler)
+    def run_command_via_connection(cmd, opts, &data_handler)
       cmd.dup.force_encoding("binary") if cmd.respond_to?(:force_encoding)
 
       reset_session if session.closed?
 
-      exit_status, stdout, stderr = execute_on_channel(cmd, &data_handler)
+      exit_status, stdout, stderr = execute_on_channel(cmd, opts, &data_handler)
 
       # Since `@session.loop` succeeded, reset the IOS command retry counter
       @ios_cmd_retries = 0
@@ -297,7 +297,8 @@ class Train::Transports::SSH
     #         not received.
     #
     # @api private
-    def execute_on_channel(cmd)
+    def execute_on_channel(cmd, opts)
+      timeout = opts[:timeout]&.to_i
       stdout = ""
       stderr = ""
       exit_status = nil
@@ -307,7 +308,7 @@ class Train::Transports::SSH
 
         logger.debug("[SSH] #{self} cmd = #{cmd}")
 
-        if @transport_options[:pty]
+        if @transport_options[:pty] || timeout
           channel.request_pty do |_ch, success|
             raise Train::Transports::SSHPTYFailed, "Requesting PTY failed" unless success
           end
@@ -334,7 +335,20 @@ class Train::Transports::SSH
           end
         end
       end
-      session.loop
+
+      thr = Thread.new { session.loop }
+
+      if timeout
+        res = thr.join(timeout)
+        unless res
+          logger.info("ssh command reached requested timeout (#{timeout}s)")
+          session.channels.each_value { |c| c.eof!; c.close }
+          raise Train::CommandTimeoutReached.new "ssh command reached timeout (#{timeout}s)"
+        end
+      else
+        thr.join
+      end
+
       [exit_status, stdout, stderr]
     end
   end

--- a/test/integration/tests/run_command_test.rb
+++ b/test/integration/tests/run_command_test.rb
@@ -30,4 +30,17 @@ describe "run_command" do
     _(res.stderr).must_equal("")
     _(res.exit_status).must_equal(123)
   end
+
+  it "completes a command with ample timeout" do
+    res = backend.run_command("echo hello world", timeout: 5)
+    _(res.stdout).must_equal("hello world\n")
+    _(res.stderr).must_equal("")
+    _(res.exit_status).must_equal(0)
+  end
+
+  it "raises CommandTimeoutReached on timeout" do
+    assert_raises Train::CommandTimeoutReached do
+      backend.run_command("sleep 2", timeout: 1)
+    end
+  end
 end

--- a/test/unit/plugins/connection_test.rb
+++ b/test/unit/plugins/connection_test.rb
@@ -9,8 +9,12 @@ describe "v1 Connection Plugin" do
       connection.close # wont raise
     end
 
-    it "raises an exception for run_command" do
+    it "raises NotImplementedError exception for run_command" do
       _ { connection.run_command("") }.must_raise NotImplementedError
+    end
+
+    it "raises NotImplementedError exception for run_command with options hash (arity of 2)" do
+      _ { connection.run_command("", {}) }.must_raise NotImplementedError
     end
 
     it "raises an exception for run_command_via_connection" do

--- a/test/unit/transports/ssh_connection_test.rb
+++ b/test/unit/transports/ssh_connection_test.rb
@@ -74,5 +74,10 @@ describe "ssh connection" do
       _(called).must_equal true
 
     end
+
+    it "accepts an options hash" do
+      ssh.stubs(:session).returns(session_mock)
+      _(ssh.run_command("keychecks off; safety -o; white rabbit object", my_option: "my value").stdout).must_equal "testdata"
+    end
   end
 end


### PR DESCRIPTION
The option is per-command not per-connection so that end users can timeout individual InSpec tests.
The default is no timeout - timing out has the side effect of leaving commands running on the host. It should only be used where the end user is OK with this.

Signed-off-by: James Stocks <jstocks@chef.io>
