### PR TITLE
Powershell process keep running with local train transport.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,27 @@
-<!-- latest_release -->
-<!-- latest_release -->
-
-<!-- release_rollup -->
-<!-- release_rollup -->
-
-<!-- latest_stable_release -->
+<!-- latest_release 3.4.7 -->
 ## [v3.4.7](https://github.com/inspec/train/tree/v3.4.7) (2021-01-11)
 
 #### Merged Pull Requests
-- Update chefstyle requirement from 1.5.7 to 1.5.9 [#654](https://github.com/inspec/train/pull/654) ([dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
-- Update google API upper constraints to allow Ruby 3 [#656](https://github.com/inspec/train/pull/656) ([clintoncwolfe](https://github.com/clintoncwolfe))
 - Test on ruby 3.0, drop testing on ruby 2.4 [#657](https://github.com/inspec/train/pull/657) ([clintoncwolfe](https://github.com/clintoncwolfe))
-<!-- latest_stable_release -->
+<!-- latest_release -->
 
+<!-- release_rollup since=3.4.4 -->
+### Changes not yet released to rubygems.org
+
+#### Merged Pull Requests
+- Test on ruby 3.0, drop testing on ruby 2.4 [#657](https://github.com/inspec/train/pull/657) ([clintoncwolfe](https://github.com/clintoncwolfe)) <!-- 3.4.7 -->
+- Update google API upper constraints to allow Ruby 3 [#656](https://github.com/inspec/train/pull/656) ([clintoncwolfe](https://github.com/clintoncwolfe)) <!-- 3.4.6 -->
+- Update chefstyle requirement from 1.5.7 to 1.5.9 [#654](https://github.com/inspec/train/pull/654) ([dependabot-preview[bot]](https://github.com/dependabot-preview[bot])) <!-- 3.4.5 -->
+<!-- release_rollup -->
+
+<!-- latest_stable_release -->
 ## [v3.4.4](https://github.com/inspec/train/tree/v3.4.4) (2020-12-14)
 
 #### Merged Pull Requests
 - Update parallel requirement from &lt; 1.20.0 to &lt; 1.21.0 [#651](https://github.com/inspec/train/pull/651) ([dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 - Update chefstyle requirement from 1.5.0 to 1.5.7 [#652](https://github.com/inspec/train/pull/652) ([dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 - Use IdentitiesOnly only when keys are present [#650](https://github.com/inspec/train/pull/650) ([drbrain](https://github.com/drbrain))
+<!-- latest_stable_release -->
 
 ## [v3.4.1](https://github.com/inspec/train/tree/v3.4.1) (2020-12-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,24 @@
-<!-- latest_release 3.4.7 -->
-## [v3.4.7](https://github.com/inspec/train/tree/v3.4.7) (2021-01-11)
-
-#### Merged Pull Requests
-- Test on ruby 3.0, drop testing on ruby 2.4 [#657](https://github.com/inspec/train/pull/657) ([clintoncwolfe](https://github.com/clintoncwolfe))
+<!-- latest_release -->
 <!-- latest_release -->
 
-<!-- release_rollup since=3.4.4 -->
-### Changes not yet released to rubygems.org
-
-#### Merged Pull Requests
-- Test on ruby 3.0, drop testing on ruby 2.4 [#657](https://github.com/inspec/train/pull/657) ([clintoncwolfe](https://github.com/clintoncwolfe)) <!-- 3.4.7 -->
-- Update google API upper constraints to allow Ruby 3 [#656](https://github.com/inspec/train/pull/656) ([clintoncwolfe](https://github.com/clintoncwolfe)) <!-- 3.4.6 -->
-- Update chefstyle requirement from 1.5.7 to 1.5.9 [#654](https://github.com/inspec/train/pull/654) ([dependabot-preview[bot]](https://github.com/dependabot-preview[bot])) <!-- 3.4.5 -->
+<!-- release_rollup -->
 <!-- release_rollup -->
 
 <!-- latest_stable_release -->
+## [v3.4.7](https://github.com/inspec/train/tree/v3.4.7) (2021-01-11)
+
+#### Merged Pull Requests
+- Update chefstyle requirement from 1.5.7 to 1.5.9 [#654](https://github.com/inspec/train/pull/654) ([dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+- Update google API upper constraints to allow Ruby 3 [#656](https://github.com/inspec/train/pull/656) ([clintoncwolfe](https://github.com/clintoncwolfe))
+- Test on ruby 3.0, drop testing on ruby 2.4 [#657](https://github.com/inspec/train/pull/657) ([clintoncwolfe](https://github.com/clintoncwolfe))
+<!-- latest_stable_release -->
+
 ## [v3.4.4](https://github.com/inspec/train/tree/v3.4.4) (2020-12-14)
 
 #### Merged Pull Requests
 - Update parallel requirement from &lt; 1.20.0 to &lt; 1.21.0 [#651](https://github.com/inspec/train/pull/651) ([dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 - Update chefstyle requirement from 1.5.0 to 1.5.7 [#652](https://github.com/inspec/train/pull/652) ([dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 - Use IdentitiesOnly only when keys are present [#650](https://github.com/inspec/train/pull/650) ([drbrain](https://github.com/drbrain))
-<!-- latest_stable_release -->
 
 ## [v3.4.1](https://github.com/inspec/train/tree/v3.4.1) (2020-12-07)
 

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -31,6 +31,10 @@ module Train::Transports
         nil # none, open your shell
       end
 
+      def close
+        @runner.close
+      end
+
       def uri
         "local://"
       end
@@ -108,6 +112,10 @@ module Train::Transports
           res.run_command
           Local::CommandResult.new(res.stdout, res.stderr, res.exitstatus)
         end
+
+        def close
+          # nothing to do at the moment
+        end
       end
 
       class WindowsShellRunner
@@ -132,6 +140,11 @@ module Train::Transports
           res.run_command
           Local::CommandResult.new(res.stdout, res.stderr, res.exitstatus)
         end
+
+        def close
+          # nothing to do at the moment
+        end
+
       end
 
       class WindowsPipeRunner
@@ -141,6 +154,7 @@ module Train::Transports
 
         def initialize(powershell_cmd = "powershell")
           @powershell_cmd = powershell_cmd
+          @server_pid = nil
           @pipe = acquire_pipe
           raise PipeError if @pipe.nil?
         end
@@ -160,12 +174,22 @@ module Train::Transports
           Local::CommandResult.new(res.stdout, res.stderr, res.exitstatus)
         end
 
+        def close
+          Process.kill("KILL", @server_pid)
+          @server_pid = nil
+        end
+
         private
 
         def acquire_pipe
+          require "win32/process"
+
           pipe_name = "inspec_#{SecureRandom.hex}"
 
-          start_pipe_server(pipe_name)
+          @server_pid = start_pipe_server(pipe_name)
+
+          # Ensure process is killed when the Train process exits
+          at_exit { Process.kill("KILL", @server_pid) unless @server_pid.nil? }
 
           pipe = nil
 
@@ -227,11 +251,7 @@ module Train::Transports
           utf8_script = script.encode("UTF-16LE", "UTF-8")
           base64_script = Base64.strict_encode64(utf8_script)
           cmd = "#{@powershell_cmd} -NoProfile -ExecutionPolicy bypass -NonInteractive -EncodedCommand #{base64_script}"
-
-          server_pid = Process.create(command_line: cmd).process_id
-
-          # Ensure process is killed when the Train process exits
-          at_exit { Process.kill("KILL", server_pid) }
+          Process.create(command_line: cmd).process_id
         end
       end
     end

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -59,6 +59,8 @@ describe "windows local command" do
   describe "force 64 bit powershell command" do
     let(:runner) { conn.instance_variable_get(:@runner) }
     let(:powershell) { runner.instance_variable_get(:@powershell_cmd) }
+    let(:server_pid) { runner.instance_variable_get(:@server_pid) }
+
     RUBY_PLATFORM_DUP = RUBY_PLATFORM.dup
 
     def override_platform(platform)
@@ -112,6 +114,19 @@ describe "windows local command" do
       override_platform("i386-mingw32")
       _(runner.class).must_equal Train::Transports::Local::Connection::WindowsShellRunner
       _(powershell).must_equal "#{ENV["SystemRoot"]}\\sysnative\\WindowsPowerShell\\v1.0\\powershell.exe"
+    end
+
+
+    it "sets server_pid and returns nil on close" do
+      Train::Transports::Local::Connection::WindowsPipeRunner
+        .any_instance
+        .expects(:new)
+        .never
+
+      override_platform("x64-mingw32")
+      _(powershell).must_equal "powershell"
+      _(server_pid).wont_be_nil
+      _(runner.close).must_be_nil
     end
   end
 

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -116,7 +116,6 @@ describe "windows local command" do
       _(powershell).must_equal "#{ENV["SystemRoot"]}\\sysnative\\WindowsPowerShell\\v1.0\\powershell.exe"
     end
 
-
     it "sets server_pid and returns nil on close" do
       Train::Transports::Local::Connection::WindowsPipeRunner
         .any_instance


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
While running compliance remediation cookbook for Windows Server 2019 one of the customer has reported that its creating multiple Powershell processes as defined in issue #358 after debugging the same.

This PR adds the implementation of close method which kills all running processes once the execution of the command is done.
Issue can be reproduce with following
```
cmds = ["dir", "mkdir test", "hostname", "$env:PATH"]
cmds.each do |cmd|
  conn = Train.create('local').connection
  conn = conn.run_command(cmd)
 end
```
Testing close method

```
cmds = ["dir", "mkdir test", "hostname", "$env:PATH"]
cmds.each do |cmd|
  conn = Train.create('local').connection
  conn = conn.run_command(cmd)
  conn.close
 end
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
