### PR TITLE
Updated json gem to security fixed version

### DIFF
--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "addressable", "~> 2.5"
   spec.add_dependency "ffi", ">= 1.16.0", "< 1.18"
-  spec.add_dependency "json", ">= 1.8", "< 3.0"
+  spec.add_dependency "json", ">= 2.19.2", "< 3.0"
   spec.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
   spec.add_dependency "net-scp", ">= 1.2", "< 5.0"
   spec.add_dependency "net-ssh", ">= 2.9", "< 8.0"


### PR DESCRIPTION
Updated the ffi gem dependency to allow versions greater than or equal to `2.19.2` but less than `3`.

## Description
Updated json gem to security fixed version.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
