### PR TITLE
Fix crash on exit

### DIFF
--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -187,7 +187,7 @@ module Train::Transports
           @server_pid = start_pipe_server(pipe_name)
 
           # Ensure process is killed when the Train process exits
-          at_exit { close }
+          at_exit { close rescue Errno::EIO }
 
           pipe = nil
 


### PR DESCRIPTION
## Description

In some cases, the local transport will crash during Ruby shutdown, throwing `Input/output error - TerminateProcess (Errno::EIO)` when ending the PipeServer process.

Expected output:
```
      ...
      
      Profile: InSpec Profile (appinstall-edge)
       Version: 0.1.0
       Target:  local://

         [FAIL]  install_edge: Check main Edge installation
            [FAIL]  Registry Key HKLM\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\{B728BA60-433F-30E9-A484-87A91F86330E} is expected to exist
            expected Registry Key HKLM\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\{B728BA60-433F-30E9-A484-87A91F86330E} to exist


       Profile Summary: 0 successful controls, 16 control failures, 4 controls skipped
       Test Summary: 2 successful, 33 failures, 4 skipped
        (up to date)

       Running handlers:
       Running handlers complete
       Chef Infra Client finished, 0/14 resources updated in 15 seconds
       Downloading files from <execute-windows2019>
       Finished converging <execute-windows2019> (0m27.14s).
-----> Test Kitchen is finished. (0m30.05s)
vagrant:~/ $
```

Actual output with Train 3.4.9:

```
       Profile: InSpec Profile (appinstall-edge)
       Version: 0.1.0
       Target:  local://

         [FAIL]  install_edge: Check main Edge installation
            [FAIL]  Registry Key HKLM\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\{B728BA60-433F-30E9-A484-87A91F86330E} is expected to exist
            expected Registry Key HKLM\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\{B728BA60-433F-30E9-A484-87A91F86330E} to exist


       Profile Summary: 0 successful controls, 16 control failures, 4 controls skipped
       Test Summary: 2 successful, 33 failures, 4 skipped
        (up to date)

       Running handlers:
       Running handlers complete
       Chef Infra Client finished, 0/14 resources updated in 16 seconds
$$$$$$ #< CLIXML
$$$$$$ ERROR: The system cannot find the file specified.
$$$$$$
$$$$$$ ERROR: The system cannot find the file specified.
$$$$$$
$$$$$$ ERROR: The system cannot find the file specified.
$$$$$$
$$$$$$ ERROR: The system cannot find the file specified.
$$$$$$
$$$$$$ <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj><Obj S="information" RefId="1"><TN RefId="1"><T>System.Management.Automation.InformationRecord</T><T>System.Object</T></TN><ToString>5.1</ToString><Props><Obj N="MessageData" RefId="2"><TN RefId="2"><T>System.Management.Automation.HostInformationMessage</T><T>System.Object</T></TN><ToString>5.1</ToString><Props><S N="Message">5.1</S><B N="NoNewLine">true</B><S N="ForegroundColor">Gray</S><S N="BackgroundColor">Black</S></Props></Obj><S N="Source">Write-Host</S><DT N="TimeGenerated">2021-02-15T17:52:27.2215744-08:00</DT><Obj N="Tags" RefId="3"><TN RefId="3"><T>System.Collections.Generic.List`1[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</T><T>System.Object</T></TN><LST><S>PSHOST</S></LST></Obj><S N="User">WIN-FATRN6PQGKK\Administrator</S><S N="Computer">WIN-FATRN6PQGKK</S><U32 N="ProcessId">2136</U32><U32 N="NativeThreadId">2704</U32><U32 N="ManagedThreadId">7</U32></Props></Obj></Objs>
$$$$$$ C:/opscode/chef/embedded/lib/ruby/gems/2.7.0/gems/win32-process-0.8.3/lib/win32/process.rb:744:in `kill': warning: $SAFE will become a normal global variable in Ruby 3.0 (StructuredWarnings::BuiltInWarning)
$$$$$$ C:/opscode/chef/embedded/lib/ruby/gems/2.7.0/gems/win32-process-0.8.3/lib/win32/process.rb:850:in `block in kill': Input/output error - TerminateProcess (Errno::EIO)
$$$$$$  from C:/opscode/chef/embedded/lib/ruby/gems/2.7.0/gems/win32-process-0.8.3/lib/win32/process.rb:797:in `each'
$$$$$$  from C:/opscode/chef/embedded/lib/ruby/gems/2.7.0/gems/win32-process-0.8.3/lib/win32/process.rb:797:in `kill'
$$$$$$  from C:/opscode/chef/embedded/lib/ruby/gems/2.7.0/gems/train-core-3.3.4/lib/train/transports/local.rb:191:in `close'
$$$$$$  from C:/opscode/chef/embedded/lib/ruby/gems/2.7.0/gems/train-core-3.3.4/lib/train/transports/local.rb:204:in `block in acquire_pipe'
^C
vagrant:~/ $
```

Examples show the remote execution of InSpec from Chef Client (use case: generating a compliance report saved on the target system for operator inspection). The current state will have Kitchen loop, as the process did apparently not exit with code 0 - although the Chef Client did.

The fix is easy: Catch that exception in the `at_exit { }` handler.

## Related Issue

#660 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
