### PR TITLE
Change timeout log entry to debug

### DIFF
--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -341,7 +341,7 @@ class Train::Transports::SSH
       if timeout
         res = thr.join(timeout)
         unless res
-          logger.info("ssh command reached requested timeout (#{timeout}s)")
+          logger.debug("train ssh command '#{cmd}' reached requested timeout (#{timeout}s)")
           session.channels.each_value { |c| c.eof!; c.close }
           raise Train::CommandTimeoutReached.new "ssh command reached timeout (#{timeout}s)"
         end


### PR DESCRIPTION
This currently appears in InSpec logging at INFO level and doesn't hint that the entry is from train, not InSpec.
Drop it to a debug entry and mention train in the string.

Signed-off-by: James Stocks <jstocks@chef.io>