### PR TITLE
Handle user option for user selection through docker transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ train = Train.create('winrm',
 require 'train'
 train = Train.create('docker', host: 'container_id...')
 ```
+You can use `user` option to connect with privileged user on non root user images.
+
+```ruby
+require 'train'
+train = Train.create('docker', host: 'container_id...', user: 'root')
+```
 
 **AWS**
 

--- a/lib/train/transports/docker.rb
+++ b/lib/train/transports/docker.rb
@@ -88,7 +88,7 @@ class Train::Transports::Docker
       stdout, stderr, exit_status = @container.exec(
         [
           "/bin/sh", "-c", cmd
-        ]
+        ], user: @options[:user]
       )
       CommandResult.new(stdout.join, stderr.join, exit_status)
     rescue ::Docker::Error::DockerError => _


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
For testing created the non root docker image and executed docker run after that executed following train commands.

Before adding user option in the run_command
```
$ irb -I lib/
2.7.0 :001 > require 'train'
 => true 
2.7.0 :002 > t = Train.create('docker', host: '5f2dbf21d6ee')
 => #<Train::Transports::Docker:0x0000000001526948 @options={:host=>"5f2dbf21d6ee", :shell=>false, :shell_options=>nil, :shell_command=>... 
2.7.0 :003 > c = t.connection
 => Train::Transports::Docker::Connection[unknown] 
2.7.0 :004 > c.run_command("whoami").stdout
 => "john\n" 
2.7.0 :005 > t = Train.create('docker', host: '5f2dbf21d6ee', user: 'root')
 => #<Train::Transports::Docker:0x0000000001cfe030 @options={:host=>"5f2dbf21d6ee", :user=>"root", :shell=>false, :shell_options=>nil, :... 
2.7.0 :006 > c = t.connection
 => Train::Transports::Docker::Connection[unknown] 
2.7.0 :007 > c.run_command("whoami").stdout
 => "john\n" 
```

Output after adding option in run_command
```
$ irb -I lib/
2.7.0 :001 > require 'train'
 => true 
2.7.0 :002 > t = Train.create('docker', host: '5f2dbf21d6ee')
 => #<Train::Transports::Docker:0x0000000002129d08 @options={:host=>"5f2dbf21d6ee", :shell=>false, :shell_options=>nil, :shell_command=>... 
2.7.0 :003 > c = t.connection
 => Train::Transports::Docker::Connection[unknown] 
2.7.0 :004 > c.run_command("whoami").stdout
 => "john\n" 
2.7.0 :005 > t = Train.create('docker', host: '5f2dbf21d6ee', user: 'root')
 => #<Train::Transports::Docker:0x000000000201a6b0 @options={:host=>"5f2dbf21d6ee", :user=>"root", :shell=>false, :shell_options=>nil, :... 
2.7.0 :006 > c = t.connection
 => Train::Transports::Docker::Connection[unknown] 
2.7.0 :007 > c.run_command("whoami").stdout
 => "root\n" 
```
Also tested with the base image where non root user is not configured and following is the output for the same

```
2.7.0 :001 > require 'train'
 => true 
2.7.0 :002 > t = Train.create('docker', host: '946f59562e28')
 => #<Train::Transports::Docker:0x0000000003066f78 @options={:host=>"946f59562e28", :shell=>false, :shell_options=>nil, :shell_command=>... 
2.7.0 :003 > t.connection
 => Train::Transports::Docker::Connection[unknown] 
2.7.0 :004 > c = t.connection
 => Train::Transports::Docker::Connection[unknown] 
2.7.0 :005 > c.run_command("whoami").stdout
 => "root\n" 
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #574 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
