### PR TITLE
Speed up requires in non-omnibus Ruby installs

### DIFF
--- a/lib/train.rb
+++ b/lib/train.rb
@@ -6,7 +6,7 @@ require_relative "train/options"
 require_relative "train/plugins"
 require_relative "train/errors"
 require_relative "train/platforms"
-require "addressable/uri"
+require "addressable/uri" unless defined?(Addressable::URI)
 
 module Train
   # Create a new transport instance, with the plugin indicated by the

--- a/lib/train/file/local/unix.rb
+++ b/lib/train/file/local/unix.rb
@@ -1,4 +1,4 @@
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 require_relative "../../extras/stat"
 
 module Train

--- a/lib/train/file/remote/unix.rb
+++ b/lib/train/file/remote/unix.rb
@@ -1,4 +1,4 @@
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 
 module Train
   class File

--- a/lib/train/platforms/detect/helpers/os_common.rb
+++ b/lib/train/platforms/detect/helpers/os_common.rb
@@ -1,6 +1,6 @@
 require_relative "os_linux"
 require_relative "os_windows"
-require "rbconfig"
+require "rbconfig" unless defined?(RbConfig)
 
 module Train::Platforms::Detect::Helpers
   module OSCommon
@@ -165,7 +165,7 @@ module Train::Platforms::Detect::Helpers
     def json_cmd(cmd)
       cmd = @backend.run_command(cmd)
       if cmd.exit_status == 0 && !cmd.stdout.empty?
-        require "json"
+        require "json" unless defined?(JSON)
         eos_ver = JSON.parse(cmd.stdout)
         @platform[:release] = eos_ver["version"]
         @platform[:arch] = eos_ver["architecture"]

--- a/lib/train/platforms/detect/uuid.rb
+++ b/lib/train/platforms/detect/uuid.rb
@@ -1,6 +1,6 @@
 require "digest/sha1"
-require "securerandom"
-require "json"
+require "securerandom" unless defined?(SecureRandom)
+require "json" unless defined?(JSON)
 
 module Train::Platforms::Detect
   class UUID

--- a/lib/train/plugin_test_helper.rb
+++ b/lib/train/plugin_test_helper.rb
@@ -13,13 +13,13 @@ require "minitest/spec"
 require "minitest/autorun"
 
 # Data formats commonly used in testing
-require "json"
-require "ostruct"
+require "json" unless defined?(JSON)
+require "ostruct" unless defined?(OpenStruct)
 
 # Utilities often needed
-require "fileutils"
-require "tmpdir"
-require "pathname"
+require "fileutils" unless defined?(FileUtils)
+require "tmpdir" unless defined?(Dir.mktmpdir)
+require "pathname" unless defined?(Pathname)
 
 # You might want to put some debugging tools here.  We run tests to find bugs,
 # after all.

--- a/lib/train/transports/azure.rb
+++ b/lib/train/transports/azure.rb
@@ -3,8 +3,8 @@ require "ms_rest_azure"
 require "azure_mgmt_resources"
 require "azure_graph_rbac"
 require "azure_mgmt_key_vault"
-require "socket"
-require "timeout"
+require "socket" unless defined?(Socket)
+require "timeout" unless defined?(Timeout)
 require "train/transports/helpers/azure/file_credentials"
 require "train/transports/clients/azure/graph_rbac"
 require "train/transports/clients/azure/vault"

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -4,7 +4,7 @@
 
 require_relative "../plugins"
 require_relative "../errors"
-require "mixlib/shellout"
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
 
 module Train::Transports
   class Local < Train.plugin(1)
@@ -111,7 +111,7 @@ module Train::Transports
       end
 
       class WindowsShellRunner
-        require "json"
+        require "json" unless defined?(JSON)
         require "base64"
 
         def initialize(powershell_cmd = "powershell")
@@ -135,9 +135,9 @@ module Train::Transports
       end
 
       class WindowsPipeRunner
-        require "json"
+        require "json" unless defined?(JSON)
         require "base64"
-        require "securerandom"
+        require "securerandom" unless defined?(SecureRandom)
 
         def initialize(powershell_cmd = "powershell")
           @powershell_cmd = powershell_cmd

--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "net/ssh"
+require "net/ssh" unless defined?(Net::SSH)
 require "net/scp"
 require_relative "../errors"
 

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -17,9 +17,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "net/ssh"
+require "net/ssh" unless defined?(Net::SSH)
 require "net/scp"
-require "timeout"
+require "timeout" unless defined?(Timeout)
 
 class Train::Transports::SSH
   # A Connection instance can be generated and re-generated, given new

--- a/lib/train/transports/vmware.rb
+++ b/lib/train/transports/vmware.rb
@@ -1,7 +1,7 @@
 require "train/plugins"
 require "open3"
-require "ostruct"
-require "json"
+require "ostruct" unless defined?(OpenStruct)
+require "json" unless defined?(JSON)
 require "mkmf"
 
 module Train::Transports


### PR DESCRIPTION
require is quite slow in Ruby and doing requires for things you've already required is also slow. We've used this simple hack in Chef to speed up our requires. In the omnibus installs we patch how rubygems works to make this somewhat pointless, but this will help non-omnibus installs of InSpec.

Signed-off-by: Tim Smith <tsmith@chef.io>