### PR TITLE
Add timeout support to Mixlib::ShellOut based local runners

### DIFF
--- a/test/unit/transports/local_test.rb
+++ b/test/unit/transports/local_test.rb
@@ -113,6 +113,7 @@ describe "local transport" do
 
     def mock_run_cmd(cmd, &block)
       cmd_runner.expect :run_command, nil
+      cmd_runner.expect :timeout=, nil, [nil]
       Mixlib::ShellOut.stub :new, cmd_runner do |*args|
         yield
       end
@@ -164,7 +165,7 @@ describe "local transport" do
         .expects(:new)
         .never
 
-      runner.expects(:run_command).with("not actually executed")
+      runner.expects(:run_command).with("not actually executed", {})
       connection.run_command("not actually executed")
     end
 
@@ -177,7 +178,7 @@ describe "local transport" do
         .expects(:new)
         .returns(runner)
 
-      runner.expects(:run_command).with("not actually executed")
+      runner.expects(:run_command).with("not actually executed", {})
       connection.run_command("not actually executed")
     end
   end


### PR DESCRIPTION
## Description

Adds support for Mixlib::ShellOut's timeout feature to two of the local command runners, GenericRunner and WindowsShellRunner. This will allow InSpec to use command timeouts in local connections on more platforms.

Unfortunately I did not see any clear way of adding timeouts to WindowsPipeRunner, which might involve wrapping the script in a watchdog script. I've left that as a TODO for now.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

https://github.com/inspec/inspec/3772


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
