### PR TITLE
Fix for Windows w/pwsh installed for vmware train

### DIFF
--- a/lib/train/transports/vmware.rb
+++ b/lib/train/transports/vmware.rb
@@ -98,10 +98,11 @@ module Train::Transports
       private
 
       def detect_powershell_binary
-        if find_executable0("pwsh")
-          :pwsh
-        elsif find_executable0("powershell")
+        # Detect Powershell first in case of Windows with Powershell 6/7/Core installed as flush_stdout/stderr doesn't work for pwsh on Windows.
+        if find_executable0("powershell")
           :powershell
+        elsif find_executable0("pwsh")
+          :pwsh
         else
           raise "Cannot find PowerShell binary, is `pwsh` installed?"
         end


### PR DESCRIPTION
Signed-off-by: rlakey <rlakey81@outlook.com>

Updated vmware transport to detect powershell before pwsh

## Description
Fixes vmware transport on Windows systems with Powershell 6/7/Core installed

## Related Issue
#720 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
