### PR TITLE
[WIP] Drop ruby 2.7 test as it has reached EOL

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -11,29 +11,21 @@ expeditor:
 steps:
 
   # make sure lint runs on the oldest Ruby we support so we catch any new Ruby-isms here
-  - label: lint-ruby-2.7
+  - label: lint-ruby-3.0.6
     command:
       - RAKE_TASK=lint /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       executor:
         docker:
-          image: ruby:2.7
+          image: ruby:3.0.6
 
-  - label: run-tests-ruby-2.7
+  - label: run-tests-ruby-3.0.6
     command:
       - /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       executor:
         docker:
-          image: ruby:2.7
-
-  - label: run-tests-ruby-3.0
-    command:
-      - /workdir/.expeditor/buildkite/verify.sh
-    expeditor:
-      executor:
-        docker:
-          image: ruby:3.0
+          image: ruby:3.0.6
 
   - label: run-tests-ruby-3.1
     command:
@@ -42,18 +34,6 @@ steps:
       executor:
         docker:
           image: ruby:3.1
-  
-  - label: run-tests-ruby-2.7-windows
-    command:
-      - /workdir/.expeditor/buildkite/verify.ps1
-    expeditor:
-      executor:
-        docker:
-          environment:
-            - BUILDKITE
-          host_os: windows
-          shell: ["powershell", "-Command"]
-          image: rubydistros/windows-2019:2.7
 
   - label: run-tests-ruby-3.0-windows
     command:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR drops support of Ruby 2.7 in the CI testing and upgrades ruby 3.0 to 3.0.6

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
