### PR TITLE
Remove old ruby 2.5 and 2.6 support

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -11,29 +11,13 @@ expeditor:
 steps:
 
   # make sure lint runs on the oldest Ruby we support so we catch any new Ruby-isms here
-  - label: lint-ruby-2.5
+  - label: lint-ruby-2.7
     command:
       - RAKE_TASK=lint /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       executor:
         docker:
-          image: ruby:2.5
-
-  - label: run-tests-ruby-2.5
-    command:
-      - /workdir/.expeditor/buildkite/verify.sh
-    expeditor:
-      executor:
-        docker:
-          image: ruby:2.5
-
-  - label: run-tests-ruby-2.6
-    command:
-      - /workdir/.expeditor/buildkite/verify.sh
-    expeditor:
-      executor:
-        docker:
-          image: ruby:2.6
+          image: ruby:2.7
 
   - label: run-tests-ruby-2.7
     command:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -42,19 +42,7 @@ steps:
       executor:
         docker:
           image: ruby:3.1
-
-  - label: run-tests-ruby-2.6-windows
-    command:
-      - /workdir/.expeditor/buildkite/verify.ps1
-    expeditor:
-      executor:
-        docker:
-          environment:
-            - BUILDKITE
-          host_os: windows
-          shell: ["powershell", "-Command"]
-          image: rubydistros/windows-2019:2.6
-
+  
   - label: run-tests-ruby-2.7-windows
     command:
       - /workdir/.expeditor/buildkite/verify.ps1

--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
     "bug_tracker_uri" => "https://github.com/inspec/train/issues",
   }
 
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.files = Dir.glob("{LICENSE,lib/**/*}")
     .grep_v(%r{transports/(azure|clients|docker|gcp|helpers|vmware)})

--- a/train.gemspec
+++ b/train.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
     "bug_tracker_uri" => "https://github.com/inspec/train/issues",
   }
 
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.files = %w{LICENSE} + Dir.glob("lib/**/*")
     .grep(%r{transports/(azure|clients|docker|gcp|helpers|vmware)})


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
