### PR TITLE
gem: pin down googleauth gem to below 1.9

### DIFF
--- a/train.gemspec
+++ b/train.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "azure_mgmt_security", "~> 0.18"
   spec.add_dependency "azure_mgmt_storage", "~> 0.18"
   spec.add_dependency "docker-api", ">= 1.26", "< 3.0"
-  spec.add_dependency "googleauth", ">= 0.16.2", "< 2.a"
+  spec.add_dependency "googleauth", ">= 0.16.2", "< 1.9.0"
   spec.add_dependency "google-apis-admin_directory_v1", "~> 0.46.0"
   spec.add_dependency "google-apis-cloudkms_v1", "~> 0.41.0"
   spec.add_dependency "google-apis-monitoring_v3", "~> 0.51.0"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR addresses recent CI failures on [Windows](https://buildkite.com/chef/inspec-inspec-main-verify-private/builds/709#018ea8b5-ad3f-47ba-8894-cde5987b0e54) caused by changes in googleauth gem's method https://github.com/googleapis/google-auth-library-ruby/blob/8f127eee40b0f970706c59cb324f71408dd2fec4/lib/googleauth/compute_engine.rb#L72 . To restore stability to our CI pipelines, we're pinning the googleauth gem to version below 1.9 in our gemspec.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
