### PR TITLE
CHEF-6440(CHEF-7426): Adds audit log support

### DIFF
--- a/docs/audit_log.md
+++ b/docs/audit_log.md
@@ -14,7 +14,7 @@ As this is a feature preview to determine what sort of functionality is desired 
 
 * Strong support for command invocations but no ability to control level of detail of output
 * Limited ability to see file operations. A file access may be seen, but what specific operation may be unknown.
-* Not all File operations are perfomed using the top-level connection methods; some file operations are implemented in the transport plugins, and are not captured consistently 
+* Not all File operations are perfomed using the top-level connection methods; some file operations are implemented in the transport plugins, and are not captured consistently
 * No support for API calls at this time. No API-based transports will show traffic in the audit log.
 
 ## Log Format
@@ -51,9 +51,9 @@ Log size and Frequency come from Ruby's Logger implementation; see that for deta
 
 `audit_log_location`: Type String, path to stem filename to create such as "~/chef/logs/my-app-audit.log" Default is nil.
 
-`audit_log_size`: Type numeric. Maximum size of the file in bytes before it gets rotated to another file. Default is 2097152.
+`audit_log_size`: Type numeric. Maximum size of the file in bytes before it gets rotated to another file (Log rotation is disabled by default). Defaults to 1048576 (1MB)
 
-`audit_log_frequency`: Type string. Frequency with which to rotate the audit log. Default is daily (Valid values: daily, weekly, monthly).
+`audit_log_frequency`: Frequency of rotation (daily, weekly or monthly). Default value is 0, which disables log file rotation.
 
 ## Driving Train from IRB
 

--- a/docs/audit_log.md
+++ b/docs/audit_log.md
@@ -1,64 +1,80 @@
-# Train Audit Logs
+# Train Audit Log
 
-## About Audit Logs
+**The Train audit log feature is in preview to determine what features the user base might want and may change at any time.**
 
-The Train Audit Log is intended to log the activities happening through the Train Connection on the target system. **The Audit log feature is in preview and may change at any time.**
+The Train audit log logs the activities happening through the Train connection on the target system.
 
-Generally, Train Connections perform three types of operations - File, Command, and API operations.
+Train connections perform three types of operations:
 
-Audit Logging works by intercepting these operations and writing details about the method call to the audit log before the call is made. Specifically, it captures the invocations that are executed on the target system through `run_command` and captures file paths that are accessed through the Train connection.
+- file
+- command
+- API operations
+
+Train intercepts these operations and writes details about the method call to the audit log before the call is made.
+Specifically, it captures the invocations that are executed on the target system through `run_command` and captures file paths that are accessed through the Train connection.
 
 ## Limitations
 
-As this is a feature preview to determine what sort of functionality is desired by the user base, no attempt at completeness was made in this release. Currently, the Train Audit Log has the following limitations:
+The Train audit log has the following limitations:
 
-* Strong support for command invocations but no ability to control level of detail of output
-* Limited ability to see file operations. A file access may be seen, but what specific operation may be unknown.
-* Not all File operations are perfomed using the top-level connection methods; some file operations are implemented in the transport plugins, and are not captured consistently
-* No support for API calls at this time. No API-based transports will show traffic in the audit log.
+- Strong support for command invocations, but no ability to control level of output detail.
+- Limited ability to see file operations. A file access may be seen, but what specific operation may be unknown.
+- Not all file operations are performed using the top-level connection methods; some file operations are implemented in the transport plugins and are not captured consistently.
+- No support for API calls at this time. No API-based transports will show traffic in the audit log.
 
-## Log Format
+## Log format
 
-Depending on the type of event in the log, the log will contain a line containing a JSON object in one of several variants.
+The audit log records event data in a JSON object. The data returned varies based on the event type.
 
-### Command Event
+### Command event
 
-In case of command execution, it logs information like timestamp, type (currently it is cmd), command (the invocation that ran on the target system), user (system user who executed the command), and hostname (hostname of the system, if it is a remote target).
+The audit log returns the following command execution data:
+
+- timestamp
+- type (`cmd`)
+- command (the invocation run on the target system)
+- user (system user who executes the command)
+- hostname (hostname of the system if it is a remote target)
+
+The following example shows data returned from a command event.
 
 ```json
 {"timestamp":"2023-11-06 11:21:32 -0500","app":"train","type":"cmd","command":"whoami"}
 ```
 
-### File Event
+### File event
 
-In the case of file operation it currently only logs the file path that has been accessed and some additional data like timestamp, type (file), user (system user who executed the command), and hostname (hostname of the system if it is a remote target).
+The audit log returns the following file event data:
+
+- file path that has been accessed
+- timestamp
+- type (`file`)
+- user (system user who executed the command)
+- hostname (hostname of the system if it is a remote target)
+
+The following example shows data returned from a file event.
 
 ```json
 {"timestamp":"2023-11-06 11:23:59 -0500","app":"train","type":"file","path":"/tmp"}
 ```
 
-### API Event
+### API event
 
 Reserved for future use.
 
 ## Log Options
 
-Audit logs are `disabled` by default. To enable the audit log and configure it use the following audit log options while creating the Train object.
+Audit Logs are disabled by default. To enable and configure the audit log, use the following audit log options while creating the Train object:
 
