### PR TITLE
Add more flexibility to authorization unique identifier expectations

### DIFF
--- a/lib/train/transports/gcp.rb
+++ b/lib/train/transports/gcp.rb
@@ -105,9 +105,10 @@ module Train::Transports
       def unique_identifier
         unique_id = "default"
         # use auth client_id for users (issuer is nil)
-        unique_id = gcp_iam_client.request_options.authorization.client_id unless gcp_iam_client.request_options.authorization.client_id.nil?
+        authorization = gcp_iam_client.request_options.authorization
+        unique_id = authorization.client_id if authorization.respond_to?(:client_id) && !authorization.client_id.nil?
         # for service account credentials (client_id is nil)
-        unique_id = gcp_iam_client.request_options.authorization.issuer unless gcp_iam_client.request_options.authorization.issuer.nil?
+        unique_id = authorization.issuer if authorization.respond_to?(:issuer) && !authorization.issuer.nil?
         unique_id
       end
     end


### PR DESCRIPTION
The current code just assumes the unique identifier responds to client ID and issuer. That is currently the case however it is potentially a flawed assumption with new authentication methods being added going forward.

## Description
I am currently working to add support to the googleauth library for Workload Identity Federation. As part of this, I am adding a new type of authentication to the googleauth library itself. It is currently assumed that the authorization responds to client_id and issuer, and if either of these are not present then train exits with a stacktrace. This small changes makes train more flexible regarding the authorization object.

## Related Issue
https://github.com/googleapis/google-auth-library-ruby/issues/354

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
