### PR TITLE
Parse Message : Added new message for lack of sudo privilege and appl…

### DIFF
--- a/lib/train/extras/command_wrapper.rb
+++ b/lib/train/extras/command_wrapper.rb
@@ -81,6 +81,9 @@ module Train::Extras
       when /sudo: sorry, you must have a tty to run sudo/
         ["Sudo requires a TTY. Please see the README on how to configure "\
           "sudo to allow for non-interactive usage.", :sudo_no_tty]
+      when /sudo: a terminal is required to read the password; either use/
+        ["Sudo cannot prompt for password because there is no terminal. "\
+            "Please provide the sudo password directly", :sudo_missing_terminal]
       else
         [rawerr, nil]
       end


### PR DESCRIPTION
Error message thrown  when user needs password everytime to perform a sudo operation on the target OS is not well handled currently 

## Description

Current Error message thrown to the user is like this : - 

```
ERROR: Train::UserError: Sudo failed: sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helpe
```
Handled in train code and returning a formatted message, that is easy to understand and helps user exactly what is the error like this : - 

```
Sudo does not have enough privileges for the operation, try passing password with -P or --ssh-password option
```
## Related Issue
https://github.com/chef/chef/issues/11359

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
