### PR TITLE
Fixed ssh connection issue if key_files array is empty

### DIFF
--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -177,7 +177,7 @@ module Train::Transports
         max_wait_until_ready: opts[:max_wait_until_ready],
         auth_methods: opts[:auth_methods],
         keys_only: opts[:keys_only],
-        keys: opts[:key_files].empty? ? nil : opts[:key_files],
+        keys: (!opts[:key_files].nil? && opts[:key_files].empty?) ? nil : opts[:key_files],
         password: opts[:password],
         forward_agent: opts[:forward_agent],
         proxy_command: opts[:proxy_command],

--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -177,7 +177,7 @@ module Train::Transports
         max_wait_until_ready: opts[:max_wait_until_ready],
         auth_methods: opts[:auth_methods],
         keys_only: opts[:keys_only],
-        keys: opts[:key_files],
+        keys: opts[:key_files].empty? ? nil : opt[:key_files],
         password: opts[:password],
         forward_agent: opts[:forward_agent],
         proxy_command: opts[:proxy_command],

--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -177,7 +177,7 @@ module Train::Transports
         max_wait_until_ready: opts[:max_wait_until_ready],
         auth_methods: opts[:auth_methods],
         keys_only: opts[:keys_only],
-        keys: opts[:key_files].empty? ? nil : opt[:key_files],
+        keys: opts[:key_files].empty? ? nil : opts[:key_files],
         password: opts[:password],
         forward_agent: opts[:forward_agent],
         proxy_command: opts[:proxy_command],

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -57,6 +57,12 @@ describe "ssh transport" do
       _(connection_options.key?(:paranoid)).must_equal false
     end
 
+    it "set key_files to nil if its []" do
+      opts = { key_files: [] }
+      seen_opts = ssh.send(:connection_options, opts)
+      assert_nil(seen_opts[:keys])
+    end
+
     describe "various values are mapped appropriately for verify_host_key" do
       # This would be better:
       # Net::SSH::Version.stub_const(:CURRENT, Net::SSH::Version[5,0,1])


### PR DESCRIPTION
Signed-off-by: sanga17 <sausekar@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
If key_files set as empty array then failing to ssh connection while bootstrapping the node

## Related Issue
https://github.com/chef/chef/issues/7053

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
