### PR TITLE
CFINSPEC-68: Fix the nil error while fetching uuid for mock transport/platform.

### DIFF
--- a/lib/train/errors.rb
+++ b/lib/train/errors.rb
@@ -38,6 +38,9 @@ module Train
   # Exception for when no platform can be detected.
   class PlatformDetectionFailed < Error; end
 
+  # Exception for when no uuid for the platform can be detected.
+  class PlatformUuidDetectionFailed < Error; end
+
   # Exception for when a invalid cache type is passed.
   class UnknownCacheType < Error; end
 

--- a/lib/train/platforms/detect/helpers/os_common.rb
+++ b/lib/train/platforms/detect/helpers/os_common.rb
@@ -122,7 +122,6 @@ module Train::Platforms::Detect::Helpers
     end
 
     def unix_uuid_from_machine_file
-      # require 'pry';binding.pry
       %W{
         /etc/chef/chef_guid
         #{ENV["HOME"]}/.chef/chef_guid

--- a/lib/train/platforms/detect/uuid.rb
+++ b/lib/train/platforms/detect/uuid.rb
@@ -20,12 +20,13 @@ module Train::Platforms::Detect
       elsif @platform.windows?
         windows_uuid
       else
-        if @platform[:uuid_command]
+        # Checking "unknown" :uuid_command which is set for mock transport.
+        if @platform[:uuid_command] && !@platform[:uuid_command] == "unknown"
           result = @backend.run_command(@platform[:uuid_command])
           return uuid_from_string(result.stdout.chomp) if result.exit_status == 0 && !result.stdout.empty?
         end
 
-        raise "Could not find platform uuid! Please set a uuid_command for your platform."
+        raise Train::PlatformUuidDetectionFailed.new("Could not find platform uuid! Please set a uuid_command for your platform.")
       end
     end
   end

--- a/test/unit/platforms/detect/uuid_test.rb
+++ b/test/unit/platforms/detect/uuid_test.rb
@@ -128,4 +128,10 @@ describe "uuid" do
     plat.backend.stubs(:unique_identifier).returns("1d74ce61-ac15-5c48-9ee3-5aa8207ac37f")
     _(plat.uuid).must_equal "2c2e4fa9-7287-5dee-85a3-6527face7b7b"
   end
+
+  it "raises error if uuid not found" do
+    plat = mock_platform("foo")
+    err = _ { plat.uuid }.must_raise Train::PlatformUuidDetectionFailed
+    _(err.message).must_match("Could not find platform uuid! Please set a uuid_command for your platform.")
+  end
 end

--- a/test/unit/transports/mock_test.rb
+++ b/test/unit/transports/mock_test.rb
@@ -127,6 +127,13 @@ describe "mock transport" do
       _(connection.os[:name]).must_equal "mock"
       _(connection.os[:family]).must_equal "mock"
     end
+
+    it "rauses error for default mock os uuid" do
+      _(connection.os[:name]).must_equal "mock"
+      _(connection.platform[:name]).must_equal "mock"
+      err = _ { connection.platform[:uuid] }.must_raise Train::PlatformUuidDetectionFailed
+      _(err.message).must_match("Could not find platform uuid! Please set a uuid_command for your platform.")
+    end
   end
 
   describe "when accessing a mocked file" do


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This fixes the nil error in InSpec while fetching platform uuid for mock transport in the test.
PR https://github.com/inspec/inspec/pull/5895 in the InSpec has a dependency on it.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Part of CFINSPEC-58
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
