### PR TITLE
Prevent Cisco devices being detected as Arista

### DIFF
--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -383,7 +383,7 @@ module Train::Platforms::Detect::Specifications
     def self.load_other
       plat.family("arista_eos").title("Arista EOS Family").in_family("os")
         .detect do
-          true
+          !@backend.run_command("show version").stdout.match(/Arista/).nil?
         end
 
       declare_instance("arista_eos", "Arista EOS", "arista_eos") do


### PR DESCRIPTION
- Some Cisco devices are being mis-detected as Arista devices from `show version` command
- Added a conditional to the Arista `declare_instance` to make sure that calls to `show version` contain `Arista`

Signed-off-by: Richard Nixon <richard.nixon@btinternet>

<!--- Provide a short summary of your changes in the Title above -->

## Description

When running `inspec detect -t ssh://nexus001` against a virtual Nexus 9300 (NXOS) the platform was being mis-detected as Arista EOS with no version number. 

After applying this bugfix, virtual Nexus and virtual Arista devices are correctly detected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
