### PR TITLE
Use ssh config file by default

### DIFF
--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -97,22 +97,20 @@ module Train::Transports
     end
 
     def apply_ssh_config_file(host)
-      if options[:ssh_config_file] != false && !options[:ssh_config_file].nil?
-        files = options[:ssh_config_file] == true ? Net::SSH::Config.default_files : options[:ssh_config_file]
-        host_cfg = ssh_config_file_for_host(host, files)
-        host_cfg.each do |key, value|
-          # setting the key_files option to the private keys set in ssh config file
-          if key == :keys && options[:key_files].nil? && !host_cfg[:keys].nil? && options[:password].nil?
-            options[:key_files] = host_cfg[key]
-          elsif options[key].nil?
-            # Precedence is given to the option set by the user manually.
-            # And only assigning value to the option from the ssh config file when it is not set by the user
-            # in the option. When the option has a default value for e.g. option "user" has the "root" as the default
-            # value, then the default value will be used even though the value for "user" is present in the ssh
-            # config file. That is because the precedence is to the options set manually, and we don't have
-            # any way to differentiate between the value set by the user or is it the default.
-            options[key] = host_cfg[key]
-          end
+      files = options[:ssh_config_file] == true ? Net::SSH::Config.default_files : options[:ssh_config_file]
+      host_cfg = ssh_config_file_for_host(host, files)
+      host_cfg.each do |key, value|
+        # setting the key_files option to the private keys set in ssh config file
+        if key == :keys && options[:key_files].nil? && !host_cfg[:keys].nil? && options[:password].nil?
+          options[:key_files] = host_cfg[key]
+        elsif options[key].nil?
+          # Precedence is given to the option set by the user manually.
+          # And only assigning value to the option from the ssh config file when it is not set by the user
+          # in the option. When the option has a default value for e.g. option "keepalive_interval" has the "60" as the default
+          # value, then the default value will be used even though the value for "user" is present in the ssh
+          # config file. That is because the precedence is to the options set manually, and currently we don't have
+          # any way to differentiate between the value set by the user or is it the default. This has a future of improvement.
+          options[key] = host_cfg[key]
         end
       end
     end

--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -104,10 +104,12 @@ module Train::Transports
           if key == :keys && options[:key_files].nil? && !host_cfg[:keys].nil? && options[:password].nil?
             options[:key_files] = host_cfg[key]
           elsif options[key].nil?
-            # Give precedence to config file when ssh_config_file options is set to true or to the path of the config file.
-            # This is required as there are default values set for some of the opitons and we unable to
-            # identify whether the values are set from the cli option or those are default so either we should give
-            # precedence to config file or otherwise we need to check each options default values and then set the value for that option.
+            # Precedence is given to the option set by the user manually.
+            # And only assigning value to the option from the ssh config file when it is not set by the user
+            # in the option. When the option has a default value for e.g. option "user" has the "root" as the default
+            # value, then the default value will be used even though the value for "user" is present in the ssh
+            # config file. That is because the precedence is to the options set manually, and we don't have
+            # any way to differentiate between the value set by the user or is it the default.
             options[key] = host_cfg[key]
           end
         end

--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -87,12 +87,13 @@ module Train::Transports
       end
     end
 
+    # Returns the ssh config option like user, port from config files
+    # Params options [Hash], option_type [String]
+    # Return String
     def self.read_options_from_ssh_config(options, option_type)
-      if options[:ssh_config_file] != false && !options[:ssh_config_file].nil?
-        files = options[:ssh_config_file] == true ? Net::SSH::Config.default_files : options[:ssh_config_file]
-        config_options = Net::SSH::Config.for(options[:host], files)
-        config_options[option_type]
-      end
+      files = options[:ssh_config_file].nil? || options[:ssh_config_file] == true ? Net::SSH::Config.default_files : options[:ssh_config_file]
+      config_options = Net::SSH::Config.for(options[:host], files)
+      config_options[option_type]
     end
 
     def apply_ssh_config_file(host)

--- a/test/unit/transports/cisco_ios_connection_test.rb
+++ b/test/unit/transports/cisco_ios_connection_test.rb
@@ -2,6 +2,11 @@ require "helper"
 require "train/transports/ssh"
 
 describe "CiscoIOSConnection" do
+  before do
+    # This is to skip the test on windows as bundle exec rake is giving eror ArgumentError: non-absolute home
+    skip "not on windows" if windows?
+  end
+
   let(:cls) do
     plat = Train::Platforms.name("mock").in_family("cisco_ios")
     plat.add_platform_methods

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -400,6 +400,11 @@ describe "ssh transport with bastion" do
 end
 
 describe "ssh transport with bastion and proxy" do
+  before do
+    # This is to skip the test on windows as bundle exec rake is giving eror ArgumentError: non-absolute home
+    skip "not on windows" if windows?
+  end
+
   let(:cls) do
     plat = Train::Platforms.name("mock").in_family("linux")
     plat.add_platform_methods

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -2,6 +2,11 @@ require "helper"
 require "train/transports/ssh"
 
 describe "ssh transport" do
+  before do
+    # This is to skip the test on windows as bundle exec rake is giving eror ArgumentError: non-absolute home
+    skip "not on windows" if windows?
+  end
+
   let(:cls) do
     plat = Train::Platforms.name("mock").in_family("linux")
     plat.add_platform_methods
@@ -264,6 +269,11 @@ describe "ssh transport" do
 end
 
 describe "ssh transport with bastion" do
+  before do
+    # This is to skip the test on windows as bundle exec rake is giving eror ArgumentError: non-absolute home
+    skip "not on windows" if windows?
+  end
+
   let(:cls) do
     plat = Train::Platforms.name("mock").in_family("linux")
     plat.add_platform_methods
@@ -299,6 +309,11 @@ describe "ssh transport with bastion" do
     end
 
     describe "opening a connection" do
+      before do
+        # This is to skip the test on windows as bundle exec rake is giving eror ArgumentError: non-absolute home
+        skip "not on windows" if windows?
+      end
+
       let(:ssh) { cls.new(conf) }
       let(:connection) { ssh.connection }
 
@@ -411,6 +426,11 @@ describe "ssh transport with bastion and proxy" do
 end
 
 describe "ssh transport ssh_config_file option" do
+  before do
+    # This is to skip the test on windows as bundle exec rake is giving eror ArgumentError: non-absolute home
+    skip "not on windows" if windows?
+  end
+
   let(:cls) do
     plat = Train::Platforms.name("mock").in_family("linux")
     plat.add_platform_methods

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -438,11 +438,11 @@ describe "ssh transport ssh_config_file option" do
   it "sets the default auth_methods when password is specified" do
     conf[:host] = "localhost2"
     conf[:password] = rand.to_s
-    _(cls.new(conf).connection.method(:options).call[:auth_methods]).must_equal %w{none publickey password keyboard-interactive}
+    _(cls.new(conf).connection.method(:options).call[:auth_methods]).must_equal %w{none password keyboard-interactive}
   end
 
   it "sets the default auth_methods when password is not specified" do
-    _(cls.new(conf).connection.method(:options).call[:auth_methods]).must_equal %w{none publickey password keyboard-interactive}
+    _(cls.new(conf).connection.method(:options).call[:auth_methods]).must_equal %w{none publickey}
   end
 
   it "gets overridden by command line option if port and user provided through command line options." do


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The Net::SSH config option set true by default https://www.rubydoc.info/github/net-ssh/net-ssh/Net/SSH. So it is required to set the ssh_config_file newly added option to true to keep earlier behavior. 
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#709
Fixes #712

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
