### PR TITLE
Fix `mocha` ~1.1 incompatibility with `minitest`

### DIFF
--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -7,6 +7,7 @@ bundle --version
 
 echo "--- bundle install"
 bundle config --local path vendor/bundle
+bundle config --local without integration tools
 bundle install --jobs=7 --retry=3
 
 echo "+++ bundle exec rake"

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :test do
   # but it's close enough to show the gempath handler can find a plugin
   # See test/unit/
   gem "train-test-fixture", path: "test/fixtures/plugins/train-test-fixture"
-  gem "mocha", "~> 1.1"
+  gem "mocha", "~> 2.1"
 end
 
 if Gem.ruby_version >= Gem::Version.new("2.7.0")

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,6 @@
 source "https://rubygems.org"
 gemspec name: "train"
 
-# if Gem.ruby_version.to_s.start_with?("2.5")
-#   # 16.7.23 required ruby 2.6+
-#   gem "chef-utils", "< 16.7.23" # TODO: remove when we drop ruby 2.5
-# end
-
 group :test do
   gem "minitest", "~> 5.8"
   gem "rake", "~> 13.0"
@@ -27,7 +22,7 @@ end
 
 if Gem.ruby_version >= Gem::Version.new("2.7.0")
   group :integration do
-    #gem "berkshelf", ">= 6.0"
+    gem "berkshelf", ">= 6.0"
     gem "test-kitchen", ">= 2"
     gem "kitchen-vagrant"
   end

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,9 @@ group :test do
   # but it's close enough to show the gempath handler can find a plugin
   # See test/unit/
   gem "train-test-fixture", path: "test/fixtures/plugins/train-test-fixture"
-  gem "mocha", "~> 2.1"
+  # Mocha ~1.1 is incompatible with minitest v5.19 and later
+  # More on the issue: https://github.com/freerange/mocha/issues/614
+  gem "mocha", (RUBY_VERSION < "3.1" ? "~> 1.1" : "~> 2.1")
 end
 
 if Gem.ruby_version >= Gem::Version.new("2.7.0")

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,12 @@ group :test do
   gem "train-test-fixture", path: "test/fixtures/plugins/train-test-fixture"
   # Mocha ~1.1 is incompatible with minitest v5.19 and later
   # More on the issue: https://github.com/freerange/mocha/issues/614
-  gem "mocha", (RUBY_VERSION < "3.1" ? "~> 1.1" : "~> 2.1")
+  # It seems non-windows platforms lower than ruby 3.1 are affected
+  if !Gem.win_platform? && (Gem.ruby_version < Gem::Version.new("3.1"))
+    gem "mocha", "~> 1.1"
+  else
+    gem "mocha", "~> 2.1"
+  end
 end
 
 if Gem.ruby_version >= Gem::Version.new("2.7.0")

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 source "https://rubygems.org"
 gemspec name: "train"
 
-if Gem.ruby_version.to_s.start_with?("2.5")
-  # 16.7.23 required ruby 2.6+
-  gem "chef-utils", "< 16.7.23" # TODO: remove when we drop ruby 2.5
-end
+# if Gem.ruby_version.to_s.start_with?("2.5")
+#   # 16.7.23 required ruby 2.6+
+#   gem "chef-utils", "< 16.7.23" # TODO: remove when we drop ruby 2.5
+# end
 
 group :test do
   gem "minitest", "~> 5.8"
@@ -27,7 +27,7 @@ end
 
 if Gem.ruby_version >= Gem::Version.new("2.7.0")
   group :integration do
-    gem "berkshelf", ">= 6.0"
+    #gem "berkshelf", ">= 6.0"
     gem "test-kitchen", ">= 2"
     gem "kitchen-vagrant"
   end

--- a/Gemfile
+++ b/Gemfile
@@ -22,12 +22,7 @@ group :test do
   gem "train-test-fixture", path: "test/fixtures/plugins/train-test-fixture"
   # Mocha ~1.1 is incompatible with minitest v5.19 and later
   # More on the issue: https://github.com/freerange/mocha/issues/614
-  # It seems non-windows platforms lower than ruby 3.1 are affected
-  if !Gem.win_platform? && (Gem.ruby_version < Gem::Version.new("3.1"))
-    gem "mocha", "~> 1.1"
-  else
-    gem "mocha", "~> 2.1"
-  end
+  gem "mocha", "~> 2"
 end
 
 if Gem.ruby_version >= Gem::Version.new("2.7.0")

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -215,7 +215,12 @@ describe "ssh transport" do
     end
 
     it "sets up a proxy when ssh proxy command is specified" do
-      mock = RUBY_VERSION < "3.1" ? MiniTest::Mock.new : Minitest::Mock.new
+      # Only non-windows ruby < 3.1 uses MiniTest::Mock
+      if !windows? && RUBY_VERSION < "3.1"
+        mock = MiniTest::Mock.new
+      else
+        mock = Minitest::Mock.new
+      end
       mock.expect(:call, true) do |hostname, username, options|
         options[:proxy].is_a?(Net::SSH::Proxy::Command) &&
           "ssh root@127.0.0.1 -W %h:%p" == options[:proxy].command_line_template
@@ -384,7 +389,12 @@ describe "ssh transport with bastion" do
       end
 
       it "sets up a proxy when ssh proxy command is specified" do
