### PR TITLE
revert back to the old constraint to use greater than 1.16.0 ffi gem

### DIFF
--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "addressable", "~> 2.5"
-  spec.add_dependency "ffi", "!= 1.13.0" # train-core doesn't directly depend on FFI, but 1.13.0 broke windows
+  spec.add_dependency "ffi", "~> 1.16.0" # train-core doesn't directly depend on FFI, but 1.13.0 broke windows
   spec.add_dependency "json", ">= 1.8", "< 3.0"
   spec.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
   spec.add_dependency "net-scp", ">= 1.2", "< 5.0"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Inspec Hab builds are throwing a warning for ambigous gem version of ffi 
https://buildkite.com/chef/inspec-inspec-main-artifact-habitat/builds/365#01961a32-2e45-4fff-a3d0-329ef49a8a3d

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This change brings back the original constraints that was somehow misplaced.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
