### PR TITLE
CFINSPEC-356 Add podman transport to connect with podman containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Train supports:
 * Local execution
 * SSH
 * WinRM
-* Docker
+* Docker and Podman
 * Mock (for testing and debugging)
 * AWS as an API
 * Azure as an API
@@ -109,7 +109,7 @@ require 'train'
 train = Train.create('podman', host: 'container_id...', podman_url: 'tcp://localhost:1234')
 ```
 
-To connect to the Podman container Podman API endpoint URL needs to set. It cans et through the `podman_url` option else it will check for the CONTAINER_HOST environment variable. If both is not defined then it will try to connect to the default URL that is `unix:///run/user/UID/podman/podman.sock` for non-root user and `unix:///run/podman/podman.sock` for root user. Precedence is given to the options set through the arguments.
+To connect to a Podman container, the Podman API endpoint URL needs to set. It can be set through the `podman_url` option or else Train will check for the CONTAINER_HOST environment variable. If neither is defined then Train will try to connect to the default URL, that is `unix:///run/user/UID/podman/podman.sock` for non-root users and `unix:///run/podman/podman.sock` for the root user. Precedence is given to options set through the arguments.
 
 **AWS**
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ require 'train'
 train = Train.create('podman', host: 'container_id...', podman_url: 'tcp://localhost:1234')
 ```
 
-Podman URL can be set through `podman_url` option else it will read it from the CONTAINER_HOST environment variable if set. If both is nil then it will try to connect to the default url that is `unix:///run/user/UID/podman/podman.sock` for rootless user and `unix:///run/podman/podman.sock` for root user.
+To connect to the Podman container Podman URL needs to be set. It can be set through the `podman_url` option else it will check for the CONTAINER_HOST environment variable. If both is not defined then it will try to connect to the default URL that is `unix:///run/user/UID/podman/podman.sock` for rootless user and `unix:///run/podman/podman.sock` for root user. Precedence is given to the options set through the arguments.
 
 If `user: 'root'` option is not given it will always use the rootless user as default URL.
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ train = Train.create('podman', host: 'container_id...', user: 'root')
 ```ruby
 require 'train'
 train = Train.create('podman', host: 'container_id...', podman_url: 'tcp://localhost:1234')
-...
+```
 
 Podman URL can be set through `podman_url` option else it will read it from the CONTAINER_HOST environment variable if set. If both is nil then it will try to connect to the default url that is `unix:///run/user/UID/podman/podman.sock` for rootless user and `unix:///run/podman/podman.sock` for root user.
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,27 @@ train = Train.create('docker', host: 'container_id...', docker_url: 'tcp://local
 
 Windows Docker containers require PowerShell, which is assumed to be installed as `powershell.exe`. If it is installed as `pwsh`, use the `--shell-command` option to specify `pwsh` as the shell.
 
+**Podman**
+
+```ruby
+require 'train'
+train = Train.create('podman', host: 'container_id...')
+```
+You can use `user` option to connect with privileged user on non root user images.
+
+```ruby
+require 'train'
+train = Train.create('podman', host: 'container_id...', user: 'root')
+```
+
+```ruby
+require 'train'
+train = Train.create('podman', host: 'container_id...', podman_url: 'tcp://localhost:1234')
+...
+
+Podman URL can be set through `podman_url` option else it will read it from the CONTAINER_HOST environment variable if set. If both is nil then it will try to connect to the default url that is `unix:///run/user/UID/podman/podman.sock` for rootless user and `unix:///run/podman/podman.sock` for root user.
+
+If `user: 'root'` option is not given it will always use the rootless user as default URL.
 
 **AWS**
 

--- a/README.md
+++ b/README.md
@@ -103,21 +103,13 @@ Windows Docker containers require PowerShell, which is assumed to be installed a
 require 'train'
 train = Train.create('podman', host: 'container_id...')
 ```
-You can use `user` option to connect with privileged user on non root user images.
-
-```ruby
-require 'train'
-train = Train.create('podman', host: 'container_id...', user: 'root')
-```
 
 ```ruby
 require 'train'
 train = Train.create('podman', host: 'container_id...', podman_url: 'tcp://localhost:1234')
 ```
 
-To connect to the Podman container Podman URL needs to be set. It can be set through the `podman_url` option else it will check for the CONTAINER_HOST environment variable. If both is not defined then it will try to connect to the default URL that is `unix:///run/user/UID/podman/podman.sock` for rootless user and `unix:///run/podman/podman.sock` for root user. Precedence is given to the options set through the arguments.
-
-If `user: 'root'` option is not given it will always use the rootless user as default URL.
+To connect to the Podman container Podman API endpoint URL needs to set. It cans et through the `podman_url` option else it will check for the CONTAINER_HOST environment variable. If both is not defined then it will try to connect to the default URL that is `unix:///run/user/UID/podman/podman.sock` for non-root user and `unix:///run/podman/podman.sock` for root user. Precedence is given to the options set through the arguments.
 
 **AWS**
 

--- a/lib/train/transports/podman.rb
+++ b/lib/train/transports/podman.rb
@@ -1,0 +1,147 @@
+require "docker"
+module Train::Transports
+  class Podman < Train.plugin(1)
+    name 'podman'
+
+    include_options Train::Extras::CommandWrapper
+    option :host, required: true
+    option :podman_url, required: false
+
+    def connection(state = {}, &block)
+      opts = merge_options(options, state || {})
+
+      validate_options(opts)
+
+      if @connection && @connection_options == opts
+        reuse_connection(&block)
+      else
+        create_new_connection(opts, &block)
+      end
+    end
+
+    private
+    # Creates a new Podman connection instance and save it for potential future
+    # reuse.
+    #
+    # @param options [Hash] connection options
+    # @return [Podman::Connection] a Podman connection instance
+    # @api private
+    def create_new_connection(options, &block)
+      if @connection
+        logger.debug("[Podman] shutting previous connection #{@connection}")
+        @connection.close
+      end
+
+      @connection_options = options
+      @connection = Connection.new(options, &block)
+    end
+
+    # Return the last saved Podman connection instance.
+    #
+    # @return [Podman::Connection] a Podman connection instance
+    # @api private
+    def reuse_connection
+      logger.debug("[Podman] reusing existing connection #{@connection}")
+      yield @connection if block_given?
+      @connection
+    end
+  end
+  class Train::Transports::Podman
+    class Connection < BaseConnection
+      def initialize(options)
+        super(options)
+
+        @id = options[:host]
+
+        # Currently Podman url can be set using option and setting the environment variable.
+        uid = Process::uid
+        podman_url = options[:podman_url] || ENV["CONTAINER_HOST"]
+
+        if podman_url.nil?
+          podman_url = options[:user] == "root" ? "unix:///run/podman/podman.sock" : "unix:///run/user/#{uid}/podman/podman.sock"
+        end
+
+        Docker.url = podman_url if podman_url
+
+        # Using docker-api ruby library to fetch the Podman container data.
+        @container = ::Docker::Container.get(@id) ||
+          raise("Can't find Podman container #{@id}")
+        @cmd_wrapper = nil
+        @cmd_wrapper = CommandWrapper.load(self, @options)
+        @probably_windows = nil
+      rescue Excon::Error::Socket => e
+        raise "Unable to connect to Podman using #{podman_url}"
+      end
+
+      def close
+        # nothing to do at the moment
+      end
+
+      def uri
+        if @container.nil?
+          "podman://#{@id}"
+        else
+          "podman://#{@container.id}"
+        end
+      end
+
+      def unique_identifier
+        @container.nil? ? @id : @container.id # default uuid set to the podman host.
+      end
+
+      private
+
+
+      def file_via_connection(path)
+        if os.aix?
+          Train::File::Remote::Aix.new(self, path)
+        elsif os.solaris?
+          Train::File::Remote::Unix.new(self, path)
+        elsif os.windows?
+          Train::File::Remote::Windows.new(self, path)
+        else
+          Train::File::Remote::Linux.new(self, path)
+        end
+      end
+
+      def run_command_via_connection(cmd, &_data_handler)
+        cmd = @cmd_wrapper.run(cmd) unless @cmd_wrapper.nil?
+
+        # Cannot use os.windows? here because it calls run_command_via_connection,
+        # causing infinite recursion during initial platform detection
+        if sniff_for_windows?
+          invocation = cmd_run_command(cmd)
+        else
+          invocation = sh_run_command(cmd)
+        end
+        stdout, stderr, exit_status = @container.exec(
+          invocation, user: @options[:user]
+        )
+        CommandResult.new(stdout.join, stderr.join, exit_status)
+      rescue ::Docker::Error::DockerError => _
+        raise
+      rescue => _
+        # @TODO: differentiate any other error
+        raise
+      end
+
+      def sh_run_command(cmd)
+        ["/bin/sh", "-c", cmd]
+      end
+
+      def cmd_run_command(cmd)
+        ["cmd.exe", "/s", "/c", cmd]
+      end
+
+      def sniff_for_windows?
+        return @probably_windows unless @probably_windows.nil?
+
+        # Run a command using /bin/sh, which should fail under Windows
+        stdout, _stderr, _exit_status = @container.exec(
+          sh_run_command("true"), user: @options[:user]
+        )
+        @probably_windows = !!stdout.detect { |l| l.include? "failure in a Windows system call" }
+      end
+    end
+  end
+end

--- a/lib/train/transports/podman.rb
+++ b/lib/train/transports/podman.rb
@@ -3,7 +3,8 @@ require_relative "../errors"
 
 module Train::Transports
   class Podman < Train.plugin(1)
-    name 'podman'
+
+    name "podman"
 
     include_options Train::Extras::CommandWrapper
     option :host, required: true
@@ -22,6 +23,7 @@ module Train::Transports
     end
 
     private
+
     # Creates a new Podman connection instance and save it for potential future
     # reuse.
     #
@@ -56,7 +58,7 @@ module Train::Transports
         @id = options[:host]
 
         # Currently Podman url can be set using option and setting the environment variable.
-        uid = Process::uid
+        uid = Process.uid
         podman_url = options[:podman_url] || ENV["CONTAINER_HOST"]
 
         if podman_url.nil?
@@ -71,7 +73,7 @@ module Train::Transports
         @cmd_wrapper = nil
         @cmd_wrapper = CommandWrapper.load(self, @options)
         @probably_windows = nil
-      rescue Excon::Error::Socket => e
+      rescue Excon::Error::Socket
         raise Train::TransportError, "Unable to connect to Podman using #{podman_url}"
       rescue Docker::Error::NotFoundError => e
         raise Train::TransportError, "Container Not Found: #{e.message}"

--- a/lib/train/transports/podman.rb
+++ b/lib/train/transports/podman.rb
@@ -91,7 +91,6 @@ module Train::Transports
 
       private
 
-
       def file_via_connection(path)
         if os.aix?
           Train::File::Remote::Aix.new(self, path)

--- a/lib/train/transports/podman.rb
+++ b/lib/train/transports/podman.rb
@@ -61,10 +61,8 @@ module Train::Transports
         # Currently Podman url can be set using option and setting the environment variable.
         uid = Process.uid
         podman_url = options[:podman_url] || ENV["CONTAINER_HOST"]
-
-        if podman_url.nil?
-          podman_url = options[:user] == "root" ? "unix:///run/podman/podman.sock" : "unix:///run/user/#{uid}/podman/podman.sock"
-        end
+        podman_url ||= "unix:///run/podman/podman.sock" if uid == 0
+        podman_url ||=  "unix:///run/user/#{uid}/podman/podman.sock"
 
         Docker.url = podman_url
 

--- a/lib/train/transports/podman.rb
+++ b/lib/train/transports/podman.rb
@@ -50,6 +50,7 @@ module Train::Transports
       @connection
     end
   end
+
   class Train::Transports::Podman
     class Connection < BaseConnection
       def initialize(options)

--- a/lib/train/transports/podman.rb
+++ b/lib/train/transports/podman.rb
@@ -66,7 +66,7 @@ module Train::Transports
         uid = Process.uid
         podman_url = options[:podman_url] || ENV["CONTAINER_HOST"]
         podman_url ||= "unix:///run/podman/podman.sock" if uid == 0
-        podman_url ||=  "unix:///run/user/#{uid}/podman/podman.sock"
+        podman_url ||= "unix:///run/user/#{uid}/podman/podman.sock"
 
         Docker.url = podman_url
 

--- a/lib/train/transports/podman.rb
+++ b/lib/train/transports/podman.rb
@@ -66,7 +66,7 @@ module Train::Transports
           podman_url = options[:user] == "root" ? "unix:///run/podman/podman.sock" : "unix:///run/user/#{uid}/podman/podman.sock"
         end
 
-        Docker.url = podman_url if podman_url
+        Docker.url = podman_url
 
         # Using docker-api ruby library to fetch the Podman container data.
         @container = ::Docker::Container.get(@id) ||

--- a/lib/train/transports/podman.rb
+++ b/lib/train/transports/podman.rb
@@ -58,6 +58,10 @@ module Train::Transports
 
         @id = options[:host]
 
+        if RUBY_PLATFORM =~ /windows|mswin|msys|mingw|cygwin/
+          raise "Unsupported host platform."
+        end
+
         # Currently Podman url can be set using option and setting the environment variable.
         uid = Process.uid
         podman_url = options[:podman_url] || ENV["CONTAINER_HOST"]

--- a/lib/train/transports/podman.rb
+++ b/lib/train/transports/podman.rb
@@ -1,4 +1,6 @@
 require "docker"
+require_relative "../errors"
+
 module Train::Transports
   class Podman < Train.plugin(1)
     name 'podman'
@@ -70,7 +72,11 @@ module Train::Transports
         @cmd_wrapper = CommandWrapper.load(self, @options)
         @probably_windows = nil
       rescue Excon::Error::Socket => e
-        raise "Unable to connect to Podman using #{podman_url}"
+        raise Train::TransportError, "Unable to connect to Podman using #{podman_url}"
+      rescue Docker::Error::NotFoundError => e
+        raise Train::TransportError, "Container Not Found: #{e.message}"
+      rescue Docker::Error::ServerError => e
+        raise Train::TransportError, "#{e.message}"
       end
 
       def close

--- a/test/integration/podman_test_container.rb
+++ b/test/integration/podman_test_container.rb
@@ -1,12 +1,10 @@
 require "train"
 require_relative "helper"
 
-
 (container_id = ENV["CONTAINER"]) ||
-  raise("You must provide a container ID via CONTAINER env"
-)
+  raise("You must provide a container ID via CONTAINER env")
 
-(podman_url = ENV["CONTAINER_HOST"])
+podman_url = ENV["CONTAINER_HOST"]
 
 tests = ARGV
 puts ["Running tests:", tests].flatten.join("\n- ")

--- a/test/integration/podman_test_container.rb
+++ b/test/integration/podman_test_container.rb
@@ -1,0 +1,25 @@
+require "train"
+require_relative "helper"
+
+
+(container_id = ENV["CONTAINER"]) ||
+  raise("You must provide a container ID via CONTAINER env"
+)
+
+(podman_url = ENV["CONTAINER_HOST"])
+
+tests = ARGV
+puts ["Running tests:", tests].flatten.join("\n- ")
+puts ""
+
+backends = {}
+backends[:podman] = proc { |*args|
+  opt = Train.target_config({ host: container_id, podman_url: podman_url })
+  Train.create("podman", opt).connection(args[0])
+}
+
+backends.each do |type, get_backend|
+  tests.each do |test|
+    instance_eval(File.read(test), test, 1)
+  end
+end

--- a/train.gemspec
+++ b/train.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.7"
 
   spec.files = %w{LICENSE} + Dir.glob("lib/**/*")
-    .grep(%r{transports/(azure|clients|docker|gcp|helpers|vmware)})
+    .grep(%r{transports/(azure|clients|docker|podman|gcp|helpers|vmware)})
     .reject { |f| File.directory?(f) }
 
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This adds the podman transport to the train.
Updated README doc.


Usage:
```
t = Train.create("podman"; host: <container_id>, podman_url: "unix:///run/user/$UID/podman/podman.sock")`
conn = t.connection`
conn.run_command("whoami")
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
