### PR TITLE
Fix Cisco Nexus version detection

### DIFF
--- a/lib/train/platforms/detect/helpers/os_common.rb
+++ b/lib/train/platforms/detect/helpers/os_common.rb
@@ -106,6 +106,7 @@ module Train::Platforms::Detect::Helpers
       m = res.match(/Cisco Nexus Operating System \(NX-OS\) Software/)
       unless m.nil?
         v = res[/^\s*system:\s+version (\d+\.\d+)/, 1]
+        v ||= res[/NXOS: version (\d+\.\d+)/, 1]
         return @cache[:cisco] = { version: v, type: "nexus" }
       end
 


### PR DESCRIPTION
The format of the output from `show version` has changed in Cisco NXOS 9.3
and requires a different regex to match it.

Tested on 9.3(10) virtual Nexus 9300

Signed-off-by: Richard Nixon <richard.nixon@btinternet>

## Description

Added a new regex to extract the version number for Cisco Nexus switches

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
