### PR TITLE
Switch to GNU timeout-based implementation of SSH timeouts

### DIFF
--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -321,6 +321,9 @@ class Train::Transports::SSH
         # wrap commands if that is configured
         cmd = @cmd_wrapper.run(cmd) if @cmd_wrapper
 
+        # Timeout the command if requested and able
+        cmd = "timeout #{timeout}s #{cmd}" if timeout && timeoutable?(cmd)
+
         logger.debug("[SSH] #{self} cmd = #{cmd}")
 
         if @transport_options[:pty]
@@ -350,21 +353,30 @@ class Train::Transports::SSH
           end
         end
       end
+      session.loop
 
-      thr = Thread.new { session.loop }
-
-      if timeout
-        res = thr.join(timeout)
-        unless res
-          logger.debug("train ssh command '#{cmd}' reached requested timeout (#{timeout}s)")
-          session.channels.each_value { |c| c.eof!; c.close }
-          raise Train::CommandTimeoutReached.new "ssh command reached timeout (#{timeout}s)"
-        end
-      else
-        thr.join
+      if timeout && timeoutable?(cmd) && exit_status == 124
+        logger.debug("train ssh command '#{cmd}' reached requested timeout (#{timeout}s)")
+        session.channels.each_value { |c| c.eof!; c.close }
+        raise Train::CommandTimeoutReached.new "ssh command reached timeout (#{timeout}s)"
       end
 
       [exit_status, stdout, stderr]
+    end
+
+    # Returns true if we think we can attempt to timeout the command
+    def timeoutable?(cmd)
+      have_timeout_cli? && !cmd.include?("|") # Don't try to timeout a command that has pipes
+    end
+
+    # Returns true if the GNU timeout command is available
+    def have_timeout_cli?
+      return @have_timeout_cli unless @have_timeout_cli.nil?
+
+      res = session.exec!("timeout --version")
+      @have_timeout_cli = res.exitstatus == 0
+      logger.debug("train ssh have_timeout_cli status is '#{@have_timeout_cli}'")
+      @have_timeout_cli
     end
   end
 end

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -32,6 +32,10 @@ class Train::Transports::SSH
     attr_reader   :hostname
     attr_accessor :transport_options
 
+    # If we use the GNU timeout utility to timout a command server-side, it will
+    # exit with this status code if the command timed out.
+    GNU_TIMEOUT_EXIT_STATUS = 124
+
     def initialize(options)
       # Track IOS command retries to prevent infinite loop on IOError. This must
       # be done before `super()` because the parent runs detection commands.
@@ -355,7 +359,7 @@ class Train::Transports::SSH
       end
       session.loop
 
-      if timeout && timeoutable?(cmd) && exit_status == 124
+      if timeout && timeoutable?(cmd) && exit_status == GNU_TIMEOUT_EXIT_STATUS
         logger.debug("train ssh command '#{cmd}' reached requested timeout (#{timeout}s)")
         session.channels.each_value { |c| c.eof!; c.close }
         raise Train::CommandTimeoutReached.new "ssh command reached timeout (#{timeout}s)"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

As the title says, this PR switches the SSH timeout feature to use the GNU timeout utility (when available) to implement command timeouts instead of using a client-side thread and closing the session, which abandons processes on the server (See #677). 

This severely limits the applicability of the feature. First, the timeout utility must be installed. As it is part of gnu coreutils, it is common on Linux and other systems, but not universal, so we must do a check for it. Second, as it is a command wrapper, it does not function properly with any command string that includes pipes. Notably, all InSpec sudo commands include pipes. So, we check for pipes, and do not attempt to do a timeout on any command containing pipes. 

This PR retains some functionality while making the feature safe to use. It is a compromise between letting the processes continue to run as on #677, and withdrawing the feature entirely from the SSH transport.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #677

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
