### PR TITLE
Revert "CHEF-13189: Remove ruby 3.0 support"

### DIFF
--- a/.expeditor/coverage.pipeline.yml
+++ b/.expeditor/coverage.pipeline.yml
@@ -9,11 +9,11 @@ expeditor:
 
 steps:
 
-  - label: coverage-ruby-3.1
+  - label: coverage-ruby-3.0.6
     command:
       - CI_ENABLE_COVERAGE=1 RAKE_TASK=test /workdir/.expeditor/buildkite/coverage.sh
     expeditor:
       secrets: true
       executor:
         docker:
-          image: ruby:3.1-bullseye
+          image: ruby:3.0.6

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -9,13 +9,21 @@ expeditor:
 steps:
 
   # make sure lint runs on the oldest Ruby we support so we catch any new Ruby-isms here
-  - label: lint-ruby-3.1
+  - label: lint-ruby-3.0.6
     command:
       - RAKE_TASK=lint /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       executor:
         docker:
-          image: ruby:3.1-bullseye
+          image: ruby:3.0.6
+
+  - label: run-tests-ruby-3.0.6
+    command:
+      - /workdir/.expeditor/buildkite/verify.sh
+    expeditor:
+      executor:
+        docker:
+          image: ruby:3.0.6
 
   - label: run-tests-ruby-3.1
     command:
@@ -24,6 +32,18 @@ steps:
       executor:
         docker:
           image: ruby:3.1-bullseye
+
+  - label: run-tests-ruby-3.0-windows
+    command:
+      - /workdir/.expeditor/buildkite/verify.ps1
+    expeditor:
+      executor:
+        docker:
+          environment:
+            - BUILDKITE
+          host_os: windows
+          shell: ["powershell", "-Command"]
+          image: rubydistros/windows-2019:3.0
 
   - label: run-tests-ruby-3.1-windows
     command:

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec name: "train"
 group :test do
   gem "minitest", "~> 5.8"
   gem "rake", "~> 13.0"
-  gem "chefstyle"
+  gem "chefstyle", "2.1.1"
   gem "concurrent-ruby", "~> 1.0"
   gem "pry-byebug"
   gem "m"

--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
     "bug_tracker_uri" => "https://github.com/inspec/train/issues",
   }
 
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.files = Dir.glob("{LICENSE,lib/**/*}")
     .grep_v(%r{transports/(azure|clients|docker|podman|gcp|helpers|vmware)})

--- a/train.gemspec
+++ b/train.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
     "bug_tracker_uri" => "https://github.com/inspec/train/issues",
   }
 
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.files = %w{LICENSE} + Dir.glob("lib/**/*")
     .grep(%r{transports/(azure|clients|docker|podman|gcp|helpers|vmware)})


### PR DESCRIPTION
Reverts inspec/train#781

Reverting this change as Chef 17 and Chef 18 has a dependency on this.