### PR TITLE
Support unpacking train options from URI query values

### DIFF
--- a/lib/train.rb
+++ b/lib/train.rb
@@ -113,6 +113,9 @@ module Train
     # TODO: rewrite next line using compact! once we drop support for ruby 2.3
     creds = creds.delete_if { |_, value| value.nil? }
 
+    # merge train options in from the URI query string
+    creds.merge!(uri.query_values.transform_keys(&:to_sym)) unless uri.query_values.nil?
+
     # return the updated config
     creds
   end

--- a/lib/train.rb
+++ b/lib/train.rb
@@ -114,7 +114,7 @@ module Train
     creds = creds.delete_if { |_, value| value.nil? }
 
     # merge train options in from the URI query string
-    creds.merge!(uri.query_values.transform_keys(&:to_sym)) unless uri.query_values.nil?
+    creds.merge!(uri.query_values.map { |k, v| [k.to_sym, v] }.to_h) unless uri.query_values.nil?
 
     # return the updated config
     creds

--- a/test/unit/train_test.rb
+++ b/test/unit/train_test.rb
@@ -235,7 +235,7 @@ describe Train do
 
     it "unpacks the query values as options to inspec" do
       org = {
-        target: "ssh://user:pass@host.com:123/path?bastion_host=stronghold.example.org&bastion_user=bulwark"
+        target: "ssh://user:pass@host.com:123/path?bastion_host=stronghold.example.org&bastion_user=bulwark",
       }
       res = Train.target_config(org)
       _(res[:backend]).must_equal "ssh"

--- a/test/unit/train_test.rb
+++ b/test/unit/train_test.rb
@@ -232,6 +232,23 @@ describe Train do
       org = { target: "123://invalid_scheme.example.com/" }
       _ { Train.target_config(org) }.must_raise Train::UserError
     end
+
+    it "unpacks the query values as options to inspec" do
+      org = {
+        target: "ssh://user:pass@host.com:123/path?bastion_host=stronghold.example.org&bastion_user=bulwark"
+      }
+      res = Train.target_config(org)
+      _(res[:backend]).must_equal "ssh"
+      _(res[:host]).must_equal "host.com"
+      _(res[:user]).must_equal "user"
+      _(res[:password]).must_equal "pass"
+      _(res[:port]).must_equal 123
+      _(res[:target]).must_equal org[:target]
+      _(res[:path]).must_equal "/path"
+      _(res[:bastion_host]).must_equal "stronghold.example.org"
+      _(res[:bastion_user]).must_equal "bulwark"
+      _(org.keys).must_equal [:target]
+    end
   end
 
   describe "#validate_backend" do


### PR DESCRIPTION
Pretty simple to support arbitrary options in URIs so that stuff like `ssh://user:pass@host.com:123/path?bastion_host=stronghold.example.org&bastion_user=bulwark` becomes valid.  This came up as a result of the work in https://github.com/chef/ohai/pull/1503 to support ohai over train and to allow passing a URL into ohai with the `--target` option on the command line such that it doesn't require the presence of a `.chef/crendentials` file.
