### PR TITLE
Updating expeditor configuration

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -21,7 +21,8 @@ github:
     - "Expeditor: Bump Minor Version"
   major_bump_labels:
     - "Expeditor: Bump Major Version"
-  release_branch:
+    
+release_branches:
     - 2-stable:
         version_constraint: 2.*
     - master:
@@ -30,25 +31,27 @@ github:
 changelog:
   rollup_header: Changes not yet released to rubygems.org
 
+subscriptions:
 # These actions are taken, in order they are specified, anytime a Pull Request is merged.
-merge_actions:
-  - built_in:bump_version:
-      ignore_labels:
-        - "Expeditor: Skip Version Bump"
-        - "Expeditor: Skip All"
-  - bash:.expeditor/update_version.sh:
-      only_if: built_in:bump_version
-  - built_in:update_changelog:
-      ignore_labels:
-        - "Expeditor: Skip Changelog"
-        - "Expeditor: Skip All"
-  - built_in:build_gem:
-      only_if: built_in:bump_version
-  - trigger_pipeline:coverage:
-      post_commit: true
+  - workload: pull_request_merged:{{github_repo}}:{{release_branch}}:*
+    actions:
+      - built_in:bump_version:
+         ignore_labels:
+          - "Expeditor: Skip Version Bump"
+          - "Expeditor: Skip All"
+      - bash:.expeditor/update_version.sh:
+         only_if: built_in:bump_version
+      - built_in:update_changelog:
+         ignore_labels:
+          - "Expeditor: Skip Changelog"
+          - "Expeditor: Skip All"
+      - built_in:build_gem:
+         only_if: built_in:bump_version
+      - trigger_pipeline:coverage:
+         post_commit: true
 
 subscriptions:
-  - workload: pull_request_opened:{{agent_id}}:*
+  - workload: pull_request_opened:{{github_repo}}:{{release_branch}}:*
     actions:
       - post_github_comment:.expeditor/templates/pull_request.mustache:
           ignore_team_members:


### PR DESCRIPTION
Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description

i) The merge_actions subscription shortcut has been deprecated. All subscriptions should be declared via the subscriptions block for clarity.
ii) Release branches are a first-class concept in Expeditor, and should be represented as such.
iii) The {{agent_id}} format is changing such that it is no longer a viable variable for the pull_request_* event subscriptions.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
