### PR TITLE
fix: CHEF-33393 - Fall back to PowerShell syntax for arch detection in WinRM sessions

### DIFF
--- a/lib/train/platforms/detect/helpers/os_windows.rb
+++ b/lib/train/platforms/detect/helpers/os_windows.rb
@@ -244,27 +244,33 @@ module Train::Platforms::Detect::Helpers
 
     # Fallback method for reading OS info using cmd-only commands when wmic is not available
     def read_cmd_os
-      # Try to get architecture from PROCESSOR_ARCHITECTURE environment variable
+      # Try to get architecture from PROCESSOR_ARCHITECTURE environment variable.
       # This covers the same architectures as wmic CPU detection but uses environment variables
-      # which are available on all Windows versions since NT
+      # which are available on all Windows versions since NT.
       arch_res = @backend.run_command("echo %PROCESSOR_ARCHITECTURE%")
-      if arch_res.exit_status == 0
-        arch_string = arch_res.stdout.strip.downcase
-        # Only set architecture if we got actual output
-        unless arch_string.empty?
-          @platform[:arch] = case arch_string
-                            when "x86"
-                              "i386"
-                            when "amd64", "x64"
-                              "x86_64"
-                            when "ppc", "powerpc"
-                              "powerpc"
-                            else
-                              # For any unknown architecture, preserve the original value
-                              # This handles: arm64, ia64, arm, mips, alpha, and future architectures
-                              arch_string
-                             end
-        end
+      arch_string = arch_res.exit_status == 0 ? arch_res.stdout.strip.downcase : ""
+
+      # In PowerShell sessions (e.g., WinRM in Test Kitchen), CMD-style variable
+      # expansion is not supported — %PROCESSOR_ARCHITECTURE% is returned literally
+      # rather than being expanded.  Fall back to PowerShell syntax in that case.
+      if arch_string.empty? || arch_string == "%processor_architecture%"
+        ps_res = @backend.run_command("$env:PROCESSOR_ARCHITECTURE")
+        arch_string = ps_res.exit_status == 0 ? ps_res.stdout.strip.downcase : ""
+      end
+
+      unless arch_string.empty?
+        @platform[:arch] = case arch_string
+                          when "x86"
+                            "i386"
+                          when "amd64", "x64"
+                            "x86_64"
+                          when "ppc", "powerpc"
+                            "powerpc"
+                          else
+                            # For any unknown architecture, preserve the original value
+                            # This handles: arm64, ia64, arm, mips, alpha, and future architectures
+                            arch_string
+                           end
       end
       # If PROCESSOR_ARCHITECTURE fails, architecture remains unset (consistent with other methods)
 

--- a/test/unit/platforms/detect/os_windows_test.rb
+++ b/test/unit/platforms/detect/os_windows_test.rb
@@ -289,6 +289,7 @@ describe "read_cmd_os" do
     let(:detector) do
       detector = OsDetectWindowsTester.new
       detector.backend.mock_command("echo %PROCESSOR_ARCHITECTURE%", "", "", 1)
+      detector.backend.mock_command("$env:PROCESSOR_ARCHITECTURE", "", "", 1)
       detector.backend.mock_command("systeminfo", "", "", 0)
       detector
     end
@@ -296,6 +297,30 @@ describe "read_cmd_os" do
     it "sets architecture to nil explicitly" do
       detector.read_cmd_os
       _(detector.platform[:arch]).must_be_nil
+    end
+  end
+
+  describe "in a PowerShell session where %VAR% expansion is not supported" do
+    let(:detector) do
+      detector = OsDetectWindowsTester.new
+      # PowerShell returns the literal string instead of expanding %VAR%
+      detector.backend.mock_command("echo %PROCESSOR_ARCHITECTURE%", "%PROCESSOR_ARCHITECTURE%", "", 0)
+      # Fallback to PowerShell $env: syntax
+      detector.backend.mock_command("$env:PROCESSOR_ARCHITECTURE", "AMD64", "", 0)
+      detector.backend.mock_command("systeminfo", "OS Name:                   Microsoft Windows Server 2025 Datacenter\r\nOS Version:                10.0.26100 N/A Build 26100\r\n", "", 0)
+      detector
+    end
+
+    it "falls back to PowerShell syntax and retrieves the correct architecture" do
+      detector.read_cmd_os
+      _(detector.platform[:arch]).must_equal("x86_64")
+    end
+
+    it "still retrieves OS info from systeminfo" do
+      detector.read_cmd_os
+      _(detector.platform[:name]).must_equal("Windows Server 2025 Datacenter")
+      _(detector.platform[:release]).must_equal("10.0.26100")
+      _(detector.platform[:build]).must_equal("26100")
     end
   end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
On Windows Server 2025, `wmic` has been deprecated and removed. When train falls back to `read_cmd_os` for architecture detection, it runs `echo %PROCESSOR_ARCHITECTURE%` which is CMD batch syntax. However, WinRM sessions in Test Kitchen default to **PowerShell**, where `%VAR%` expansion is not supported — the literal string `%PROCESSOR_ARCHITECTURE%` is returned instead.

This left `os.arch` as `nil`/`unknown`, which caused the InSpec `package` resource to skip `WOW6432Node` registry paths, making 32-bit packages (e.g. .NET Framework SDK, VC++ x86 redistributables) appear as "not installed" during `kitchen verify`.

**Fix:** In `read_cmd_os`, detect when the CMD command returns the unexpanded literal and fall back to the PowerShell-native `$env:PROCESSOR_ARCHITECTURE`.

## Related Issue
CHEF-33393 — InSpec Package Resource Fails in Kitchen Verify on Windows

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
