### PR TITLE
Fix: Update ruby base image to bullseye in CI tests

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -33,7 +33,7 @@ steps:
     expeditor:
       executor:
         docker:
-          image: ruby:3.1
+          image: ruby:3.1-bullseye
 
   - label: run-tests-ruby-3.0-windows
     command:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

The current Docker image version (ruby:3.1) encounters a ThreadError due to restrictions imposed by libseccomp, blocking certain system calls necessary for the certain operations.

```
/workdir/vendor/bundle/ruby/3.1.0/gems/minitest-5.22.3/lib/minitest/parallel.rb:28:in `initialize': can't create Thread: Operation not permitted (ThreadError)
```

This PR addresses the issue encountered in the current Docker image setup by updating the Docker image version from ruby:3.1 to ruby:3.1-bullseye.

_Note: This is a workaround_

## Related Issue
CHEF-11234: CI is breaking for inspec, inspec-gcp, and train due to issue with docker image used for the tests


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
