### PR TITLE
Remove dependency on `coveralls` gem from train

### DIFF
--- a/.expeditor/coverage.pipeline.yml
+++ b/.expeditor/coverage.pipeline.yml
@@ -1,19 +1,28 @@
 ---
+# TODO: Update pipeline when we introduce the coverage pipeline
 
 steps:
-  - label: coverage
-    commands:
-      - /workdir/.expeditor/buildkite/coverage.sh
+  - label: "placeholder-for-coverage-pipeline"
     expeditor:
-      secrets:
-        COVERALLS_REPO_TOKEN:
-          path: secret/coveralls/inspec/train
-          field: repo_token
       executor:
         docker:
-          environment:
-            - CI_ENABLE_COVERAGE=true
-            - CI_NAME=Buildkite
-            - CI_BUILD_NUMBER=$BUILDKITE_BUILD_NUMBER
-            - CI_BUILD_URL=$BUILDKITE_BUILD_URL
-            - CI_BRANCH=$BUILDKITE_BRANCH
+    commands:
+      - "echo ## This pipeline does nothing. Implement the coverage pipeline in near future."
+
+# steps:
+#   - label: coverage
+#     commands:
+#       - /workdir/.expeditor/buildkite/coverage.sh
+#     expeditor:
+#       secrets:
+#         COVERALLS_REPO_TOKEN:
+#           path: secret/coveralls/inspec/train
+#           field: repo_token
+#       executor:
+#         docker:
+#           environment:
+#             - CI_ENABLE_COVERAGE=true
+#             - CI_NAME=Buildkite
+#             - CI_BUILD_NUMBER=$BUILDKITE_BUILD_NUMBER
+#             - CI_BUILD_URL=$BUILDKITE_BUILD_URL
+#             - CI_BRANCH=$BUILDKITE_BRANCH

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ if Gem.ruby_version.to_s.start_with?("2.5")
 end
 
 group :test do
-  gem "coveralls", require: false
   gem "minitest", "~> 5.8"
   gem "rake", "~> 13.0"
   gem "chefstyle", "2.1.1"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ For more information on project states and SLAs, see [this documentation](https:
 
 [![Build status](https://badge.buildkite.com/ee9d6f49d995b23e943955b12d5aaadf4314d12b7cc99b03be.svg?branch=master)](https://buildkite.com/chef-oss/inspec-train-master-verify)
 [![Gem Version](https://badge.fury.io/rb/train.svg)](https://badge.fury.io/rb/train)
-[![Coverage Status](https://coveralls.io/repos/github/inspec/train/badge.svg?branch=master)](https://coveralls.io/github/inspec/train?branch=master)
 
 **Umbrella Project**: [Chef Foundation](https://github.com/chef/chef-oss-practices/blob/master/projects/chef-foundation.md)
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,9 +1,7 @@
 if ENV["CI_ENABLE_COVERAGE"]
   require "simplecov"
-  require "coveralls"
   SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
     SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter,
   ])
 
   SimpleCov.start do

--- a/test/integration/helper.rb
+++ b/test/integration/helper.rb
@@ -1,6 +1,3 @@
-require "coveralls"
-Coveralls.wear!
-
 require "minitest/autorun"
 require "minitest/spec"
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR removes the dependency on coveralls. We no longer use coveralls for our coverage pipeline.

Dependency on coveralls is breaking the verify pipeline for Ruby 3.0

We will implement this pipeline in near future.

Reverts - https://github.com/inspec/train/pull/440

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://buildkite.com/chef-oss/inspec-train-main-verify/builds/888#018b241a-d0da-4c45-afa8-562cac70d8ee

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
