### PR TITLE
chore: Bump activesupport minimum version to 7.2.3.1

### DIFF
--- a/train.gemspec
+++ b/train.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "train-core", "= #{Train::VERSION}"
   spec.add_dependency "train-winrm", "~> 0.4.0" # Ruby 3.4 upgrade included
 
-  spec.add_dependency "activesupport", "~> 7.2", ">= 7.2.2.1"
+  spec.add_dependency "activesupport", "~> 7.2", ">= 7.2.3.1"
 
   # azure, docker, gcp dependencies
   spec.add_dependency "inifile", "~> 3.0"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Bumps the minimum required version of `activesupport` from `>= 7.2.2.1` to `>= 7.2.3.1` to align with the latest stable patch release in the 7.2.x series. The upper bound constraint (`~> 7.2`) is unchanged.

This work was completed with AI assistance following Progress AI policies.

## Related Issue

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
