### PR TITLE
walk-ex15: add safer opt-in local pipe retry backoff

### DIFF
--- a/.copilot-track/walk/ex15/notes.md
+++ b/.copilot-track/walk/ex15/notes.md
@@ -1,0 +1,56 @@
+## ex15 notes
+
+Date: 2026-05-27
+
+### Goal
+Introduce a safer reliability improvement for local connection pipe failures with no default behavior change.
+
+### What changed
+- Kept existing `WindowsPipeRunner#run_command` default recovery logic intact.
+- Added optional extra retry path gated by environment variable.
+- Added short configurable backoff before the optional retry.
+- Added tests for default and opt-in behavior.
+
+### Tuning parameters
+- `TRAIN_LOCAL_PIPE_EXTRA_RETRY`
+  - Enables extra retry when set to one of: `1`, `true`, `yes`, `on`.
+  - Default: disabled (unset / any other value).
+- `TRAIN_LOCAL_PIPE_RETRY_BACKOFF_SECONDS`
+  - Backoff before extra retry.
+  - Default: `0.05` seconds.
+  - Invalid/negative values fall back to `0.05`.
+
+### Validation output
+Lint:
+
+```text
+Inspecting 2 files
+..
+
+2 files inspected, no offenses detected
+```
+
+Tests:
+
+```text
+Run options: --seed 13469
+
+# Running:
+
+...................................
+
+Finished in 0.119072s, 293.9398 runs/s, 881.8194 assertions/s.
+
+35 runs, 105 assertions, 0 failures, 0 errors, 0 skips
+```
+
+### Contract evidence
+- Default mode: behavior unchanged from previous implementation (single recovery retry on `Errno::EPIPE`).
+- Opt-in mode: one additional recovery retry is attempted with backoff.
+
+### Rollback
+Revert commit touching:
+- `lib/train/transports/local.rb`
+- `test/unit/transports/local_test.rb`
+- `.copilot-track/walk/ex15/plan.md`
+- `.copilot-track/walk/ex15/notes.md`

--- a/.copilot-track/walk/ex15/plan.md
+++ b/.copilot-track/walk/ex15/plan.md
@@ -1,0 +1,50 @@
+## Plan
+
+Exercise: ex15
+
+### Goal / Outcome
+Add a safer, opt-in resilience improvement for local connection pipe recovery that does not change default behavior.
+
+### Scope
+- Keep existing `WindowsPipeRunner#run_command` behavior unchanged by default.
+- Add one additional retry attempt with backoff only when an env flag is enabled.
+- Add failure tests for both default and opt-in paths.
+
+### Call site
+- `Train::Transports::Local::Connection::WindowsPipeRunner#run_command`
+  - Existing behavior: one recovery retry on `Errno::EPIPE`.
+  - New behavior: optional second recovery retry with backoff when flag is enabled.
+
+### Steps
+1. Add opt-in env toggle and backoff parsing in `local.rb`.
+2. Integrate optional second retry path after existing retry failure.
+3. Add tests for:
+   - default mode: second `Errno::EPIPE` still raises
+   - opt-in mode: second retry with backoff can succeed
+4. Capture tuning and rollback guidance in notes.
+
+### Files to change
+- `lib/train/transports/local.rb`
+- `test/unit/transports/local_test.rb`
+- `.copilot-track/walk/ex15/notes.md`
+
+### Test strategy
+- Lint changed Ruby files:
+  - `bundle exec chefstyle lib/train/transports/local.rb test/unit/transports/local_test.rb`
+- Run focused tests:
+  - `bundle exec ruby -Itest test/unit/transports/local_test.rb`
+
+### Evidence to capture (coverage/contract)
+- Test output showing all local transport tests pass.
+- Explicit test evidence for default and opt-in paths.
+
+### Tuning parameters
+- `TRAIN_LOCAL_PIPE_EXTRA_RETRY` (`1|true|yes|on` to enable)
+- `TRAIN_LOCAL_PIPE_RETRY_BACKOFF_SECONDS` (default `0.05`)
+
+### Rollback
+- Revert commit touching:
+  - `lib/train/transports/local.rb`
+  - `test/unit/transports/local_test.rb`
+  - `.copilot-track/walk/ex15/plan.md`
+  - `.copilot-track/walk/ex15/notes.md`

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -192,21 +192,20 @@ module Train::Transports
           encoded_script = Base64.strict_encode64(script)
           # TODO: no way to safely implement timeouts here.
           begin
