### PR TITLE
fix: pin bigdecimal to < 4 to avoid broken transitive installs via activesupport

### DIFF
--- a/train.gemspec
+++ b/train.gemspec
@@ -31,6 +31,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "train-winrm", "~> 0.4.0" # Ruby 3.4 upgrade included
 
   spec.add_dependency "activesupport", "~> 7.2", ">= 7.2.3.1"
+  # bigdecimal 4.x is incompatible to el-7-aarch64, el-7-x86_64; pin to < 4 to avoid broken transitive installs via activesupport
+  spec.add_dependency "bigdecimal", "< 4"
 
   # azure, docker, gcp dependencies
   spec.add_dependency "inifile", "~> 3.0"


### PR DESCRIPTION
<h2>Summary</h2>
<p>Pins <code>bigdecimal</code> to <code>&lt; 4</code> in <code>train.gemspec</code> to prevent broken installs on platforms like <code>el-7-aarch64</code> and <code>el-7-x86_64</code>.</p>
<p><code>bigdecimal 4.x</code> is incompatible with certain runtimes. Without this pin, a bare <code>gem install train</code> resolves <code>activesupport</code>'s transitive dependency to <code>bigdecimal 4.x</code> and fails.</p>

ad-hoc build: https://buildkite.com/chef/inspec-inspec-inspec-5-omnibus-adhoc/builds/339#_
inspec test PR : https://github.com/inspec/inspec/pull/7941
<h2>Files Changed</h2>
<ul><li><code>train.gemspec</code> — added <code>spec.add_dependency "bigdecimal", "&lt; 4"</code></li></ul>
<h2>Testing</h2>
<p>Change is a dependency constraint only; no functional code changed. Existing test suite validates gemspec correctness.</p>
<h2>Risk</h2>
<p>Low — constrains a transitive dependency to a known-good version range already present in <code>Gemfile.lock</code>.</p>
<p><em>This work was completed with AI assistance following Progress AI policies.</em></p>