### PR TITLE
Remove pins for Ruby < 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,6 @@ group :test do
   gem "minitest", "~> 5.8"
   gem "rake", "~> 13.0"
   gem "chefstyle", "2.0.5"
-  gem "parallel", "< 1.21.0" # remove this pin once support for Ruby 2.4 ends
-  gem "simplecov", "< 0.19" # remove this pin once support for Ruby 2.4 ends
   gem "concurrent-ruby", "~> 1.0"
   gem "pry-byebug"
   gem "m"


### PR DESCRIPTION
We don't need / want these pins anymore

Signed-off-by: Tim Smith <tsmith@chef.io>