### PR TITLE
Support Docker for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ require 'train'
 train = Train.create('docker', host: 'container_id...', docker_url: 'tcp://localhost:1234')
 ```
 
+Windows Docker containers require PowerShell, which is assumed to be installed as `powershell.exe`. If it is installed as `pwsh`, use the `--shell-command` option to specify `pwsh` as the shell.
+
 
 **AWS**
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,13 @@ require 'train'
 train = Train.create('docker', host: 'container_id...', user: 'root')
 ```
 
-For Docker Desktop for Windows, you must enable the "Expose daemon on tcp://localhost:2375 without TLS" setting.
+For Docker Desktop for Windows, you must enable the "Expose daemon on tcp://localhost:2375 without TLS" setting. To change the URL that train uses to connect to Docker, use the `docker_url` option:
+
+```ruby
+require 'train'
+train = Train.create('docker', host: 'container_id...', docker_url: 'tcp://localhost:1234')
+```
+
 
 **AWS**
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ require 'train'
 train = Train.create('docker', host: 'container_id...', user: 'root')
 ```
 
+For Docker Desktop for Windows, you must enable the "Expose daemon on tcp://localhost:2375 without TLS" setting.
+
 **AWS**
 
 To use AWS API authentication, setup an AWS client profile to store the Access Key ID and Secret Access Key.

--- a/lib/train/transports/docker.rb
+++ b/lib/train/transports/docker.rb
@@ -53,6 +53,12 @@ class Train::Transports::Docker
     def initialize(conf)
       super(conf)
       @id = options[:host]
+      if RUBY_PLATFORM =~ /windows|mswin|msys|mingw|cygwin/
+        # Docker Desktop for windows. Must override socket location.
+        # https://docs.docker.com/desktop/faqs/#how-do-i-connect-to-the-remote-docker-engine-api
+        # Docker.url = "npipe:////./pipe/docker_engine" # # Doesn't require a settings change, but also doesn't work
+        Docker.url = "tcp://localhost:2375"
+      end
       @container = ::Docker::Container.get(@id) ||
         raise("Can't find Docker container #{@id}")
       @cmd_wrapper = nil

--- a/lib/train/transports/docker.rb
+++ b/lib/train/transports/docker.rb
@@ -6,6 +6,7 @@ module Train::Transports
 
     include_options Train::Extras::CommandWrapper
     option :host, required: true
+    option :docker_url, required: false
 
     def connection(state = {}, &block)
       opts = merge_options(options, state || {})
@@ -53,12 +54,16 @@ class Train::Transports::Docker
     def initialize(conf)
       super(conf)
       @id = options[:host]
+
+      docker_url = options[:docker_url]
       if RUBY_PLATFORM =~ /windows|mswin|msys|mingw|cygwin/
         # Docker Desktop for windows. Must override socket location.
         # https://docs.docker.com/desktop/faqs/#how-do-i-connect-to-the-remote-docker-engine-api
-        # Docker.url = "npipe:////./pipe/docker_engine" # # Doesn't require a settings change, but also doesn't work
-        Docker.url = "tcp://localhost:2375"
+        # docker_socket ||= "npipe:////./pipe/docker_engine" # # Doesn't require a settings change, but also doesn't work
+        docker_url ||= "tcp://localhost:2375"
       end
+      Docker.url = docker_url if docker_url
+
       @container = ::Docker::Container.get(@id) ||
         raise("Can't find Docker container #{@id}")
       @cmd_wrapper = nil

--- a/lib/train/transports/docker.rb
+++ b/lib/train/transports/docker.rb
@@ -99,10 +99,11 @@ class Train::Transports::Docker
 
     def run_command_via_connection(cmd, &_data_handler)
       cmd = @cmd_wrapper.run(cmd) unless @cmd_wrapper.nil?
+
       # Cannot use os.windows? here because it calls run_command_via_connection,
       # causing infinite recursion during initial platform detection
       if sniff_for_windows?
-        invocation = powershell_run_command(cmd)
+        invocation = cmd_run_command(cmd)
       else
         invocation = sh_run_command(cmd)
       end
@@ -119,20 +120,6 @@ class Train::Transports::Docker
 
     def sh_run_command(cmd)
       ["/bin/sh", "-c", cmd]
-    end
-
-    def powershell_run_command(script)
-      # Adapted from local command runner
-      require "base64" unless defined?(Base64)
-
-      # Prevent progress stream from leaking into stderr
-      script = "$ProgressPreference='SilentlyContinue';" + script
-
-      # Encode script so PowerShell can use it
-      script = script.encode("UTF-16LE", "UTF-8")
-      base64_script = Base64.strict_encode64(script)
-
-      ["pwsh", "-NoProfile", "-EncodedCommand", base64_script]
     end
 
     def cmd_run_command(cmd)


### PR DESCRIPTION
## Description

Supports Docker for Windows, by:

 * Making the docker URL an option, and defaulting it to be the TCP port 2375 on Windows
 * Updating the `run_command_via_connection` method to use `cmd.exe` when on Windows, rather than always using `/bin/sh`

Caveats:
 * For Docker Desktop for Windows, you must make a special setting to enable TCP connections on port 2375. I could not get the default named pipe connection to work. 
 * Initial Windows detection is crude, by attempting to use `/bin/sh` and falling back to cmd.exe if a Windows-style error message is detected. 
 * If using Windows containers, you must have PowerShell installed in the container, and if not available as `powershell.exe`, you must pass the name of the executable (likely `pwsh`) using `--shell-command`


Tested using the `mcr.microsoft.com/powershell:lts-nanoserver-1809` image and the `mcr.microsoft.com/windows/servercore:ltsc2019` image. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #672 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
