### PR TITLE
Implement upload/download for connections

### DIFF
--- a/lib/train/file.rb
+++ b/lib/train/file.rb
@@ -24,7 +24,7 @@ module Train
     # interface methods: these fields should be implemented by every
     # backend File
     DATA_FIELDS = %w{
-      exist? mode owner group uid gid content content= mtime size selinux_label path
+      exist? mode owner group uid gid content mtime size selinux_label path
     }.freeze
 
     DATA_FIELDS.each do |m|

--- a/lib/train/file.rb
+++ b/lib/train/file.rb
@@ -24,7 +24,7 @@ module Train
     # interface methods: these fields should be implemented by every
     # backend File
     DATA_FIELDS = %w{
-      exist? mode owner group uid gid content mtime size selinux_label path
+      exist? mode owner group uid gid content content= mtime size selinux_label path
     }.freeze
 
     DATA_FIELDS.each do |m|

--- a/lib/train/file/local.rb
+++ b/lib/train/file/local.rb
@@ -15,6 +15,12 @@ module Train
         nil
       end
 
+      def content=(new_content)
+        ::File.open(@path, "w", encoding: "UTF-8") { |fp| fp.write(new_content) }
+
+        @content = new_content
+      end
+
       def link_path
         return nil unless symlink?
 

--- a/lib/train/file/remote/windows.rb
+++ b/lib/train/file/remote/windows.rb
@@ -26,6 +26,16 @@ module Train
           @content
         end
 
+        def content=(new_content)
+          win_cmd = format('[IO.File]::WriteAllBytes("%<file>s", [Convert]::FromBase64String("%<base64>s"))',
+                           base64: Base64.strict_encode64(new_content),
+                           file: @spath)
+
+          @backend.run_command(win_cmd)
+
+          @content = new_content
+        end
+
         def exist?
           return @exist if defined?(@exist)
 

--- a/lib/train/transports/cisco_ios_connection.rb
+++ b/lib/train/transports/cisco_ios_connection.rb
@@ -29,6 +29,14 @@ class Train::Transports::SSH
       result.stdout.split(" ")[-1]
     end
 
+    def upload(locals, remote)
+      raise NotImplementedError, "#{self.class} does not implement #upload()"
+    end
+
+    def download(remotes, local)
+      raise NotImplementedError, "#{self.class} does not implement #download()"
+    end
+
     private
 
     def establish_connection

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -39,6 +39,18 @@ module Train::Transports
         "local://"
       end
 
+      def upload(locals, remote)
+        FileUtils.mkdir_p(remote)
+
+        Array(locals).each do |local|
+          FileUtils.cp_r(local, remote)
+        end
+      end
+
+      def download(remotes, local)
+        upload(remotes, local)
+      end
+
       private
 
       def select_runner(options)


### PR DESCRIPTION
Adds default `upload`/`download` methods to transfer files. Also adds a `content=` method for remote file manipulation.

## Description

While the SSH and the WinRM transport plugin already implemented the `upload`/`download` methods, those were not part of the general plugin API.

Offering these two methods and general file manipulation capabilities greatly extends any tool built on Train (e.g. Chef Target Mode).

On `base_connection`, the `upload` method iterates using the new `content=` method which uses base64 en-/decoding on Unix/Windows platforms. The `local` transport got simple local file manipulations for this, the `cisco_ios_connection`will throw an error. Can't test QNX/AIX, sorry.

I actually prepared both a Test Kitchen "train" transport and a remote shell utility based on this and it's working fine with my Linux/Windows systems. So I suppose the same goes for any other transport (AWS Systems Manager, VMware GOM etc).

## Related Issue

none

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
