### PR TITLE
Use IdentitiesOnly only when keys are present

### DIFF
--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -72,13 +72,18 @@ class Train::Transports::SSH
 
       args  = %w{ -o UserKnownHostsFile=/dev/null }
       args += %w{ -o StrictHostKeyChecking=no }
-      args += %w{ -o IdentitiesOnly=yes }        if options[:keys]
-      args += %w{ -o BatchMode=yes }             if options[:non_interactive]
+      args += %w{ -o BatchMode=yes } if options[:non_interactive]
       args += %W{ -o LogLevel=#{level} }
       args += %W{ -o ForwardAgent=#{fwd_agent} } if options.key?(:forward_agent)
-      Array(options[:keys]).each do |ssh_key|
-        args += %W{ -i #{ssh_key} }
+
+      keys = Array(options[:keys])
+      unless keys.empty?
+        args += %w{ -o IdentitiesOnly=yes }
+        keys.each do |ssh_key|
+          args += %W{ -i #{ssh_key} }
+        end
       end
+
       args
     end
 


### PR DESCRIPTION
## Description

Previously train would include `-o IdentitiesOnly` when the :keys option was present but empty.

The IdentitiesOnly entry for ssh_config(5) states:

> Specifies that ssh(1) should only use the configured authentication
> identity and certificate files (either the default files, or those
> explicitly configured in the ssh_config files or passed on the ssh(1)
> command-line), even if ssh-agent(1) or a PKCS11Provider offers more
> identities.  The argument to this keyword must be yes or no (the
> default).  This option is intended for situations where ssh-agent
> offers many different identities.

While `IdentitiesOnly=yes` makes sense if the user specified `IdentityFile` in their `ssh_config`, it seems that for train `IdentitiesOnly=yes` was intended to override any `ssh_config` values with the user's configured keys.

Additionally, `knife bootstrap` has a `-i` option for specifying SSH keys.  If `-i` is not set then `knife bootstrap` sets train's :key_files option to an empty array which causes the old behavior:

https://github.com/chef/chef/blob/v16.8.9/lib/chef/knife/bootstrap.rb#L950

Perhaps this should be fixed only in chef?  Or in both places?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