-            @pipe.puts(encoded_script)
-            @pipe.flush
+            write_to_pipe(encoded_script)
           rescue Errno::EPIPE
             # Retry once if the pipe went away
-            begin
-              # Maybe the pipe went away, but the server didn't? Reset it, to get a clean start.
-              close
-            rescue Errno::EIO
-              # Ignore - server already went away
-            end
-            @pipe = acquire_pipe
-            raise PipeError if @pipe.nil?
+            recover_pipe!
 
-            @pipe.puts(encoded_script)
-            @pipe.flush
+            begin
+              write_to_pipe(encoded_script)
+            rescue Errno::EPIPE
+              raise unless extra_pipe_retry_enabled?
+
+              sleep(extra_pipe_retry_backoff_seconds)
+              recover_pipe!
+              write_to_pipe(encoded_script)
+            end
           end
           res = OpenStruct.new(JSON.parse(Base64.decode64(@pipe.readline)))
           Local::CommandResult.new(res.stdout, res.stderr, res.exitstatus)
@@ -218,6 +217,40 @@ module Train::Transports
         end
 
         private
+
+        def write_to_pipe(encoded_script)
+          @pipe.puts(encoded_script)
+          @pipe.flush
+        end
+
+        def recover_pipe!
+          begin
+            # Maybe the pipe went away, but the server didn't? Reset it, to get a clean start.
+            close
+          rescue Errno::EIO
+            # Ignore - server already went away
+          end
+
+          @pipe = acquire_pipe
+          raise PipeError if @pipe.nil?
+        end
+
+        def extra_pipe_retry_enabled?
+          value = ENV["TRAIN_LOCAL_PIPE_EXTRA_RETRY"]
+          return false if value.nil?
+
+          %w{1 true yes on}.include?(value.to_s.strip.downcase)
+        end
+
+        def extra_pipe_retry_backoff_seconds
+          raw = ENV["TRAIN_LOCAL_PIPE_RETRY_BACKOFF_SECONDS"]
+          return 0.05 if raw.nil?
+
+          parsed = Float(raw)
+          parsed < 0 ? 0.05 : parsed
+        rescue ArgumentError, TypeError
+          0.05
+        end
 
         def acquire_pipe
           require "win32/process"

--- a/test/unit/transports/local_test.rb
+++ b/test/unit/transports/local_test.rb
@@ -384,6 +384,59 @@ describe "local transport" do
         _(result.exit_status).must_equal 0
       end
 
+      it "raises Errno::EPIPE when second retry fails by default" do
+        old_pipe = mock("old_pipe")
+        new_pipe = mock("new_pipe")
+        runner.instance_variable_set(:@pipe, old_pipe)
+
+        old_pipe.expects(:puts).raises(Errno::EPIPE)
+        runner.expects(:close).once
+        runner.expects(:acquire_pipe).returns(new_pipe)
+
+        new_pipe.expects(:puts).raises(Errno::EPIPE)
+
+        _ { runner.run_command("test-command", {}) }.must_raise Errno::EPIPE
+      end
+
+      it "performs one additional retry with backoff when opt-in flag is enabled" do
+        old_pipe = mock("old_pipe")
+        retry_pipe = mock("retry_pipe")
+        recovered_pipe = mock("recovered_pipe")
+        runner.instance_variable_set(:@pipe, old_pipe)
+
+        original_flag = ENV["TRAIN_LOCAL_PIPE_EXTRA_RETRY"]
+        original_backoff = ENV["TRAIN_LOCAL_PIPE_RETRY_BACKOFF_SECONDS"]
+        ENV["TRAIN_LOCAL_PIPE_EXTRA_RETRY"] = "1"
+        ENV["TRAIN_LOCAL_PIPE_RETRY_BACKOFF_SECONDS"] = "0.05"
+
+        old_pipe.expects(:puts).raises(Errno::EPIPE)
+        runner.expects(:close).twice
+        runner.expects(:acquire_pipe).twice.returns(retry_pipe, recovered_pipe)
+
+        retry_pipe.expects(:puts).raises(Errno::EPIPE)
+        runner.expects(:sleep).with(0.05).once
+
+        recovered_pipe.expects(:puts).with(anything)
+        recovered_pipe.expects(:flush)
+        recovered_pipe.expects(:readline).returns(Base64.encode64('{"stdout":"ok","stderr":"","exitstatus":0}'))
+
+        result = runner.run_command("test-command", {})
+        _(result.stdout).must_equal "ok"
+        _(result.exit_status).must_equal 0
+      ensure
+        if original_flag.nil?
+          ENV.delete("TRAIN_LOCAL_PIPE_EXTRA_RETRY")
+        else
+          ENV["TRAIN_LOCAL_PIPE_EXTRA_RETRY"] = original_flag
+        end
+
+        if original_backoff.nil?
+          ENV.delete("TRAIN_LOCAL_PIPE_RETRY_BACKOFF_SECONDS")
+        else
+          ENV["TRAIN_LOCAL_PIPE_RETRY_BACKOFF_SECONDS"] = original_backoff
+        end
+      end
+
       it "raises PipeError when recovery fails" do
         old_pipe = mock("old_pipe")
         runner.instance_variable_set(:@pipe, old_pipe)


