### PR TITLE
Add missing require for OpenStruct library

### DIFF
--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -5,6 +5,7 @@
 require_relative "../plugins"
 require_relative "../errors"
 require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
+require "ostruct" unless defined?(OpenStruct)
 
 module Train::Transports
   class Local < Train.plugin(1)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Windows build is failing diue to the missing require on this PR https://buildkite.com/chef-oss/inspec-train-main-verify/builds/1086#018ee09e-57e6-4fc2-9032-0093608acf29/311-316

Adding require will fix the issue
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
