### PR TITLE
Allow for docker-api 2.x

### DIFF
--- a/train.gemspec
+++ b/train.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "azure_mgmt_resources", "~> 0.15"
   spec.add_dependency "azure_mgmt_security", "~> 0.18"
   spec.add_dependency "azure_mgmt_storage", "~> 0.18"
-  spec.add_dependency "docker-api", "~> 1.26"
+  spec.add_dependency "docker-api", ">= 1.26", "< 3.0"
   spec.add_dependency "google-api-client", ">= 0.23.9", "< 0.44.1"
   spec.add_dependency "googleauth", ">= 0.6.6", "< 0.13.1"
 end


### PR DESCRIPTION
docker-api resolves warnings with Ruby 2.7 and removes the pin to legacy docker API releases which kept it from working properly on Windows platforms.

Signed-off-by: Tim Smith <tsmith@chef.io>