-Log size and Frequency come from Ruby's Logger implementation; see that for details.
-
-`enable_audit_log`: Type boolean. Default is false.
-
-`audit_log_location`: Type String, path to stem filename to create such as "~/chef/logs/my-app-audit.log" Default is nil.
-
-`audit_log_size`: Type numeric. Maximum size of the file in bytes before it gets rotated to another file (Log rotation is disabled by default). Defaults to 1048576 (1MB)
-
-`audit_log_frequency`: Frequency of rotation (daily, weekly or monthly). Default value is 0, which disables log file rotation.
+- Log size and frequency come from Ruby's Logger implementation. See Ruby's Logger documentation for details.
+- `enable_audit_log`: Type Boolean. Default is `false`.
+- `audit_log_location`: Type String. Path to audit log file. For example, `"~/chef/logs/my-app-audit.log"`. Default is nil.
+- `audit_log_size`: Type Numeric. Maximum file size in bytes before it gets rotated to another file. Log rotation is disabled by default. Defaults to `1048576` (1MB)
+- `audit_log_frequency`: Frequency of rotation (`daily`, `weekly`, or `monthly`). Default value is `0`, which disables log file rotation.
 
 ## Driving Train from IRB
 
-Note: this is an example for developers; Train is a support library and has no direct UI. Most people use Audit Logging through an application that embeds it such as Chef InSpec.
-
+Note: this is an example for developers; Train is a support library and has no direct UI. Most people use audit log through an application that embeds Train, such as Chef InSpec.
 
 ```ruby
   require 'train'

--- a/docs/audit_log.md
+++ b/docs/audit_log.md
@@ -1,29 +1,68 @@
 # Train Audit Logs
 
-Train audit is integrated to log the activities happening through train on target system.
-Currently, it is scoped to log the commands that are executed on the target system through `run_command` and logs file path that is accessed through train connection.
-Logs are stored in the JSON format at a given log location. In case of command execution, it logs information like timestamp, type (currently it is cmd), command (the command that ran on the target system), user (system user who executed the command), and hostname (hostname of the system, if it is a remote target).
+## About Audit Logs
+
+The Train Audit Log is intended to log the activities happening through the Train Connection on the target system. **The Audit log feature is in preview and may change at any time.**
+
+Generally, Train Connections perform three types of operations - File, Command, and API operations.
+
+Audit Logging works by intercepting these operations and writing details about the method call to the audit log before the call is made. Specifically, it captures the invocations that are executed on the target system through `run_command` and captures file paths that are accessed through the Train connection.
+
+## Limitations
+
+As this is a feature preview to determine what sort of functionality is desired by the user base, no attempt at completeness was made in this release. Currently, the Train Audit Log has the following limitations:
+
+* Strong support for command invocations but no ability to control level of detail of output
+* Limited ability to see file operations. A file access may be seen, but what specific operation may be unknown.
+* Not all File operations are perfomed using the top-level connection methods; some file operations are implemented in the transport plugins, and are not captured consistently 
+* No support for API calls at this time. No API-based transports will show traffic in the audit log.
+
+## Log Format
+
+Depending on the type of event in the log, the log will contain a line containing a JSON object in one of several variants.
+
+### Command Event
+
+In case of command execution, it logs information like timestamp, type (currently it is cmd), command (the invocation that ran on the target system), user (system user who executed the command), and hostname (hostname of the system, if it is a remote target).
+
+```json
+{"timestamp":"2023-11-06 11:21:32 -0500","app":"train","type":"cmd","command":"whoami"}
+```
+
+### File Event
+
 In the case of file operation it currently only logs the file path that has been accessed and some additional data like timestamp, type (file), user (system user who executed the command), and hostname (hostname of the system if it is a remote target).
 
-** Note: Currently audit logging system is not mature enough to log all the activities with all types of train plugins.
+```json
+{"timestamp":"2023-11-06 11:23:59 -0500","app":"train","type":"file","path":"/tmp"}
+```
 
-## Enable audit log
+### API Event
+
+Reserved for future use.
+
+## Log Options
 
 Audit logs are `disabled` by default. To enable the audit log and configure it use the following audit log options while creating the Train object.
 
+Log size and Frequency come from Ruby's Logger implementation; see that for details.
+
 `enable_audit_log`: Type boolean. Default is false.
 
-`audit_log_location`: Type String. Default is nil.
+`audit_log_location`: Type String, path to stem filename to create such as "~/chef/logs/my-app-audit.log" Default is nil.
 
-`audit_log_size`: Type numeric. Default is 2097152.
+`audit_log_size`: Type numeric. Maximum size of the file in bytes before it gets rotated to another file. Default is 2097152.
 
-`audit_log_frequency`: Type string, Default is daily (Valid values: daily, weekly, monthly).
+`audit_log_frequency`: Type string. Frequency with which to rotate the audit log. Default is daily (Valid values: daily, weekly, monthly).
 
-* Example:
+## Driving Train from IRB
+
+Note: this is an example for developers; Train is a support library and has no direct UI. Most people use Audit Logging through an application that embeds it such as Chef InSpec.
+
 
 ```ruby
   require 'train'
-  t = Train.create('local', enable_audit_log: true)
+  t = Train.create('local', enable_audit_log: true, audit_log_location: "my.log")
   c = t.connection
   c.run_command("whoami")
   c.file("<path-to-file>").content

--- a/docs/audit_log.md
+++ b/docs/audit_log.md
@@ -11,7 +11,7 @@ In the case of file operation it currently only logs the file path that has been
 
 Audit logs are `disabled` by default. To enable the audit log and configure it use the following audit log options while creating the Train object.
 
-`enable_audit_log`: Type boolean. Default is false.
+`disable_audit_log`: Type boolean. Default is true.
 
 `audit_log_location`: Type String. Default is nil.
 

--- a/docs/audit_log.md
+++ b/docs/audit_log.md
@@ -11,7 +11,7 @@ In the case of file operation it currently only logs the file path that has been
 
 Audit logs are `disabled` by default. To enable the audit log and configure it use the following audit log options while creating the Train object.
 
-`disable_audit_log`: Type boolean. Default is true.
+`enable_audit_log`: Type boolean. Default is false.
 
 `audit_log_location`: Type String. Default is nil.
 