-        mock = RUBY_VERSION < "3.1" ? MiniTest::Mock.new : Minitest::Mock.new
+        # Only non-windows ruby < 3.1 uses MiniTest::Mock
+        if !windows? && RUBY_VERSION < "3.1"
+          mock = MiniTest::Mock.new
+        else
+          mock = Minitest::Mock.new
+        end
         mock.expect(:call, true) do |hostname, username, options|
           options[:proxy].is_a?(Net::SSH::Proxy::Command) &&
             "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -o ForwardAgent=no -o IdentitiesOnly=yes -i #{conf[:key_files]} root@bastion_dummy -p 22 -W %h:%p" == options[:proxy].command_line_template

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -215,12 +215,8 @@ describe "ssh transport" do
     end
 
     it "sets up a proxy when ssh proxy command is specified" do
-      # Only non-windows ruby < 3.1 uses MiniTest::Mock
-      if !windows? && RUBY_VERSION < "3.1"
-        mock = MiniTest::Mock.new
-      else
-        mock = Minitest::Mock.new
-      end
+      mock = Minitest::Mock.new
+
       mock.expect(:call, true) do |hostname, username, options|
         options[:proxy].is_a?(Net::SSH::Proxy::Command) &&
           "ssh root@127.0.0.1 -W %h:%p" == options[:proxy].command_line_template
@@ -389,12 +385,7 @@ describe "ssh transport with bastion" do
       end
 
       it "sets up a proxy when ssh proxy command is specified" do
-        # Only non-windows ruby < 3.1 uses MiniTest::Mock
-        if !windows? && RUBY_VERSION < "3.1"
-          mock = MiniTest::Mock.new
-        else
-          mock = Minitest::Mock.new
-        end
+        mock = Minitest::Mock.new
         mock.expect(:call, true) do |hostname, username, options|
           options[:proxy].is_a?(Net::SSH::Proxy::Command) &&
             "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -o ForwardAgent=no -o IdentitiesOnly=yes -i #{conf[:key_files]} root@bastion_dummy -p 22 -W %h:%p" == options[:proxy].command_line_template

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -215,7 +215,7 @@ describe "ssh transport" do
     end
 
     it "sets up a proxy when ssh proxy command is specified" do
-      mock = Minitest::Mock.new
+      mock = RUBY_VERSION < "3.1" ? MiniTest::Mock.new : Minitest::Mock.new
       mock.expect(:call, true) do |hostname, username, options|
         options[:proxy].is_a?(Net::SSH::Proxy::Command) &&
           "ssh root@127.0.0.1 -W %h:%p" == options[:proxy].command_line_template
@@ -384,7 +384,7 @@ describe "ssh transport with bastion" do
       end
 
       it "sets up a proxy when ssh proxy command is specified" do
-        mock = Minitest::Mock.new
+        mock = RUBY_VERSION < "3.1" ? MiniTest::Mock.new : Minitest::Mock.new
         mock.expect(:call, true) do |hostname, username, options|
           options[:proxy].is_a?(Net::SSH::Proxy::Command) &&
             "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -o ForwardAgent=no -o IdentitiesOnly=yes -i #{conf[:key_files]} root@bastion_dummy -p 22 -W %h:%p" == options[:proxy].command_line_template

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -215,7 +215,7 @@ describe "ssh transport" do
     end
 
     it "sets up a proxy when ssh proxy command is specified" do
-      mock = MiniTest::Mock.new
+      mock = Minitest::Mock.new
       mock.expect(:call, true) do |hostname, username, options|
         options[:proxy].is_a?(Net::SSH::Proxy::Command) &&
           "ssh root@127.0.0.1 -W %h:%p" == options[:proxy].command_line_template
@@ -384,7 +384,7 @@ describe "ssh transport with bastion" do
       end
 
       it "sets up a proxy when ssh proxy command is specified" do
-        mock = MiniTest::Mock.new
+        mock = Minitest::Mock.new
         mock.expect(:call, true) do |hostname, username, options|
           options[:proxy].is_a?(Net::SSH::Proxy::Command) &&
             "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -o ForwardAgent=no -o IdentitiesOnly=yes -i #{conf[:key_files]} root@bastion_dummy -p 22 -W %h:%p" == options[:proxy].command_line_template


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The omnibus build is currently failing because [Mocha ~1.1 is incompatible with minitest v5.19 and later](https://github.com/freerange/mocha/issues/614#top) and it results to an error as:

```
.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/mocha-1.16.1/lib/mocha/integration/mini_test/adapter.rb:26:in `included': uninitialized constant MiniTest (NameError)

          Mocha::ExpectationErrorFactory.exception_class = ::MiniTest::Assertion
                                                           ^^^^^^^^^^
Did you mean?  Minitest
```

Build link here: https://buildkite.com/chef-oss/inspec-train-main-verify/builds/876

This would require upgrade to mocha and rename the occurence of `MiniTest::Mock.new` to `Minitest::Mock.new` in our codebase.

This PR fixes the incompatibility of `mocha` with `minitest`

## Related Issue
[Mocha ~1.1 is incompatible with minitest v5.19 and later](https://github.com/freerange/mocha/issues/614#top)
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
