### PR TITLE
Add x25519 gem for SSH KEX support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :test do
   gem "pry-byebug"
   gem "m"
   gem "ed25519" # ed25519 ssh key support
+  gem "x25519" # ed25519 ssh key support for KEX
   gem "bcrypt_pbkdf" # ed25519 ssh key support
   # This is not a true gem installation
   # (Gem::Specification.find_by_path('train-gem-fixture') will return nil)


### PR DESCRIPTION
Turns out that the `ed25519` gem only provides key algorithms, not key *exchange* algorithms, which are included in a separate sister gem. This bit us on inspec. When one is included, the other should be as well.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #691

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