### PR DESCRIPTION
## Summary
- Added a safer, opt-in resilience improvement for local Windows pipe command execution.
- Preserved default behavior and added optional extra retry with configurable backoff.
- Added focused failure tests for default and opt-in paths.

## Branch Lineage
- Current PR branch: `vasundhara-walk-ex15`
- Base branch: `vasundhara-walk-ex14`
- Walk chain context:
  - `vasundhara-walk-ex12`: backlog epic/future work planning in repo docs.
  - `vasundhara-walk-ex13`: command-completion audit feature flag lifecycle + ON/OFF validation.
  - `vasundhara-walk-ex14`: scoped strict lint enforcement and path-scoped CI gate.
  - `vasundhara-walk-ex15` (this PR): local reliability hardening under failure, safe-by-default.

## Previous Branch Change Details (Cumulative Context)
- ex12 introduced structured backlog planning and dependency mapping for follow-up improvements.
- ex13 added feature-flag lifecycle discipline and dual-mode validation pattern.
- ex14 added scoped quality enforcement (`.rubocop-strict-plugins.yml` + path-gated CI workflow).
- ex15 builds on this by applying reliability hardening in a local-only call path with minimal blast radius.

## What Changed In ex15
- `lib/train/transports/local.rb`
  - Enhanced `WindowsPipeRunner#run_command` with an optional second retry path.
  - Added opt-in env controls:
    - `TRAIN_LOCAL_PIPE_EXTRA_RETRY` (`1|true|yes|on` enables)
    - `TRAIN_LOCAL_PIPE_RETRY_BACKOFF_SECONDS` (default `0.05`)
  - Default mode remains unchanged: existing single recovery retry behavior persists.
- `test/unit/transports/local_test.rb`
  - Added failure-path coverage:
    - default mode still raises on repeated `Errno::EPIPE`
    - opt-in mode performs one additional retry with backoff and can recover
- `.copilot-track/walk/ex15/plan.md`
- `.copilot-track/walk/ex15/notes.md`

## Validation
- Lint:

```text
Inspecting 2 files
..

2 files inspected, no offenses detected
```

- Tests:

```text
Run options: --seed 13469

# Running:

...................................

Finished in 0.119072s, 293.9398 runs/s, 881.8194 assertions/s.

35 runs, 105 assertions, 0 failures, 0 errors, 0 skips
```

## Acceptance Mapping
- Resilience improvement applied: yes (local pipe recovery path)
- Failure tests passing: yes
- Tuning/rollback guidance documented: yes

## Tuning Parameters
- `TRAIN_LOCAL_PIPE_EXTRA_RETRY`
- `TRAIN_LOCAL_PIPE_RETRY_BACKOFF_SECONDS`

## Risk & Rollback
- Risk: low; default behavior unchanged unless env flag is enabled.
- Rollback: revert commit `07e4b86`.

## AI Assistance
This work was completed with AI assistance following Progress AI policies.

## Track
- Level: Walk
- Exercise: ex15
