### PR TITLE
su - USER command execution support & change transport_options to attr_accessor

### DIFF
--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -315,7 +315,7 @@ class Train::Transports::SSH
 
         channel.exec(cmd) do |_, success|
           abort "Couldn't execute command on SSH." unless success
-          channel.on_data do |ch, data|
+          channel.on_data do |_, data|
             yield(data, channel) if block_given?
             stdout += data
           end

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -242,6 +242,16 @@ class Train::Transports::SSH
 
       exit_status, stdout, stderr = execute_on_channel(cmd, &data_handler)
 
+      # An interactive console might contain the STDERR in STDOUT
+      # concat both outputs for non-zero exit status. 
+      output = "#{stdout} #{stderr}".strip if exit_status != 0
+
+      # Abstract the su - USER authentication failure
+      # raise the Train::UserError and passes message & reason
+      if output && output.match?("su: Authentication failure")
+        raise Train::UserError.new(output, :bad_su_user_password)
+      end
+
       # Since `@session.loop` succeeded, reset the IOS command retry counter
       @ios_cmd_retries = 0
 

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -321,7 +321,7 @@ class Train::Transports::SSH
           end
 
           channel.on_extended_data do |_, _type, data|
-            yield(data) if block_given?
+            yield(data, channel) if block_given?
             stderr += data
           end
 

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -315,13 +315,9 @@ class Train::Transports::SSH
 
         channel.exec(cmd) do |_, success|
           abort "Couldn't execute command on SSH." unless success
-          channel.on_data do |_, data|
-            if data == "Password: "
-              channel.send_data "#{@transport_options[:su_password]}\n"
-            else
-              yield(data) if block_given?
-              stdout += data
-            end
+          channel.on_data do |ch, data|
+            yield(data, channel) if block_given?
+            stdout += data
           end
 
           channel.on_extended_data do |_, _type, data|


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
 - Modify transport options whenever required.
 - su - USER command execution using -c require a password ie. `su - USER -c 'ls;date;'`
 - Append the `su_password` option if command execution required a password.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes: https://github.com/inspec/train/issues/633

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>