--- a/docs/audit_log.md
+++ b/docs/audit_log.md
@@ -1,0 +1,30 @@
+# Train Audit Logs
+
+Train audit is integrated to log the activities happening through train on target system.
+Currently, it is scoped to log the commands that are executed on the target system through `run_command` and logs file path that is accessed through train connection.
+Logs are stored in the JSON format at a given log location. In case of command execution, it logs information like timestamp, type (currently it is cmd), command (the command that ran on the target system), user (system user who executed the command), and hostname (hostname of the system, if it is a remote target).
+In the case of file operation it currently only logs the file path that has been accessed and some additional data like timestamp, type (file), user (system user who executed the command), and hostname (hostname of the system if it is a remote target).
+
+** Note: Currently audit logging system is not mature enough to log all the activities with all types of train plugins.
+
+## Enable audit log
+
+Audit logs are `disabled` by default. To enable the audit log and configure it use the following audit log options while creating the Train object.
+
+`enable_audit_log`: Type boolean. Default is false.
+
+`audit_log_location`: Type String. Default is nil.
+
+`audit_log_size`: Type numeric. Default is 2097152.
+
+`audit_log_frequency`: Type string, Default is daily (Valid values: daily, weekly, monthly).
+
+* Example:
+
+```ruby
+  require 'train'
+  t = Train.create('local', enable_audit_log: true)
+  c = t.connection
+  c.run_command("whoami")
+  c.file("<path-to-file>").content
+```

--- a/lib/train.rb
+++ b/lib/train.rb
@@ -26,7 +26,8 @@ module Train
   # @return [Hash] map of default options
   def self.options(name)
     cls = load_transport(name)
-    cls.default_options unless cls.nil?
+    # Merging default_audit_log_options so that they will get listed in the options that are available.
+    cls.default_options.merge(cls.default_audit_log_options) unless cls.nil?
   end
 
   # Load the transport plugin indicated by name. If the plugin is not

--- a/lib/train/audit_log.rb
+++ b/lib/train/audit_log.rb
@@ -7,7 +7,7 @@ module Train
     def self.create(options = {})
       logger = Logger.new(options[:audit_log_location], options[:audit_log_frequency], options[:audit_log_size])
       logger.level = options[:level] || Logger::INFO
-      logger.progname = options[:audi_log_app_name]
+      logger.progname = options[:audit_log_app_name]
       logger.datetime_format = "%Y-%m-%d %H:%M:%S"
       logger.formatter = proc do |severity, datetime, progname, msg|
         {

--- a/lib/train/audit_log.rb
+++ b/lib/train/audit_log.rb
@@ -1,0 +1,29 @@
+module Train
+  class AuditLog
+    # TODO:
+    # Configurable values log location, log file size, log frequency((available options, daily, weeks, monthly))
+
+    # Default values for audit log options are set in the options.rb
+    def self.create(options = {})
+      logger = Logger.new(options[:audit_log_location], options[:audit_log_frequency], options[:audit_log_size])
+      logger.level = options[:level] || Logger::INFO
+      logger.progname = options[:audi_log_app_name]
+      logger.datetime_format = "%Y-%m-%d %H:%M:%S"
+      logger.formatter = proc do |severity, datetime, progname, msg|
+        {
+          level: severity,
+          timestamp: datetime.to_s,
+          app: progname,
+          type: msg[:type],
+          command: msg[:command],
+          path: msg[:path],
+          source: msg[:source],
+          destination: msg[:destination],
+          hostname: msg[:hostname],
+          user: msg[:user],
+        }.compact.to_json + $/
+      end
+      logger
+    end
+  end
+end

--- a/lib/train/audit_log.rb
+++ b/lib/train/audit_log.rb
@@ -2,6 +2,9 @@ module Train
   class AuditLog
     # Default values for audit log options are set in the options.rb
     def self.create(options = {})
+      # Load monkey-patch to disable leading comment in logfiles
+      require_relative "logger_ext"
+
       logger = Logger.new(options[:audit_log_location], options[:audit_log_frequency], options[:audit_log_size])
       logger.level = options[:level] || Logger::INFO
       logger.progname = options[:audit_log_app_name]

--- a/lib/train/audit_log.rb
+++ b/lib/train/audit_log.rb
@@ -1,8 +1,5 @@
 module Train
   class AuditLog
-    # TODO:
-    # Configurable values log location, log file size, log frequency((available options, daily, weeks, monthly))
-
     # Default values for audit log options are set in the options.rb
     def self.create(options = {})
       logger = Logger.new(options[:audit_log_location], options[:audit_log_frequency], options[:audit_log_size])

--- a/lib/train/audit_log.rb
+++ b/lib/train/audit_log.rb
@@ -11,17 +11,9 @@ module Train
       logger.datetime_format = "%Y-%m-%d %H:%M:%S"
       logger.formatter = proc do |severity, datetime, progname, msg|
         {
-          level: severity,
           timestamp: datetime.to_s,
           app: progname,
-          type: msg[:type],
-          command: msg[:command],
-          path: msg[:path],
-          source: msg[:source],
-          destination: msg[:destination],
-          hostname: msg[:hostname],
-          user: msg[:user],
-        }.compact.to_json + $/
+        }.merge(msg).compact.to_json + $/
       end
       logger
     end

--- a/lib/train/logger_ext.rb
+++ b/lib/train/logger_ext.rb
@@ -1,0 +1,9 @@
+
+# Part of Audit Log.
+# The default logger implementation injects a comment as the first line of the 
+# log file, which makes it an invalid JSON file. No way to disable that other than monkey-patching.
+
+class Logger::LogDevice
+  def add_log_header(file)
+  end
+end

--- a/lib/train/logger_ext.rb
+++ b/lib/train/logger_ext.rb
@@ -1,9 +1,8 @@
 
 # Part of Audit Log.
