### PR TITLE
Add a new regex for Cisco XE devices

### DIFF
--- a/lib/train/platforms/detect/helpers/os_common.rb
+++ b/lib/train/platforms/detect/helpers/os_common.rb
@@ -97,6 +97,12 @@ module Train::Platforms::Detect::Helpers
         return @cache[:cisco] = { version: m[2], model: m[1], type: "ios-xe" }
       end
 
+      # CSR 1000V (for example) does not specify model
+      m = res.match(/Cisco IOS XE Software, Version (\d+\.\d+\.\d+[A-Z]*)/)
+      unless m.nil?
+        return @cache[:cisco] = { version: m[1], type: "ios-xe" }
+      end
+
       m = res.match(/Cisco Nexus Operating System \(NX-OS\) Software/)
       unless m.nil?
         v = res[/^\s*system:\s+version (\d+\.\d+)/, 1]


### PR DESCRIPTION
This adds a new platform detection regular expression to pick up Cisco CSR1000V virtual devices.

It is untested whether it will match anything else, but it fixes platform detection on CSR 1000V's.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
