### PR TITLE
Test on ruby 3.0, drop testing on ruby 2.4

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -60,3 +60,28 @@ steps:
             - BUILDKITE
           host_os: windows
           shell: ["powershell", "-Command"]
+          image: rubydistros/windows-2019:2.6
+
+  - label: run-tests-ruby-2.7-windows
+    command:
+      - /workdir/.expeditor/buildkite/verify.ps1
+    expeditor:
+      executor:
+        docker:
+          environment:
+            - BUILDKITE
+          host_os: windows
+          shell: ["powershell", "-Command"]
+          image: rubydistros/windows-2019:2.7
+
+  - label: run-tests-ruby-3.0-windows
+    command:
+      - /workdir/.expeditor/buildkite/verify.ps1
+    expeditor:
+      executor:
+        docker:
+          environment:
+            - BUILDKITE
+          host_os: windows
+          shell: ["powershell", "-Command"]
+          image: rubydistros/windows-2019:3.0

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -10,21 +10,13 @@ expeditor:
 steps:
 
   # make sure lint runs on the oldest Ruby we support so we catch any new Ruby-isms here
-  - label: lint-ruby-2.4
+  - label: lint-ruby-2.5
     command:
       - RAKE_TASK=lint /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       executor:
         docker:
-          image: ruby:2.4
-
-  - label: run-tests-ruby-2.4
-    command:
-      - /workdir/.expeditor/buildkite/verify.sh
-    expeditor:
-      executor:
-        docker:
-          image: ruby:2.4
+          image: ruby:2.5
 
   - label: run-tests-ruby-2.5
     command:
@@ -49,6 +41,14 @@ steps:
       executor:
         docker:
           image: ruby:2.7
+
+  - label: run-tests-ruby-3.0
+    command:
+      - /workdir/.expeditor/buildkite/verify.sh
+    expeditor:
+      executor:
+        docker:
+          image: ruby:3.0
 
   - label: run-tests-ruby-2.6-windows
     command:


### PR DESCRIPTION
## Description

Adds CI testing for Ruby 3.0, and drops CI testing on EOL Ruby 2.4. Linting is now performed on Ruby 2.5 .

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