-# The default logger implementation injects a comment as the first line of the 
+# The default logger implementation injects a comment as the first line of the
 # log file, which makes it an invalid JSON file. No way to disable that other than monkey-patching.
 
 class Logger::LogDevice
-  def add_log_header(file)
-  end
+  def add_log_header(file); end
 end

--- a/lib/train/options.rb
+++ b/lib/train/options.rb
@@ -41,7 +41,7 @@ module Train
         # should we keep it to $stdout.
         {
           enable_audit_log: { default: false },
-          audit_log_location: { required: true },
+          audit_log_location: { required: true, default: nil },
           audit_log_app_name: { default: "train" },
           audit_log_size: { default: 2000000 },
           audit_log_frequency: { default: "daily" },

--- a/lib/train/options.rb
+++ b/lib/train/options.rb
@@ -41,8 +41,8 @@ module Train
           enable_audit_log: { default: false },
           audit_log_location: { required: true, default: nil },
           audit_log_app_name: { default: "train" },
-          audit_log_size: { default: 2097152 },
-          audit_log_frequency: { default: "daily" },
+          audit_log_size: { default: nil },
+          audit_log_frequency: { default: 0 },
         }
       end
 

--- a/lib/train/options.rb
+++ b/lib/train/options.rb
@@ -38,7 +38,7 @@ module Train
       # and will not break any existing functionality
       def default_audit_log_options
         {
-          enable_audit_log: { default: false },
+          disable_audit_log: { default: true },
           audit_log_location: { required: true, default: nil },
           audit_log_app_name: { default: "train" },
           audit_log_size: { default: 2097152 },
@@ -69,7 +69,7 @@ module Train
 
       def merge_options(base, opts)
         res = base.merge(opts || {})
-        default_options.each do |field, hm|
+        default_options.merge(default_audit_log_options).each do |field, hm|
           next unless res[field].nil? && hm.key?(:default)
 
           default = hm[:default]

--- a/lib/train/options.rb
+++ b/lib/train/options.rb
@@ -31,7 +31,21 @@ module Train
 
       def default_options
         @default_options = {} unless defined? @default_options
+        # TODO: This is hacky way to set the default options for audit log for all type of transport.
+        @default_options.merge!(default_audit_log_options)
         @default_options
+      end
+
+      def default_audit_log_options
+        # TODO: What should be the default audit log location if any of the application using train does not set it?
+        # should we keep it to $stdout.
+        {
+          enable_audit_log: { default: false },
+          audit_log_location: { default: $stdout },
+          audit_log_app_name: { default: "train" },
+          audit_log_size: { default: 2000000 },
+          audit_log_frequency: { default: "daily" },
+        }
       end
 
       def include_options(other)

--- a/lib/train/options.rb
+++ b/lib/train/options.rb
@@ -38,7 +38,7 @@ module Train
       # and will not break any existing functionality
       def default_audit_log_options
         {
-          disable_audit_log: { default: true },
+          enable_audit_log: { default: false },
           audit_log_location: { required: true, default: nil },
           audit_log_app_name: { default: "train" },
           audit_log_size: { default: 2097152 },
@@ -69,7 +69,7 @@ module Train
 
       def merge_options(base, opts)
         res = base.merge(opts || {})
-        default_options.merge(default_audit_log_options).each do |field, hm|
+        default_options.each do |field, hm|
           next unless res[field].nil? && hm.key?(:default)
 
           default = hm[:default]

--- a/lib/train/options.rb
+++ b/lib/train/options.rb
@@ -41,7 +41,7 @@ module Train
         # should we keep it to $stdout.
         {
           enable_audit_log: { default: false },
-          audit_log_location: { default: $stdout },
+          audit_log_location: { required: true },
           audit_log_app_name: { default: "train" },
           audit_log_size: { default: 2000000 },
           audit_log_frequency: { default: "daily" },

--- a/lib/train/options.rb
+++ b/lib/train/options.rb
@@ -69,7 +69,8 @@ module Train
 
       def merge_options(base, opts)
         res = base.merge(opts || {})
-        default_options.each do |field, hm|
+        # Also merge the default audit log options into the options so that those are available at the time of validation.
+        default_options.merge(default_audit_log_options).each do |field, hm|
           next unless res[field].nil? && hm.key?(:default)
 
           default = hm[:default]

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -30,9 +30,9 @@ class Train::Plugins::Transport
       # To make the data like hostname, username available to aduit logs dup the options
       @audit_log_data = options.dup || {}
       # For transport other than local all audit log options accessible inside transport_options key
-      if @options[:transport_options] && @options[:transport_options][:enable_audit_log]
+      if !@options.empty? && @options[:transport_options] && !@options[:transport_options][:disable_audit_log]
         @audit_log = Train::AuditLog.create(options[:transport_options])
-      elsif @options[:enable_audit_log]
+      elsif !@options.empty? && !@options[:disable_audit_log]
         @audit_log = Train::AuditLog.create(@options)
       end
 

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -30,9 +30,9 @@ class Train::Plugins::Transport
       # To make the data like hostname, username available to aduit logs dup the options
       @audit_log_data = options.dup || {}
       # For transport other than local all audit log options accessible inside transport_options key
-      if @options[:transport_options] && @options[:transport_options][:enable_audit_log]
+      if !options.empty? && @options[:transport_options] && @options[:transport_options][:enable_audit_log]
         @audit_log = Train::AuditLog.create(options[:transport_options])
-      elsif @options[:enable_audit_log]
+      elsif !options.empty? && @options[:enable_audit_log]
         @audit_log = Train::AuditLog.create(@options)
       end
 

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -30,9 +30,9 @@ class Train::Plugins::Transport
       # To make the data like hostname, username available to aduit logs dup the options
       @audit_log_data = options.dup || {}
       # For transport other than local all audit log options accessible inside transport_options key
-      if !options.empty? && @options[:transport_options] && @options[:transport_options][:enable_audit_log]
+      if !@options.empty? && @options[:transport_options] && @options[:transport_options][:enable_audit_log]
         @audit_log = Train::AuditLog.create(options[:transport_options])
-      elsif !options.empty? && @options[:enable_audit_log]
+      elsif !@options.empty? && @options[:enable_audit_log]
         @audit_log = Train::AuditLog.create(@options)
       end
 

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -30,9 +30,9 @@ class Train::Plugins::Transport
       # To make the data like hostname, username available to aduit logs dup the options
       @audit_log_data = options.dup || {}
       # For transport other than local all audit log options accessible inside transport_options key
-      if !@options.empty? && @options[:transport_options] && !@options[:transport_options][:disable_audit_log]
+      if @options[:transport_options] && @options[:transport_options][:enable_audit_log]
         @audit_log = Train::AuditLog.create(options[:transport_options])
-      elsif !@options.empty? && !@options[:disable_audit_log]
+      elsif @options[:enable_audit_log]
         @audit_log = Train::AuditLog.create(@options)
       end
 

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -30,10 +30,10 @@ class Train::Plugins::Transport
       # To make the data like hostname, username available to aduit logs dup the options
       @audit_log_data = options.dup || {}
       # For transport other than local all audit log options accessible inside transport_options key
-      if @options[:transport_options]
-        @audit_log = Train::AuditLog.create(options[:transport_options]) if @options[:transport_options][:enable_audit_log]
-      else
-        @audit_log = Train::AuditLog.create(options) if @options[:enable_audit_log]
+      if @options[:transport_options] && @options[:transport_options][:enable_audit_log]
+        @audit_log = Train::AuditLog.create(options[:transport_options])
+      elsif @options[:enable_audit_log]
+        @audit_log = Train::AuditLog.create(@options)
       end
 
       # default caching options

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -3,6 +3,7 @@ require_relative "../extras"
 require_relative "../file"
 require "fileutils" unless defined?(FileUtils)
 require "logger"
+require_relative "../audit_log"
 
 class Train::Plugins::Transport
   # A Connection instance can be generated and re-generated, given new
@@ -20,9 +21,16 @@ class Train::Plugins::Transport
     # @yield [self] yields itself for block-style invocation
     def initialize(options = nil)
       @options = options || {}
-      @logger = @options.delete(:logger) || Logger.new($stdout, level: :fatal)
+
       Train::Platforms::Detect::Specifications::OS.load
       Train::Platforms::Detect::Specifications::Api.load
+
+      @logger = @options.delete(:logger) || Logger.new($stdout, level: :fatal)
+
+      # In run_command all options are not accessible as some of them gets deleted in transit.
+      # To make the data like hostname, username available to aduit logs dup the options
+      @audit_log_data = options.dup || {}
+      @audit_log = Train::AuditLog.create(options) if @options[:enable_audit_log]
 
       # default caching options
       @cache_enabled = {
@@ -140,11 +148,14 @@ class Train::Plugins::Transport
       # Some implementations do not accept an opts argument.
       # We cannot update all implementations to accept opts due to them being separate plugins.
       # Therefore here we check the implementation's arity to maintain compatibility.
+      @audit_log.info({ type: "cmd", command: "#{cmd}", user: "#{@audit_log_data[:username]}", hostname: "#{@audit_log_data[:hostname]}" }) if @audit_log
+
       case method(:run_command_via_connection).arity.abs
       when 1
         return run_command_via_connection(cmd, &data_handler) unless cache_enabled?(:command)
 
         @cache[:command][cmd] ||= run_command_via_connection(cmd, &data_handler)
+
       when 2
         return run_command_via_connection(cmd, opts, &data_handler) unless cache_enabled?(:command)
 
@@ -157,6 +168,7 @@ class Train::Plugins::Transport
     # This is the main file call for all connections. This will call the private
     # file_via_connection on the connection with optional caching
     def file(path, *args)
+      @audit_log.info({ type: "file", path: "#{path}", user: "#{@audit_log_data[:username]}", hostname: "#{@audit_log_data[:hostname]}" }) if @audit_log
       return file_via_connection(path, *args) unless cache_enabled?(:file)
 
       @cache[:file][path] ||= file_via_connection(path, *args)
@@ -177,7 +189,7 @@ class Train::Plugins::Transport
 
       Array(locals).each do |local|
         remote_file = remote_directory ? File.join(remote, File.basename(local)) : remote
-
+        @audit_log.info({ type: "file upload", source: "#{local}", destination: "#{remote_file}", user: "#{@audit_log_data[:username]}", hostname: "#{@audit_log_data[:hostname]}" }) if @audit_log
         logger.debug("Attempting to upload '#{local}' as file #{remote_file}")
 
         file(remote_file).content = File.read(local)
@@ -198,7 +210,6 @@ class Train::Plugins::Transport
       Array(remotes).each do |remote|
         new_content = file(remote).content
         local_file = File.join(local, File.basename(remote))
-
         logger.debug("Attempting to download '#{remote}' as file #{local_file}")
 
         File.open(local_file, "w") { |fp| fp.write(new_content) }

--- a/lib/train/plugins/transport.rb
+++ b/lib/train/plugins/transport.rb
@@ -21,6 +21,12 @@ class Train::Plugins
     def initialize(options = {})
       @options = merge_options({}, options || {})
       @logger = @options[:logger] || Logger.new($stdout, level: :fatal)
+      # Validates audit log configuration options if audit log is enabled
+      # The reason to implement different validate method for audit log options is
+      # to validate only audit log options and not to break any existing validate_option implementation.
+      if @options[:enable_audit_log]
+        validate_audit_log_options(options)
+      end
     end
 
     # Create a connection to the target. Options may be provided

--- a/lib/train/plugins/transport.rb
+++ b/lib/train/plugins/transport.rb
@@ -21,11 +21,6 @@ class Train::Plugins
     def initialize(options = {})
       @options = merge_options({}, options || {})
       @logger = @options[:logger] || Logger.new($stdout, level: :fatal)
-      # validate_options is called/overridden by specific transport. We are only calling the validate_options so that it validates the newly introduced
-      # options for audit log configuration. This is a hack and should be replaced with something better.
-      if @options[:enable_audit_log]
-        validate_options(@options)
-      end
     end
 
     # Create a connection to the target. Options may be provided

--- a/lib/train/plugins/transport.rb
+++ b/lib/train/plugins/transport.rb
@@ -24,7 +24,7 @@ class Train::Plugins
       # Validates audit log configuration options if audit log is enabled
       # The reason to implement different validate method for audit log options is
       # to validate only audit log options and not to break any existing validate_option implementation.
-      if @options[:enable_audit_log]
+      if !options.empty? && @options[:enable_audit_log]
         validate_audit_log_options(options)
       end
     end

--- a/lib/train/plugins/transport.rb
+++ b/lib/train/plugins/transport.rb
@@ -24,7 +24,7 @@ class Train::Plugins
       # Validates audit log configuration options if audit log is enabled
       # The reason to implement different validate method for audit log options is
       # to validate only audit log options and not to break any existing validate_option implementation.
-      if !options.empty? && @options[:enable_audit_log]
+      if !@options.empty? && @options[:enable_audit_log]
         validate_audit_log_options(options)
       end
     end

--- a/lib/train/plugins/transport.rb
+++ b/lib/train/plugins/transport.rb
@@ -24,7 +24,7 @@ class Train::Plugins
       # Validates audit log configuration options if audit log is enabled
       # The reason to implement different validate method for audit log options is
       # to validate only audit log options and not to break any existing validate_option implementation.
-      if @options[:enable_audit_log]
+      if !@options.empty? && @options[:disable_audit_log] == false
         validate_audit_log_options(options)
       end
     end

--- a/lib/train/plugins/transport.rb
+++ b/lib/train/plugins/transport.rb
@@ -21,6 +21,11 @@ class Train::Plugins
     def initialize(options = {})
       @options = merge_options({}, options || {})
       @logger = @options[:logger] || Logger.new($stdout, level: :fatal)
+      # validate_options is called/overridden by specific transport. We are only calling the validate_options so that it validates the newly introduced
+      # options for audit log configuration. This is a hack and should be replaced with something better.
+      if @options[:enable_audit_log]
+        validate_options(@options)
+      end
     end
 
     # Create a connection to the target. Options may be provided

--- a/lib/train/plugins/transport.rb
+++ b/lib/train/plugins/transport.rb
@@ -24,7 +24,7 @@ class Train::Plugins
       # Validates audit log configuration options if audit log is enabled
       # The reason to implement different validate method for audit log options is
       # to validate only audit log options and not to break any existing validate_option implementation.
-      if !@options.empty? && @options[:disable_audit_log] == false
+      if @options[:enable_audit_log]
         validate_audit_log_options(options)
       end
     end

--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -139,6 +139,9 @@ module Train::Transports
       if key_files.empty?
         options[:auth_methods].delete("publickey")
       else
+        # When validate_options directly called in transport.rb auth_methods does not include the publickey so
+        # adding that if key_files is not empty
+        options[:auth_methods].push("publickey") unless options[:auth_methods].include?("publickey")
         options[:keys_only] = true if options[:password].nil?
         options[:key_files] = key_files
       end

--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -139,9 +139,6 @@ module Train::Transports
       if key_files.empty?
         options[:auth_methods].delete("publickey")
       else
-        # When validate_options directly called in transport.rb auth_methods does not include the publickey so
-        # adding that if key_files is not empty
-        options[:auth_methods].push("publickey") unless options[:auth_methods].include?("publickey")
         options[:keys_only] = true if options[:password].nil?
         options[:key_files] = key_files
       end

--- a/test/unit/plugins/transport_test.rb
+++ b/test/unit/plugins/transport_test.rb
@@ -1,20 +1,29 @@
 require "helper"
 
 describe "v1 Transport Plugin" do
+  let(:default_options) {
+    {
+      enable_audit_log: false,
+      audit_log_location: $stdout,
+      audit_log_app_name: "train",
+      audit_log_size: 2000000,
+      audit_log_frequency: "daily",
+    }
+  }
+
   describe "empty v1 transport plugin" do
     let(:plugin) { Class.new(Train.plugin(1)) }
-
     it "initializes an empty configuration" do
-      _(plugin.new.options).must_equal({})
+      _(plugin.new.options).must_equal(default_options)
     end
 
     it "saves the provided configuration" do
-      conf = { a: rand }
+      conf = default_options.merge({ a: rand })
       _(plugin.new(conf).options).must_equal(conf)
     end
 
     it "saves the provided configuration" do
-      conf = { a: rand }
+      conf = default_options.merge({ a: rand })
       _(plugin.new(conf).options).must_equal(conf)
     end
 
@@ -69,7 +78,8 @@ describe "v1 Transport Plugin" do
 
     it "exposes the parameters via api" do
       name, plugin = train_class
-      _(plugin.default_options.keys).must_equal [name]
+      output = default_options.keys << name
+      _(plugin.default_options.keys).must_equal output
     end
 
     it "exposes the parameters via api" do

--- a/test/unit/plugins/transport_test.rb
+++ b/test/unit/plugins/transport_test.rb
@@ -4,7 +4,7 @@ describe "v1 Transport Plugin" do
   let(:default_options) {
     {
       enable_audit_log: false,
-      audit_log_location: $stdout,
+      audit_log_location: nil,
       audit_log_app_name: "train",
       audit_log_size: 2000000,
       audit_log_frequency: "daily",

--- a/test/unit/plugins/transport_test.rb
+++ b/test/unit/plugins/transport_test.rb
@@ -4,17 +4,27 @@ describe "v1 Transport Plugin" do
   describe "empty v1 transport plugin" do
     let(:plugin) { Class.new(Train.plugin(1)) }
 
+    let(:default_audit_log_options) {
+      {
+        enable_audit_log: false,
+        audit_log_location: nil,
+        audit_log_app_name: "train",
+        audit_log_size: 2097152,
+        audit_log_frequency: "daily",
+      }
+    }
+
     it "initializes an empty configuration" do
-      _(plugin.new.options).must_equal({})
+      _(plugin.new.options).must_equal(default_audit_log_options)
     end
 
     it "saves the provided configuration" do
-      conf = { a: rand }
+      conf = default_audit_log_options.merge({ a: rand })
       _(plugin.new(conf).options).must_equal(conf)
     end
 
     it "saves the provided configuration" do
-      conf = { a: rand }
+      conf = default_audit_log_options.merge({ a: rand })
       _(plugin.new(conf).options).must_equal(conf)
     end
 

--- a/test/unit/plugins/transport_test.rb
+++ b/test/unit/plugins/transport_test.rb
@@ -1,29 +1,21 @@
 require "helper"
 
 describe "v1 Transport Plugin" do
-  let(:default_options) {
-    {
-      enable_audit_log: false,
-      audit_log_location: nil,
-      audit_log_app_name: "train",
-      audit_log_size: 2000000,
-      audit_log_frequency: "daily",
-    }
-  }
 
   describe "empty v1 transport plugin" do
     let(:plugin) { Class.new(Train.plugin(1)) }
+
     it "initializes an empty configuration" do
-      _(plugin.new.options).must_equal(default_options)
+      _(plugin.new.options).must_equal({})
     end
 
     it "saves the provided configuration" do
-      conf = default_options.merge({ a: rand })
+      conf = { a: rand }
       _(plugin.new(conf).options).must_equal(conf)
     end
 
     it "saves the provided configuration" do
-      conf = default_options.merge({ a: rand })
+      conf = { a: rand }
       _(plugin.new(conf).options).must_equal(conf)
     end
 
@@ -78,8 +70,7 @@ describe "v1 Transport Plugin" do
 
     it "exposes the parameters via api" do
       name, plugin = train_class
-      output = default_options.keys << name
-      _(plugin.default_options.keys).must_equal output
+      _(plugin.default_options.keys).must_equal [name]
     end
 
     it "exposes the parameters via api" do

--- a/test/unit/plugins/transport_test.rb
+++ b/test/unit/plugins/transport_test.rb
@@ -1,20 +1,30 @@
 require "helper"
 
 describe "v1 Transport Plugin" do
+  let(:default_audit_log_options) {
+    {
+      disable_audit_log: true,
+      audit_log_location: nil,
+      audit_log_app_name: "train",
+      audit_log_size: 2097152,
+      audit_log_frequency: "daily",
+    }
+  }
+
   describe "empty v1 transport plugin" do
     let(:plugin) { Class.new(Train.plugin(1)) }
 
     it "initializes an empty configuration" do
-      _(plugin.new.options).must_equal({})
+      _(plugin.new.options).must_equal(default_audit_log_options)
     end
 
     it "saves the provided configuration" do
-      conf = { a: rand }
+      conf = default_audit_log_options.merge({ a: rand })
       _(plugin.new(conf).options).must_equal(conf)
     end
 
     it "saves the provided configuration" do
-      conf = { a: rand }
+      conf = default_audit_log_options.merge({ a: rand })
       _(plugin.new(conf).options).must_equal(conf)
     end
 

--- a/test/unit/plugins/transport_test.rb
+++ b/test/unit/plugins/transport_test.rb
@@ -9,8 +9,8 @@ describe "v1 Transport Plugin" do
         enable_audit_log: false,
         audit_log_location: nil,
         audit_log_app_name: "train",
-        audit_log_size: 2097152,
-        audit_log_frequency: "daily",
+        audit_log_size: nil,
+        audit_log_frequency: 0,
       }
     }
 

--- a/test/unit/plugins/transport_test.rb
+++ b/test/unit/plugins/transport_test.rb
@@ -1,30 +1,20 @@
 require "helper"
 
 describe "v1 Transport Plugin" do
-  let(:default_audit_log_options) {
-    {
-      disable_audit_log: true,
-      audit_log_location: nil,
-      audit_log_app_name: "train",
-      audit_log_size: 2097152,
-      audit_log_frequency: "daily",
-    }
-  }
-
   describe "empty v1 transport plugin" do
     let(:plugin) { Class.new(Train.plugin(1)) }
 
     it "initializes an empty configuration" do
-      _(plugin.new.options).must_equal(default_audit_log_options)
+      _(plugin.new.options).must_equal({})
     end
 
     it "saves the provided configuration" do
-      conf = default_audit_log_options.merge({ a: rand })
+      conf = { a: rand }
       _(plugin.new(conf).options).must_equal(conf)
     end
 
     it "saves the provided configuration" do
-      conf = default_audit_log_options.merge({ a: rand })
+      conf = { a: rand }
       _(plugin.new(conf).options).must_equal(conf)
     end
 

--- a/test/unit/plugins/transport_test.rb
+++ b/test/unit/plugins/transport_test.rb
@@ -1,7 +1,6 @@
 require "helper"
 
 describe "v1 Transport Plugin" do
-
   describe "empty v1 transport plugin" do
     let(:plugin) { Class.new(Train.plugin(1)) }
 

--- a/test/unit/train_test.rb
+++ b/test/unit/train_test.rb
@@ -11,8 +11,8 @@ describe Train do
 
   let(:default_audit_log_options) {
     {
-      enable_audit_log: {
-        default: false,
+      disable_audit_log: {
+        default: true,
       },
       audit_log_location: {
         required: true,

--- a/test/unit/train_test.rb
+++ b/test/unit/train_test.rb
@@ -15,7 +15,8 @@ describe Train do
         default: false,
       },
       audit_log_location: {
-        default: $stdout,
+        default: nil,
+        required: true,
       },
       audit_log_app_name: {
         default: "train",

--- a/test/unit/train_test.rb
+++ b/test/unit/train_test.rb
@@ -11,8 +11,8 @@ describe Train do
 
   let(:default_audit_log_options) {
     {
-      disable_audit_log: {
-        default: true,
+      enable_audit_log: {
+        default: false,
       },
       audit_log_location: {
         required: true,

--- a/test/unit/train_test.rb
+++ b/test/unit/train_test.rb
@@ -71,7 +71,7 @@ describe Train do
 
     it "provides empty options of a transport plugin" do
       Class.new(Train.plugin 1) { name "none" }
-      _(Train.options("none")).must_equal(default_options)
+      _(Train.options("none")).must_equal({})
     end
 
     it "provides all options of a transport plugin" do
@@ -79,13 +79,12 @@ describe Train do
         name "one"
         option :one, required: true, default: 123
       end
-      output = default_options.merge(
+      _(Train.options("one")).must_equal({
         one: {
           required: true,
           default: 123,
-        }
-      )
-      _(Train.options("one")).must_equal(output)
+        },
+      })
     end
   end
 

--- a/test/unit/train_test.rb
+++ b/test/unit/train_test.rb
@@ -9,6 +9,26 @@ describe Train do
     Train::Plugins.registry.clear
   end
 
+  let(:default_options) {
+    {
+      enable_audit_log: {
+        default: false,
+      },
+      audit_log_location: {
+        default: $stdout,
+      },
+      audit_log_app_name: {
+        default: "train",
+      },
+      audit_log_size: {
+        default: 2000000,
+      },
+      audit_log_frequency: {
+        default: "daily",
+      },
+    }
+  }
+
   describe "#create" do
     it "raises an error if the plugin isnt found" do
       _ { Train.create("missing") }.must_raise Train::UserError
@@ -50,7 +70,7 @@ describe Train do
 
     it "provides empty options of a transport plugin" do
       Class.new(Train.plugin 1) { name "none" }
-      _(Train.options("none")).must_equal({})
+      _(Train.options("none")).must_equal(default_options)
     end
 
     it "provides all options of a transport plugin" do
@@ -58,12 +78,13 @@ describe Train do
         name "one"
         option :one, required: true, default: 123
       end
-      _(Train.options("one")).must_equal({
+      output = default_options.merge(
         one: {
           required: true,
           default: 123,
-        },
-      })
+        }
+      )
+      _(Train.options("one")).must_equal(output)
     end
   end
 

--- a/test/unit/train_test.rb
+++ b/test/unit/train_test.rb
@@ -22,10 +22,10 @@ describe Train do
         default: "train",
       },
       audit_log_size: {
-        default: 2097152,
+        default: nil,
       },
       audit_log_frequency: {
-        default: "daily",
+        default: 0,
       },
     }
   }

--- a/test/unit/train_test.rb
+++ b/test/unit/train_test.rb
@@ -9,20 +9,20 @@ describe Train do
     Train::Plugins.registry.clear
   end
 
-  let(:default_options) {
+  let(:default_audit_log_options) {
     {
       enable_audit_log: {
         default: false,
       },
       audit_log_location: {
-        default: nil,
         required: true,
+        default: nil,
       },
       audit_log_app_name: {
         default: "train",
       },
       audit_log_size: {
-        default: 2000000,
+        default: 2097152,
       },
       audit_log_frequency: {
         default: "daily",
@@ -69,9 +69,9 @@ describe Train do
       _ { Train.options("missing") }.must_raise Train::PluginLoadError
     end
 
-    it "provides empty options of a transport plugin" do
+    it "provides list of default options of a transport plugin" do
       Class.new(Train.plugin 1) { name "none" }
-      _(Train.options("none")).must_equal({})
+      _(Train.options("none")).must_equal(default_audit_log_options)
     end
 
     it "provides all options of a transport plugin" do
@@ -79,12 +79,13 @@ describe Train do
         name "one"
         option :one, required: true, default: 123
       end
-      _(Train.options("one")).must_equal({
+      output = {
         one: {
           required: true,
           default: 123,
         },
-      })
+      }.merge(default_audit_log_options)
+      _(Train.options("one")).must_equal(output)
     end
   end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

This PR adds the ability to configure the audit log option using train and if the audit log is enabled it generates the audit log files in the default location.

This includes the following changes

* By default audit log is disabled. Users can set the `enable_audit_log` option to `true` while creating train transport to enable it.
* User can use audit_log_location and audit_log_size options to set the location and size of the audit log file
* Currently we only do audit logging for commands executed using train connection object and logging file path that the user is trying to access or read. It also logs the file upload operations that are happening through train connection (Note currently audit log for file operations is not in a matured state so it will not work for transport which overrides the upload functionality or any other file related actions for example reading content of the file etc.).

Test using irb

```
bundle exec irb -I lib
require 'train'
t = Train.create("local")
c = t.connection
c.run_command("whoami")
```

audit_log_location is a required parameter so any library or plugin using train to pass the audit log location be they want to enable the audit log.

Pending: dev-docs
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
