### PR TITLE
Updated the platform detect for darwin to use sw_ver for release

### DIFF
--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -352,10 +352,11 @@ module Train::Platforms::Detect::Specifications
         # rubocop:disable Layout/ExtraSpacing
         # rubocop:disable Layout/SpaceAroundOperators
         if unix_uname_s =~ /darwin/i
-          @platform[:release] ||= unix_uname_r.lines[0].chomp
-          @platform[:arch]      = unix_uname_m
+          cmd = @backend.run_command("sw_vers -productVersion")
+          @platform[:release] = cmd.stdout.chomp if cmd.exit_status == 0
+          @platform[:arch] = unix_uname_m
           cmd = @backend.run_command("sw_vers -buildVersion")
-          @platform[:build]     = cmd.stdout.chomp if cmd.exit_status == 0
+          @platform[:build] = cmd.stdout.chomp if cmd.exit_status == 0
           true
         end
         # rubocop:enable Layout/ExtraSpacing

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -92,20 +92,24 @@ describe "os_detect" do
         files = {
           "/System/Library/CoreServices/SystemVersion.plist" => "<string>Mac OS X</string>",
         }
-        platform = scan_with_files("darwin", files)
+        platform = scan_with_files("darwin", files) do |mock|
+          mock.mock_command("sw_vers -productVersion", "10.15.7\n")
+        end
         _(platform[:name]).must_equal("mac_os_x")
         _(platform[:family]).must_equal("darwin")
-        _(platform[:release]).must_equal("test-release")
+        _(platform[:release]).must_equal("10.15.7")
       end
 
       it "sets the correct family, name, and release on macOS >= 11" do
         files = {
           "/System/Library/CoreServices/SystemVersion.plist" => "<string>macOS</string>",
         }
-        platform = scan_with_files("darwin", files)
+        platform = scan_with_files("darwin", files) do |mock|
+          mock.mock_command("sw_vers -productVersion", "11.2.3\n")
+        end
         _(platform[:name]).must_equal("mac_os_x")
         _(platform[:family]).must_equal("darwin")
-        _(platform[:release]).must_equal("test-release")
+        _(platform[:release]).must_equal("11.2.3")
       end
     end
 
@@ -116,10 +120,11 @@ describe "os_detect" do
         }
         platform = scan_with_files("darwin", files) do |mock|
           mock.mock_command("sw_vers -buildVersion", "12345\n")
+          mock.mock_command("sw_vers -productVersion", "17.0.1\n")
         end
         _(platform[:name]).must_equal("darwin")
         _(platform[:family]).must_equal("darwin")
-        _(platform[:release]).must_equal("test-release")
+        _(platform[:release]).must_equal("17.0.1")
         _(platform[:build]).must_equal("12345")
       end
     end


### PR DESCRIPTION
## Description

Updated the detect for osx to use sw_vers to get the actual os release vs the kernel version


- [x] I have read the **CONTRIBUTING** document.
