### PR TITLE
Make :forward_agent a valid SSH option

### DIFF
--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -63,6 +63,7 @@ module Train::Transports
     option :bastion_port, default: 22
     option :non_interactive, default: false
     option :verify_host_key, default: false
+    option :forward_agent, default: false
 
     # Allow connecting with older algorithms
     option :append_all_supported_algorithms, default: true

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -42,6 +42,10 @@ describe "ssh transport" do
     it "by default does not request a pty" do
       _(ssh.options[:pty]).must_equal false
     end
+
+    it "does not forward the ssh agent" do
+      _(ssh.options[:forward_agent]).must_equal false
+    end
   end
 
   describe "connection options" do


### PR DESCRIPTION
## Description

When I run `knife bootstrap --forward-agent …` chef calls Train::options to fetch the valid options for an SSH connection and rejects any options that are not listed as valid for Train::Transport::SSH:

https://github.com/chef/chef/blob/v16.8.2/lib/chef/knife/bootstrap/train_connector.rb#L269-L280

One of the options validated is `:forward_agent`.  Since it is not listed as a valid option by the SSH transport it can never be set on any connection.

Without this change Train::Transport::SSH connections for `knife bootstap` will always include `-o ForwardAgent=no` regardless of the user's choices.

Previously :forward_agent was not listed as a valid option for the SSH transport.  Now it is included as a valid option.

This means that `knife bootstrap --forward-agent` will now generate an SSH command containing `-o ForwardAgent=yes`.

The option is false by default in order to match current train behavior.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
