### PR TITLE
Version pinning changes for train-winrm

### DIFF
--- a/train.gemspec
+++ b/train.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "train-core", "= #{Train::VERSION}"
-  spec.add_dependency "train-winrm", "~> 0.2"
+  spec.add_dependency "train-winrm", "~> 0.2.19" # This version is required for Ruby 3.0 compatibility
 
   if Gem.ruby_version >= Gem::Version.new("3.1.0")
     spec.add_dependency "activesupport", ">= 6.0.3.1"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Version pinning changes for train-winrm. Added pessimistic version constraint to support Ruby 3.0.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
